### PR TITLE
Text Outline

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added support for text outlines in `Font`, `DrawingHandleScreen`, `Label`, `RichTextLabel`, and overlays.
 
 ### Bugfixes
 

--- a/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
+++ b/Robust.Client/Graphics/Drawing/DrawingHandleScreen.cs
@@ -154,7 +154,7 @@ namespace Robust.Client.Graphics
         public Vector2 DrawString(Font font, Vector2 pos, string str)
             => DrawString(font, pos, str, Color.White);
 
-        public Vector2 DrawString(Font font, Vector2 pos, ReadOnlySpan<char> str, float scale, Color color)
+        public Vector2 DrawString(Font font, Vector2 pos, ReadOnlySpan<char> str, float scale, Color color, TextOutline? outline = null)
         {
             var advanceTotal = Vector2.Zero;
             var baseLine = new Vector2(pos.X, font.GetAscent(scale) + pos.Y);
@@ -170,7 +170,7 @@ namespace Robust.Client.Graphics
                     continue;
                 }
 
-                var advance = font.DrawChar(this, rune, baseLine, scale, color);
+                var advance = font.DrawChar(this, rune, baseLine, scale, color, outline);
                 advanceTotal.X += advance;
                 baseLine += new Vector2(advance, 0);
             }

--- a/Robust.Client/Graphics/Font.cs
+++ b/Robust.Client/Graphics/Font.cs
@@ -179,24 +179,27 @@ namespace Robust.Client.Graphics
             var glyphPosition = baseline + new Vector2(metrics.Value.BearingX, -metrics.Value.BearingY);
             if (outline is { Thickness: > 0 } settings)
             {
-                // Draw the outline by rendering the glyph around its original position.
-                var outlineOffset = settings.Thickness * scale;
-                foreach (var offset in OutlineOffsets)
+                // Sample concentric rings so the outline remains smooth at small sizes without gaps at larger sizes.
+                var outlineRadius = settings.Thickness * scale;
+                var ringCount = (int) MathF.Ceiling(outlineRadius);
+
+                for (var ring = 1; ring <= ringCount; ring++)
                 {
-                    DrawGlyph(handle, texture, glyphPosition + offset * outlineOffset, settings.Color);
+                    var radius = MathF.Min(ring, outlineRadius);
+                    var segmentCount = Math.Max(1, (int) MathF.Ceiling(MathHelper.TwoPi * radius));
+
+                    for (var segment = 0; segment < segmentCount; segment++)
+                    {
+                        var angle = segment / (float) segmentCount * MathHelper.TwoPi;
+                        var offset = new Vector2(MathF.Sin(angle), MathF.Cos(angle)) * radius;
+                        DrawGlyph(handle, texture, glyphPosition + offset, settings.Color);
+                    }
                 }
             }
 
             DrawGlyph(handle, texture, glyphPosition, color);
             return metrics.Value.Advance;
         }
-
-        private static readonly Vector2[] OutlineOffsets =
-        [
-            new(-1, -1), new(0, -1), new(1, -1), // Top
-            new(-1, 0), new(1, 0), // Sides
-            new(-1, 1), new(0, 1), new(1, 1), // Bottom
-        ];
 
         private static void DrawGlyph(DrawingHandleBase handle, Texture texture, Vector2 position, Color color)
         {

--- a/Robust.Client/Graphics/Font.cs
+++ b/Robust.Client/Graphics/Font.cs
@@ -177,18 +177,11 @@ namespace Robust.Client.Graphics
             }
 
             var glyphPosition = baseline + new Vector2(metrics.Value.BearingX, -metrics.Value.BearingY);
-            if (outline is { Thickness: > 0 } settings)
+            if (outline is { Thickness: > 0 } settings &&
+                Handle.GetOutlinedChar(rune, scale, settings.Thickness) is { } outlinedGlyph)
             {
-                // Sample concentric rings so the outline remains smooth at small sizes without gaps at larger sizes.
-                var outlineRadius = settings.Thickness * scale;
-                for (var radius = outlineRadius; radius > 0; radius -= 1f)
-                {
-                    for (var angle = 0f; angle < MathHelper.TwoPi; angle += 1f / radius)
-                    {
-                        var offset = new Vector2(MathF.Sin(angle), MathF.Cos(angle)) * radius;
-                        DrawGlyph(handle, texture, glyphPosition + offset, settings.Color);
-                    }
-                }
+                var outlinePosition = baseline + new Vector2(outlinedGlyph.Left, -outlinedGlyph.Top);
+                DrawGlyph(handle, outlinedGlyph.Texture, outlinePosition, settings.Color);
             }
 
             DrawGlyph(handle, texture, glyphPosition, color);

--- a/Robust.Client/Graphics/Font.cs
+++ b/Robust.Client/Graphics/Font.cs
@@ -181,16 +181,10 @@ namespace Robust.Client.Graphics
             {
                 // Sample concentric rings so the outline remains smooth at small sizes without gaps at larger sizes.
                 var outlineRadius = settings.Thickness * scale;
-                var ringCount = (int) MathF.Ceiling(outlineRadius);
-
-                for (var ring = 1; ring <= ringCount; ring++)
+                for (var radius = outlineRadius; radius > 0; radius -= 1f)
                 {
-                    var radius = MathF.Min(ring, outlineRadius);
-                    var segmentCount = Math.Max(1, (int) MathF.Ceiling(MathHelper.TwoPi * radius));
-
-                    for (var segment = 0; segment < segmentCount; segment++)
+                    for (var angle = 0f; angle < MathHelper.TwoPi; angle += 1f / radius)
                     {
-                        var angle = segment / (float) segmentCount * MathHelper.TwoPi;
                         var offset = new Vector2(MathF.Sin(angle), MathF.Cos(angle)) * radius;
                         DrawGlyph(handle, texture, glyphPosition + offset, settings.Color);
                     }

--- a/Robust.Client/Graphics/Font.cs
+++ b/Robust.Client/Graphics/Font.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using System.Text;
 using Robust.Client.ResourceManagement;
@@ -7,6 +7,31 @@ using Robust.Shared.Maths;
 
 namespace Robust.Client.Graphics
 {
+    /// <summary>
+    ///     Describes an outline drawn around text.
+    /// </summary>
+    public readonly record struct TextOutline(float Thickness, Color Color)
+    {
+        /// <summary>
+        ///     The default text outline.
+        /// </summary>
+        public static TextOutline Default => new(1f, Color.Black);
+
+        /// <summary>
+        ///     Creates an outline from optional settings.
+        /// </summary>
+        public static TextOutline? FromOverrides(float? thickness, Color? color)
+        {
+            if (thickness is null && color is null)
+                return null;
+
+            var actualThickness = thickness ?? Default.Thickness;
+            return actualThickness > 0
+                ? new TextOutline(actualThickness, color ?? Default.Color)
+                : null;
+        }
+    }
+
     /// <summary>
     ///     A generic font for rendering of text.
     ///     Does not contain properties such as size. Those are specific to children such as <see cref="VectorFont" />
@@ -55,6 +80,17 @@ namespace Robust.Client.Graphics
         public abstract float DrawChar(
             DrawingHandleBase handle, Rune rune, Vector2 baseline, float scale,
             Color color, bool fallback=true);
+
+        /// <summary>
+        ///     Draws a character with an optional outline.
+        /// </summary>
+        /// <inheritdoc cref="DrawChar(DrawingHandleBase, Rune, Vector2, float, Color, bool)"/>
+        public virtual float DrawChar(
+            DrawingHandleBase handle, Rune rune, Vector2 baseline, float scale,
+            Color color, TextOutline? outline, bool fallback=true)
+        {
+            return DrawChar(handle, rune, baseline, scale, color, fallback);
+        }
 
         /// <summary>
         ///     Gets metrics describing the dimensions and positioning of a single glyph in the font.
@@ -116,6 +152,9 @@ namespace Robust.Client.Graphics
         public override int GetLineHeight(float scale) => Handle.GetLineHeight(scale);
 
         public override float DrawChar(DrawingHandleBase handle, Rune rune, Vector2 baseline, float scale, Color color, bool fallback=true)
+            => DrawChar(handle, rune, baseline, scale, color, null, fallback);
+
+        public override float DrawChar(DrawingHandleBase handle, Rune rune, Vector2 baseline, float scale, Color color, TextOutline? outline, bool fallback=true)
         {
             var metrics = Handle.GetCharMetrics(rune, scale);
             if (!metrics.HasValue)
@@ -137,12 +176,34 @@ namespace Robust.Client.Graphics
                 return metrics.Value.Advance;
             }
 
-            baseline += new Vector2(metrics.Value.BearingX, -metrics.Value.BearingY);
-            if(handle is DrawingHandleWorld worldhandle)
-                worldhandle.DrawTextureRect(texture, Box2.FromDimensions(baseline, texture.Size), color);
-            else
-                handle.DrawTexture(texture, baseline, color);
+            var glyphPosition = baseline + new Vector2(metrics.Value.BearingX, -metrics.Value.BearingY);
+            if (outline is { Thickness: > 0 } settings)
+            {
+                // Draw the outline by rendering the glyph around its original position.
+                var outlineOffset = settings.Thickness * scale;
+                foreach (var offset in OutlineOffsets)
+                {
+                    DrawGlyph(handle, texture, glyphPosition + offset * outlineOffset, settings.Color);
+                }
+            }
+
+            DrawGlyph(handle, texture, glyphPosition, color);
             return metrics.Value.Advance;
+        }
+
+        private static readonly Vector2[] OutlineOffsets =
+        [
+            new(-1, -1), new(0, -1), new(1, -1), // Top
+            new(-1, 0), new(1, 0), // Sides
+            new(-1, 1), new(0, 1), new(1, 1), // Bottom
+        ];
+
+        private static void DrawGlyph(DrawingHandleBase handle, Texture texture, Vector2 position, Color color)
+        {
+            if (handle is DrawingHandleWorld worldhandle)
+                worldhandle.DrawTextureRect(texture, Box2.FromDimensions(position, texture.Size), color);
+            else
+                handle.DrawTexture(texture, position, color);
         }
 
         public override CharMetrics? GetCharMetrics(Rune rune, float scale, bool fallback=true)
@@ -179,16 +240,19 @@ namespace Robust.Client.Graphics
 
         // DrawChar just proxies to the stack, or invokes _main's fallback.
         public override float DrawChar(DrawingHandleBase handle, Rune rune, Vector2 baseline, float scale, Color color, bool fallback=true)
+            => DrawChar(handle, rune, baseline, scale, color, null, fallback);
+
+        public override float DrawChar(DrawingHandleBase handle, Rune rune, Vector2 baseline, float scale, Color color, TextOutline? outline, bool fallback=true)
         {
             foreach (var f in Stack)
             {
-                var w = f.DrawChar(handle, rune, baseline, scale, color, fallback: false);
+                var w = f.DrawChar(handle, rune, baseline, scale, color, outline, fallback: false);
                 if (w != 0f)
                     return w;
             }
 
             if (fallback)
-                return _main.DrawChar(handle, rune, baseline, scale, color, fallback: true);
+                return _main.DrawChar(handle, rune, baseline, scale, color, outline, fallback: true);
 
             return 0f;
         }

--- a/Robust.Client/Graphics/FontManager.cs
+++ b/Robust.Client/Graphics/FontManager.cs
@@ -350,6 +350,9 @@ namespace Robust.Client.Graphics
 
             public OutlinedGlyph? GetOutlinedChar(Rune codePoint, float scale, float thickness)
             {
+                if (thickness <= 0)
+                    return null;
+
                 var glyph = GetGlyph(codePoint);
                 if (glyph == 0)
                     return null;

--- a/Robust.Client/Graphics/FontManager.cs
+++ b/Robust.Client/Graphics/FontManager.cs
@@ -142,102 +142,128 @@ namespace Robust.Client.Graphics
                 glyphMetrics.Height.ToInt32());
 
             using var bitmap = face.Glyph.Bitmap;
-            if (bitmap.Pitch < 0)
-            {
-                throw new NotImplementedException();
-            }
-
-            if (bitmap.Pitch != 0)
-            {
-                Image<A8> img;
-                switch (bitmap.PixelMode)
-                {
-                    case PixelMode.Mono:
-                    {
-                        img = MonoBitMapToImage(bitmap);
-                        break;
-                    }
-
-                    case PixelMode.Gray:
-                    {
-                        ReadOnlySpan<A8> span;
-                        unsafe
-                        {
-                            span = new ReadOnlySpan<A8>((void*) bitmap.Buffer, bitmap.Pitch * bitmap.Rows);
-                        }
-
-                        img = new Image<A8>(bitmap.Width, bitmap.Rows);
-
-                        span.Blit(
-                            bitmap.Pitch,
-                            UIBox2i.FromDimensions(0, 0, bitmap.Pitch, bitmap.Rows),
-                            img,
-                            (0, 0));
-
-                        break;
-                    }
-
-                    case PixelMode.Gray2:
-                    case PixelMode.Gray4:
-                    case PixelMode.Lcd:
-                    case PixelMode.VerticalLcd:
-                    case PixelMode.Bgra:
-                        throw new NotImplementedException();
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-
-                OwnedTexture sheet;
-                if (scaled.AtlasTextures.Count == 0)
-                    sheet = GenSheet();
-                else
-                    sheet = scaled.AtlasTextures[^1];
-
-                var (sheetW, sheetH) = sheet.Size;
-
-                if (sheetW - scaled.CurSheetX < img.Width)
-                {
-                    scaled.CurSheetX = 0;
-                    // +1 Adds a pixel of vertical padding, to avoid arifacts when aliasing
-                    scaled.CurSheetY = scaled.CurSheetMaxY + 1;
-                }
-
-                if (sheetH - scaled.CurSheetY < img.Height)
-                {
-                    // Make new sheet.
-                    scaled.CurSheetY = 0;
-                    scaled.CurSheetX = 0;
-                    scaled.CurSheetMaxY = 0;
-
-                    sheet = GenSheet();
-                }
-
-                sheet.SetSubImage((scaled.CurSheetX, scaled.CurSheetY), img);
-
-                var atlasTexture = new AtlasTexture(
-                    sheet,
-                    UIBox2.FromDimensions(
-                        scaled.CurSheetX,
-                        scaled.CurSheetY,
-                        bitmap.Width,
-                        bitmap.Rows));
-
-                info.Texture = atlasTexture;
-
-                scaled.CurSheetMaxY = Math.Max(scaled.CurSheetMaxY, scaled.CurSheetY + bitmap.Rows);
-                // +1 adds a pixel of horizontal padding, to avoid artifacts when aliasing
-                scaled.CurSheetX += bitmap.Width + 1;
-            }
+            info.Texture = CacheBitmap(instance, scaled, scale, bitmap);
 
             scaled.GlyphInfos.Add(glyph, info);
             return info;
+        }
+
+        private OutlinedGlyphInfo EnsureOutlinedGlyphCached(
+            FontInstanceHandle instance,
+            ScaledFontData scaled,
+            float scale,
+            uint glyph,
+            int radius)
+        {
+            if (scaled.OutlinedGlyphInfos.TryGetValue((glyph, radius), out var info))
+                return info;
+
+            var face = instance.FaceHandle.Face;
+            face.SetCharSize(0, instance.Size, 0, (uint) (_baseFontDpi * scale));
+            face.LoadGlyph(glyph, LoadFlags.Default, LoadTarget.Normal);
+
+            using var sourceGlyph = face.Glyph.GetGlyph();
+            using var stroker = new Stroker(_library);
+            stroker.Set(radius, StrokerLineCap.Round, StrokerLineJoin.Round, Fixed16Dot16.FromInt32(0));
+            using var strokedGlyph = sourceGlyph.StrokeBorder(stroker, false, true);
+            strokedGlyph.ToBitmap(RenderMode.Normal, new FTVector26Dot6(0, 0), true);
+
+            var bitmapGlyph = strokedGlyph.ToBitmapGlyph();
+            using var bitmap = bitmapGlyph.Bitmap;
+            info = new OutlinedGlyphInfo
+            {
+                Texture = CacheBitmap(instance, scaled, scale, bitmap),
+                Left = bitmapGlyph.Left,
+                Top = bitmapGlyph.Top,
+            };
+
+            scaled.OutlinedGlyphInfos.Add((glyph, radius), info);
+            return info;
+        }
+
+        private AtlasTexture? CacheBitmap(
+            FontInstanceHandle instance,
+            ScaledFontData scaled,
+            float scale,
+            FTBitmap bitmap)
+        {
+            if (bitmap.Pitch < 0)
+                throw new NotImplementedException();
+
+            if (bitmap.Pitch == 0)
+                return null;
+
+            Image<A8> img;
+            switch (bitmap.PixelMode)
+            {
+                case PixelMode.Mono:
+                    img = MonoBitMapToImage(bitmap);
+                    break;
+                case PixelMode.Gray:
+                {
+                    ReadOnlySpan<A8> span;
+                    unsafe
+                    {
+                        span = new ReadOnlySpan<A8>((void*) bitmap.Buffer, bitmap.Pitch * bitmap.Rows);
+                    }
+
+                    img = new Image<A8>(bitmap.Width, bitmap.Rows);
+                    span.Blit(
+                        bitmap.Pitch,
+                        UIBox2i.FromDimensions(0, 0, bitmap.Pitch, bitmap.Rows),
+                        img,
+                        (0, 0));
+                    break;
+                }
+                case PixelMode.Gray2:
+                case PixelMode.Gray4:
+                case PixelMode.Lcd:
+                case PixelMode.VerticalLcd:
+                case PixelMode.Bgra:
+                    throw new NotImplementedException();
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            OwnedTexture sheet;
+            if (scaled.AtlasTextures.Count == 0)
+                sheet = GenSheet();
+            else
+                sheet = scaled.AtlasTextures[^1];
+
+            var (sheetW, sheetH) = sheet.Size;
+            if (sheetW - scaled.CurSheetX < img.Width)
+            {
+                scaled.CurSheetX = 0;
+                // +1 adds vertical padding to avoid artifacts when aliasing.
+                scaled.CurSheetY = scaled.CurSheetMaxY + 1;
+            }
+
+            if (sheetH - scaled.CurSheetY < img.Height)
+            {
+                scaled.CurSheetY = 0;
+                scaled.CurSheetX = 0;
+                scaled.CurSheetMaxY = 0;
+                sheet = GenSheet();
+            }
+
+            sheet.SetSubImage((scaled.CurSheetX, scaled.CurSheetY), img);
+            var atlasTexture = new AtlasTexture(
+                sheet,
+                UIBox2.FromDimensions(scaled.CurSheetX, scaled.CurSheetY, bitmap.Width, bitmap.Rows));
+
+            scaled.CurSheetMaxY = Math.Max(scaled.CurSheetMaxY, scaled.CurSheetY + bitmap.Rows);
+            // +1 adds horizontal padding to avoid artifacts when aliasing.
+            scaled.CurSheetX += bitmap.Width + 1;
+            return atlasTexture;
 
             OwnedTexture GenSheet()
             {
-                var sheet = _clyde.CreateBlankTexture<A8>((SheetWidth, SheetHeight),
+                var face = instance.FaceHandle.Face;
+                var texture = _clyde.CreateBlankTexture<A8>((SheetWidth, SheetHeight),
                     $"font-{face.FamilyName}-{instance.Size}-{(uint) (_baseFontDpi * scale)}-sheet{scaled.AtlasTextures.Count}");
-                scaled.AtlasTextures.Add(sheet);
-                return sheet;
+                scaled.AtlasTextures.Add(texture);
+                return texture;
             }
         }
 
@@ -322,6 +348,24 @@ namespace Robust.Client.Graphics
                 return glyphInfo.Texture;
             }
 
+            public OutlinedGlyph? GetOutlinedChar(Rune codePoint, float scale, float thickness)
+            {
+                var glyph = GetGlyph(codePoint);
+                if (glyph == 0)
+                    return null;
+
+                var radius = (int) MathF.Round(thickness * scale * 64f);
+                if (radius <= 0)
+                    return null;
+
+                var scaled = GetScaleDatum(scale);
+                var info = _fontManager.EnsureOutlinedGlyphCached(this, scaled, scale, glyph, radius);
+                if (info.Texture == null)
+                    return null;
+
+                return new OutlinedGlyph(info.Texture, info.Left, info.Top);
+            }
+
             public CharMetrics? GetCharMetrics(Rune codePoint, float scale)
             {
                 var glyph = GetGlyph(codePoint);
@@ -400,6 +444,7 @@ namespace Robust.Client.Graphics
 
             public readonly List<OwnedTexture> AtlasTextures = new();
             public readonly Dictionary<uint, GlyphInfo> GlyphInfos = new();
+            public readonly Dictionary<(uint Glyph, int Radius), OutlinedGlyphInfo> OutlinedGlyphInfos = new();
             public readonly int Ascent;
             public readonly int Descent;
             public readonly int Height;
@@ -414,6 +459,13 @@ namespace Robust.Client.Graphics
         {
             public CharMetrics Metrics;
             public AtlasTexture? Texture;
+        }
+
+        private sealed class OutlinedGlyphInfo
+        {
+            public AtlasTexture? Texture;
+            public int Left;
+            public int Top;
         }
 
         private sealed class ArrayMemoryHandle(byte[] array) : IFontMemoryHandle

--- a/Robust.Client/Graphics/IFontManager.cs
+++ b/Robust.Client/Graphics/IFontManager.cs
@@ -29,10 +29,13 @@ namespace Robust.Client.Graphics
 
     }
 
+    internal readonly record struct OutlinedGlyph(Texture Texture, int Left, int Top);
+
     internal interface IFontInstanceHandle
     {
         Texture? GetCharTexture(Rune codePoint, float scale);
         Texture? GetCharTexture(char chr, float scale) => GetCharTexture((Rune) chr, scale);
+        OutlinedGlyph? GetOutlinedChar(Rune codePoint, float scale, float thickness);
         CharMetrics? GetCharMetrics(Rune codePoint, float scale);
         CharMetrics? GetCharMetrics(char chr, float scale) => GetCharMetrics((Rune) chr, scale);
 

--- a/Robust.Client/UserInterface/Controls/Label.cs
+++ b/Robust.Client/UserInterface/Controls/Label.cs
@@ -18,6 +18,8 @@ namespace Robust.Client.UserInterface.Controls
     {
         public const string StylePropertyFontColor = "font-color";
         public const string StylePropertyFont = "font";
+        public const string StylePropertyFontOutlineThickness = "font-outline-thickness";
+        public const string StylePropertyFontOutlineColor = "font-outline-color";
         public const string StylePropertyAlignMode = "alignMode";
 
         private int _cachedTextHeight;
@@ -165,6 +167,25 @@ namespace Robust.Client.UserInterface.Controls
 
         public int? ShadowOffsetYOverride { get; set; }
 
+        public float? FontOutlineThicknessOverride { get; set; }
+
+        public Color? FontOutlineColorOverride { get; set; }
+
+        private TextOutline? ActualFontOutline
+        {
+            get
+            {
+                var thickness = FontOutlineThicknessOverride;
+                if (!thickness.HasValue && TryGetStyleProperty<float>(StylePropertyFontOutlineThickness, out var styleThickness))
+                    thickness = styleThickness;
+
+                var color = FontOutlineColorOverride;
+                if (!color.HasValue && TryGetStyleProperty<Color>(StylePropertyFontOutlineColor, out var styleColor))
+                    color = styleColor;
+
+                return TextOutline.FromOverrides(thickness, color);
+            }
+        }
 
         protected internal override void Draw(DrawingHandleScreen handle)
         {
@@ -234,7 +255,7 @@ namespace Robust.Client.UserInterface.Controls
                     baseLine = CalcBaseline();
                 }
 
-                var advance = font.DrawChar(handle, rune, baseLine, UIScale, actualFontColor);
+                var advance = font.DrawChar(handle, rune, baseLine, UIScale, actualFontColor, outline: ActualFontOutline);
                 baseLine += new Vector2(advance, 0);
             }
         }

--- a/Robust.Client/UserInterface/Controls/Label.cs
+++ b/Robust.Client/UserInterface/Controls/Label.cs
@@ -167,19 +167,19 @@ namespace Robust.Client.UserInterface.Controls
 
         public int? ShadowOffsetYOverride { get; set; }
 
-        public float? FontOutlineThicknessOverride { get; set; }
+        public float? OutlineThicknessOverride { get; set; }
 
-        public Color? FontOutlineColorOverride { get; set; }
+        public Color? OutlineColorOverride { get; set; }
 
         private TextOutline? ActualFontOutline
         {
             get
             {
-                var thickness = FontOutlineThicknessOverride;
+                var thickness = OutlineThicknessOverride;
                 if (!thickness.HasValue && TryGetStyleProperty<float>(StylePropertyFontOutlineThickness, out var styleThickness))
                     thickness = styleThickness;
 
-                var color = FontOutlineColorOverride;
+                var color = OutlineColorOverride;
                 if (!color.HasValue && TryGetStyleProperty<Color>(StylePropertyFontOutlineColor, out var styleColor))
                     color = styleColor;
 

--- a/Robust.Client/UserInterface/Controls/RichTextLabel.cs
+++ b/Robust.Client/UserInterface/Controls/RichTextLabel.cs
@@ -133,6 +133,26 @@ namespace Robust.Client.UserInterface.Controls
         /// </summary>
         public FormattedMessage? GetFormattedMessage() => _entry == null ? null : new FormattedMessage(_entry.Value.Message);
 
+        public float? FontOutlineThicknessOverride { get; set; }
+
+        public Color? FontOutlineColorOverride { get; set; }
+
+        private TextOutline? ActualFontOutline
+        {
+            get
+            {
+                var thickness = FontOutlineThicknessOverride;
+                if (!thickness.HasValue && TryGetStyleProperty<float>(Label.StylePropertyFontOutlineThickness, out var styleThickness))
+                    thickness = styleThickness;
+
+                var color = FontOutlineColorOverride;
+                if (!color.HasValue && TryGetStyleProperty<Color>(Label.StylePropertyFontOutlineColor, out var styleColor))
+                    color = styleColor;
+
+                return TextOutline.FromOverrides(thickness, color);
+            }
+        }
+
         protected override Vector2 MeasureOverride(Vector2 availableSize)
         {
             if (_entry == null)
@@ -150,7 +170,7 @@ namespace Robust.Client.UserInterface.Controls
         protected internal override void Draw(DrawingHandleScreen handle)
         {
             base.Draw(handle);
-            _entry?.Draw(_tagManager, handle, _getFont(), SizeBox, 0, new MarkupDrawingContext(), UIScale, LineHeightScale);
+            _entry?.Draw(_tagManager, handle, _getFont(), SizeBox, 0, new MarkupDrawingContext(), UIScale, LineHeightScale, ActualFontOutline);
         }
 
         [Pure]

--- a/Robust.Client/UserInterface/Controls/RichTextLabel.cs
+++ b/Robust.Client/UserInterface/Controls/RichTextLabel.cs
@@ -133,19 +133,19 @@ namespace Robust.Client.UserInterface.Controls
         /// </summary>
         public FormattedMessage? GetFormattedMessage() => _entry == null ? null : new FormattedMessage(_entry.Value.Message);
 
-        public float? FontOutlineThicknessOverride { get; set; }
+        public float? OutlineThicknessOverride { get; set; }
 
-        public Color? FontOutlineColorOverride { get; set; }
+        public Color? OutlineColorOverride { get; set; }
 
         private TextOutline? ActualFontOutline
         {
             get
             {
-                var thickness = FontOutlineThicknessOverride;
+                var thickness = OutlineThicknessOverride;
                 if (!thickness.HasValue && TryGetStyleProperty<float>(Label.StylePropertyFontOutlineThickness, out var styleThickness))
                     thickness = styleThickness;
 
-                var color = FontOutlineColorOverride;
+                var color = OutlineColorOverride;
                 if (!color.HasValue && TryGetStyleProperty<Color>(Label.StylePropertyFontOutlineColor, out var styleColor))
                     color = styleColor;
 

--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -233,7 +233,8 @@ namespace Robust.Client.UserInterface
             float verticalOffset,
             MarkupDrawingContext context,
             float uiScale,
-            float lineHeightScale = 1)
+            float lineHeightScale = 1,
+            TextOutline? outline = null)
         {
             context.Clear();
             context.Color.Push(_defaultColor);
@@ -274,7 +275,7 @@ namespace Robust.Client.UserInterface
                             skipSpaceBaseline = true;
                     }
 
-                    var advance = font.DrawChar(handle, rune, baseLine, uiScale, color);
+                    var advance = font.DrawChar(handle, rune, baseLine, uiScale, color, outline: outline);
 
                     if (!skipSpaceBaseline)
                         baseLine += new Vector2(advance, 0);


### PR DESCRIPTION
Added support for text outlines in `Font`, `DrawingHandleScreen`, `Label`, `RichTextLabel`, and overlays.
For https://github.com/space-wizards/space-station-14/pull/44848
<img width="93" height="70" alt="image" src="https://github.com/user-attachments/assets/aa7c7900-cee7-4dc3-91a6-7c8a3e902023" />

