### PR TITLE
Hotfix: pass last state in SharedUserInterfaceSystem.EnsureClientBui

### DIFF
--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -92,20 +92,20 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
     }
 
     /// <summary>
-    /// Enqueues a BUI command to be processed in the next Update call.
+    /// Enqueues a BUI command to be processed in the next Update call,
+    /// getting the last available state for the given UserInterfaceComponent at the last state.
     /// </summary>
-    private void AddQueued(BoundUserInterface bui, QueuedUpdate type, BoundUserInterfaceState? state = null)
+    private void AddQueued(BoundUserInterface bui, QueuedUpdate type, Entity<UserInterfaceComponent> ent, Enum key)
     {
+        var state = ent.Comp.States.GetValueOrDefault(key);
         _queuedBuis.Add((bui, type, state));
     }
 
     /// <summary>
-    /// Enqueues a BUI command to be processed in the next Update call,
-    /// getting the last available state for the given UserInterfaceComponent at the last state.
+    /// Enqueues a BUI command to be processed in the next Update call.
     /// </summary>
-    private void AddQueuedState(BoundUserInterface bui, QueuedUpdate type, Entity<UserInterfaceComponent> ent, Enum key)
+    private void AddQueued(BoundUserInterface bui, QueuedUpdate type, BoundUserInterfaceState? state = null)
     {
-        var state = ent.Comp.States.GetValueOrDefault(key);
         _queuedBuis.Add((bui, type, state));
     }
 
@@ -305,7 +305,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         // PlayerAttachedEvent will catch some of these.
         foreach (var (key, bui) in ent.Comp.ClientOpenInterfaces)
         {
-            AddQueuedState(bui, QueuedUpdate.Open, ent, key);
+            AddQueued(bui, QueuedUpdate.Open, ent, key);
         }
     }
 
@@ -566,7 +566,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         if (!open)
             return;
 
-        AddQueuedState(boundUserInterface, QueuedUpdate.Open, entity, key);
+        AddQueued(boundUserInterface, QueuedUpdate.Open, entity, key);
     }
 
     /// <summary>

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -91,8 +91,21 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         SubscribeLocalEvent<UserInterfaceUserComponent, ComponentShutdown>(OnActorShutdown);
     }
 
+    /// <summary>
+    /// Enqueues a BUI command to be processed in the next Update call.
+    /// </summary>
     private void AddQueued(BoundUserInterface bui, QueuedUpdate type, BoundUserInterfaceState? state = null)
     {
+        _queuedBuis.Add((bui, type, state));
+    }
+
+    /// <summary>
+    /// Enqueues a BUI command to be processed in the next Update call,
+    /// getting the last available state for the given UserInterfaceComponent at the last state.
+    /// </summary>
+    private void AddQueuedState(BoundUserInterface bui, QueuedUpdate type, Entity<UserInterfaceComponent> ent, Enum key)
+    {
+        var state = ent.Comp.States.GetValueOrDefault(key);
         _queuedBuis.Add((bui, type, state));
     }
 
@@ -292,8 +305,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         // PlayerAttachedEvent will catch some of these.
         foreach (var (key, bui) in ent.Comp.ClientOpenInterfaces)
         {
-            var state = ent.Comp.States.GetValueOrDefault(key);
-            AddQueued(bui, QueuedUpdate.Open, state);
+            AddQueuedState(bui, QueuedUpdate.Open, ent, key);
         }
     }
 
@@ -554,8 +566,7 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         if (!open)
             return;
 
-        var state = entity.Comp.States.GetValueOrDefault(key);
-        AddQueued(boundUserInterface, QueuedUpdate.Open, state);
+        AddQueuedState(boundUserInterface, QueuedUpdate.Open, entity, key);
     }
 
     /// <summary>

--- a/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedUserInterfaceSystem.cs
@@ -554,7 +554,8 @@ public abstract partial class SharedUserInterfaceSystem : EntitySystem
         if (!open)
             return;
 
-        AddQueued(boundUserInterface, QueuedUpdate.Open);
+        var state = entity.Comp.States.GetValueOrDefault(key);
+        AddQueued(boundUserInterface, QueuedUpdate.Open, state);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes issues described in https://github.com/space-wizards/RobustToolbox/pull/6829#issuecomment-5063702223

I goofed.  This sends null state when the last available state _might not be null!_

Proof of the pudding on ss14 master + a few compilation fixes for v284.

https://github.com/user-attachments/assets/8d2f36e5-66df-444e-8fa6-5313b187f6a8

@deltanedas sorry about that - see video attached, test for yourself