### PR TITLE
Expose cvar for changing doppler factor + lower default doppler factor

### DIFF
--- a/Robust.Client/Audio/AudioManager.Public.cs
+++ b/Robust.Client/Audio/AudioManager.Public.cs
@@ -284,6 +284,13 @@ internal partial class AudioManager
         OpenALSawmill.Info($"Set audio attenuation to {attenuation.ToString()}");
     }
 
+    public void SetDopplerFactor(float factor)
+    {
+        factor = Math.Max(factor, 0f);
+        AL.DopplerFactor(factor);
+        OpenALSawmill.Info($"Set doppler factor to {factor:F2}");
+    }
+
     internal void RemoveAudioSource(int handle)
     {
         _audioSources.Remove(handle);

--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -120,6 +120,7 @@ public sealed partial class AudioSystem : SharedAudioSystem
 
         Subs.CVar(CfgManager, CVars.AudioEndBuffer, OnAudioBuffer, true);
         Subs.CVar(CfgManager, CVars.AudioAttenuation, OnAudioAttenuation, true);
+        Subs.CVar(CfgManager, CVars.AudioDopplerFactor, OnDopplerFactor, true);
         Subs.CVar(CfgManager, CVars.AudioRaycastLength, OnRaycastLengthChanged, true);
         Subs.CVar(CfgManager, CVars.AudioTickRate, OnAudioTickRate, true);
         InitializeLimit();
@@ -298,6 +299,11 @@ public sealed partial class AudioSystem : SharedAudioSystem
     private void OnAudioAttenuation(int obj)
     {
         _audio.SetAttenuation((Attenuation) obj);
+    }
+
+    private void OnDopplerFactor(float value)
+    {
+        _audio.SetDopplerFactor(value);
     }
 
     private void OnRaycastLengthChanged(float value)

--- a/Robust.Client/Audio/HeadlessAudioManager.cs
+++ b/Robust.Client/Audio/HeadlessAudioManager.cs
@@ -81,6 +81,11 @@ internal sealed class HeadlessAudioManager : IAudioInternal
     }
 
     /// <inheritdoc />
+    public void SetDopplerFactor(float factor)
+    {
+    }
+
+    /// <inheritdoc />
     public void Remove(AudioStream stream)
     {
     }

--- a/Robust.Client/Audio/IAudioInternal.cs
+++ b/Robust.Client/Audio/IAudioInternal.cs
@@ -44,6 +44,11 @@ internal interface IAudioInternal : IAudioManager
 
     void SetAttenuation(Attenuation attenuation);
 
+    /// <summary>
+    /// Sets doppler factor, which scales listener and source velocities with regards to the doppler effect.
+    /// </summary>
+    void SetDopplerFactor(float factor);
+
     void Remove(AudioStream stream);
 
     /// <summary>

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1370,15 +1370,11 @@ namespace Robust.Shared
         /// and (if more than 1) exaggerates the effect. Setting this to 0 will disable the doppler effect.
         /// </summary>
         /// <remarks>
-        /// The default value for OpenAL is 1, but here we use 0.25, which was chosen sort of arbitrarily to better tune the effect
-        /// to velocity ranges actually common in RT projects. In SS14, with a value of 1, it was common to hear noticeable dopplering
-        /// even while just moving around as a ghost, which sounded pretty bad.
-        ///
         /// This is replicated rather than client-only because it makes more sense to control this on a server-level depending on
         /// what the game in question requires: servers with fast-moving grids may want to de-emphasize doppler even more than usual, etc.
         /// </remarks>
         public static readonly CVarDef<float> AudioDopplerFactor =
-            CVarDef.Create("audio.doppler_factor", 0.25f, CVar.REPLICATED | CVar.ARCHIVE);
+            CVarDef.Create("audio.doppler_factor", 1f, CVar.REPLICATED | CVar.ARCHIVE);
 
         /// <summary>
         /// Whether to enable HRTF (head-related transfer function) support for positional audio.

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1366,6 +1366,21 @@ namespace Robust.Shared
             CVarDef.Create("audio.attenuation", (int) Attenuation.LinearDistanceClamped, CVar.REPLICATED | CVar.ARCHIVE);
 
         /// <summary>
+        /// Scales listener & source velocities, which (if less than 1) de-emphasizes the doppler pitch-shifting effect
+        /// and (if more than 1) exaggerates the effect.
+        /// </summary>
+        /// <remarks>
+        /// The default value for OpenAL is 1, but here we use 0.25, which was chosen sort of arbitrarily to better tune the effect
+        /// to velocity ranges actually common in RT projects. In SS14, with a value of 1, it was common to hear noticeable dopplering
+        /// even while just moving around as a ghost, which sounded pretty bad.
+        ///
+        /// This is replicated rather than client-only because it makes more sense to control this on a server-level depending on
+        /// what the game in question requires: servers with fast-moving grids may want to de-emphasize doppler even more than usual, etc.
+        /// </remarks>
+        public static readonly CVarDef<float> AudioDopplerFactor =
+            CVarDef.Create("audio.doppler_factor", 0.25f, CVar.REPLICATED | CVar.ARCHIVE);
+
+        /// <summary>
         /// Whether to enable HRTF (head-related transfer function) support for positional audio.
         /// </summary>
         /// <remarks>

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1367,7 +1367,7 @@ namespace Robust.Shared
 
         /// <summary>
         /// Scales listener & source velocities, which (if less than 1) de-emphasizes the doppler pitch-shifting effect
-        /// and (if more than 1) exaggerates the effect.
+        /// and (if more than 1) exaggerates the effect. Setting this to 0 will disable the doppler effect.
         /// </summary>
         /// <remarks>
         /// The default value for OpenAL is 1, but here we use 0.25, which was chosen sort of arbitrarily to better tune the effect


### PR DESCRIPTION
fixes #6597

lowers the default doppler factor because with our physics velocities it was pretty common to hear dopplering in situations where shit really should not be dopplering like just moving around as an aghost. this sounded pretty bad. it can still occur with very fast moving grids and things like that which is when it should be happening to begin with

basically see comment on the cvar


https://github.com/user-attachments/assets/cc77db63-1592-41e5-ab7f-70ec02b34a88



