### PR TITLE
Fix sRGB framebuffer in Linux GLES compatibility mode

### DIFF
--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
@@ -175,7 +175,7 @@ internal partial class Clyde
                 SDL.SDL_GL_SetAttribute(GLAttr.SDL_GL_STENCIL_SIZE, 8);
                 SDL.SDL_GL_SetAttribute(
                     GLAttr.SDL_GL_FRAMEBUFFER_SRGB_CAPABLE,
-                    s.Profile == GLContextProfile.Es ? 0 : 1);
+                    s.Profile == GLContextProfile.Es && OperatingSystem.IsWindows() ? 0 : 1);
                 int ctxFlags = 0;
 #if DEBUG
                 ctxFlags |= SDL.SDL_GL_CONTEXT_DEBUG_FLAG;


### PR DESCRIPTION
Виправляє sRGB framebuffer у SDL3/GLES compatibility mode на Linux.