### PR TITLE
Add parrallel enumerate entities robust job

### DIFF
--- a/Robust.Benchmarks/EntityManager/ComponentIteratorBenchmark.cs
+++ b/Robust.Benchmarks/EntityManager/ComponentIteratorBenchmark.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Threading;
 using Robust.UnitTesting.Server;
 
 namespace Robust.Benchmarks.EntityManager;
@@ -9,10 +11,11 @@ namespace Robust.Benchmarks.EntityManager;
 public partial class ComponentIteratorBenchmark
 {
     private ISimulation _simulation = default!;
-    private IEntityManager _entityManager = default!;
+    private Shared.GameObjects.EntityManager _entityManager = default!;
+    private IParallelManager _parallelManager = default!;
 
     [UsedImplicitly]
-    [Params(1, 10, 100, 1000)]
+    [Params(1, 10, 100, 1000, 10000)]
     public int N;
 
     public A[] Comps = default!;
@@ -22,10 +25,12 @@ public partial class ComponentIteratorBenchmark
     {
         _simulation = RobustServerSimulation
             .NewSimulation()
+            .RegisterDependencies(c => c.Register<IParallelManager, ParallelManager>(overwrite: true))
             .RegisterComponents(f => f.RegisterClass<A>())
             .InitializeInstance();
 
-        _entityManager = _simulation.Resolve<IEntityManager>();
+        _entityManager = (Shared.GameObjects.EntityManager)_simulation.Resolve<IEntityManager>();
+        _parallelManager = _simulation.Resolve<IParallelManager>();
 
         Comps = new A[N+2];
 
@@ -40,36 +45,77 @@ public partial class ComponentIteratorBenchmark
     }
 
     [Benchmark]
-    public A[] ComponentStructEnumerator()
+    [BenchmarkCategory("Component Manipulation")]
+    public void ComponentManipulationStruct()
     {
         var query = _entityManager.EntityQueryEnumerator<A>();
-        var i = 0;
 
         while (query.MoveNext(out var comp))
         {
-            Comps[i] = comp;
-            i++;
+            comp.Foo = 0xB00BA;
         }
-
-        return Comps;
     }
 
     [Benchmark]
-    public A[] ComponentIEnumerable()
+    [BenchmarkCategory("Component Manipulation")]
+    public void ComponentManipulationQuery()
     {
-        var i = 0;
-
         foreach (var comp in _entityManager.EntityQuery<A>())
         {
-            Comps[i] = comp;
-            i++;
+            comp.Foo = 0xB00BA;
+        }
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Component Manipulation")]
+    public void ComponentManipulationParallelJob()
+    {
+        var query = _entityManager.EntityQueryEnumerator<A>();
+        var list = new List<A>(_entityManager.Count<A>());
+
+        while (query.MoveNext(out var comp))
+        {
+            list.Add(comp);
         }
 
-        return Comps;
+        var job = new SetNumberParallelJob(list);
+        _parallelManager.ProcessNow(job, list.Count);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Component Manipulation")]
+    public void ComponentManipulationParallelEnumEntJob()
+    {
+        _parallelManager.ProcessNow(new SetNumberEnumEntJob(_entityManager));
+    }
+
+    private struct SetNumberEnumEntJob(Shared.GameObjects.EntityManager entityManager) : IParallelEnumerateEntitiesRobustJob<A>
+    {
+        public int MinimumBatchParallel => 1;
+        public int BatchSize => 50;
+
+        public Shared.GameObjects.EntityManager EntityManager { get; set; } = entityManager;
+
+        public void Execute(EntityUid uid, A component)
+        {
+            component.Foo = 0xB00BA;
+        }
+    }
+
+    private struct SetNumberParallelJob(List<A> Components) : IParallelRobustJob
+    {
+        public int MinimumBatchParallel => 1;
+        public int BatchSize => 50;
+
+        public void Execute(int index)
+        {
+            Components[index].Foo = 0xB00BA;
+        }
     }
 
     [ComponentProtoName("A")]
     public sealed partial class A : Component
     {
+        public int Foo = 0;
     }
 }

--- a/Robust.Shared.Testing/TestingParallelManager.cs
+++ b/Robust.Shared.Testing/TestingParallelManager.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Threading;
 
 // ReSharper disable once CheckNamespace
@@ -70,6 +72,24 @@ public sealed class TestingParallelManager : IParallelManagerInternal
     public WaitHandle Process(IParallelBulkRobustJob jobs, int amount)
     {
         ProcessSerialNow(jobs, amount);
+        var ev = new ManualResetEventSlim();
+        ev.Set();
+        return ev.WaitHandle;
+    }
+
+    public void ProcessNow<TComp>(IParallelEnumerateEntitiesRobustJob<TComp> jobs) where TComp : IComponent
+    {
+        jobs.ExecuteRange(0, IoCManager.Instance?.Resolve<EntityManager>()?.DictionaryInternalCount<TComp>() ?? 0);
+    }
+
+    public void ProcessSerialNow<TComp>(IParallelEnumerateEntitiesRobustJob<TComp> jobs) where TComp : IComponent
+    {
+        jobs.ExecuteRange(0, IoCManager.Instance?.Resolve<EntityManager>()?.DictionaryInternalCount<TComp>() ?? 0);
+    }
+
+    public WaitHandle Process<TComp>(IParallelEnumerateEntitiesRobustJob<TComp> jobs) where TComp : IComponent
+    {
+        ProcessSerialNow(jobs);
         var ev = new ManualResetEventSlim();
         ev.Set();
         return ev.WaitHandle;

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -102,6 +102,16 @@ namespace Robust.Shared.GameObjects
             return dict.Count;
         }
 
+        /// <summary>
+        /// Required for <see cref="Robust.Shared.Threading.IParallelEnumerateEntitiesRobustJob`1>"/>
+        /// Dictionary<>.Enumerator uses dict._count, not dict.Count
+        /// </summary>
+        internal int DictionaryInternalCount<T>() where T : IComponent
+        {
+            var dict = _entTraitDict[typeof(T)];
+            return DictionaryHelper.GetCount(dict);
+        }
+
         /// <inheritdoc />
         public int Count(Type component)
         {
@@ -1229,6 +1239,13 @@ namespace Robust.Shared.GameObjects
         /// Internal variant of <see cref="GetComponents"/> that directly returns the actual component set.
         /// </summary>
         internal IReadOnlyCollection<IComponent> GetComponentsInternal(EntityUid uid) => _entCompIndex[uid];
+
+        internal Dictionary<EntityUid, IComponent> GetComponentsDictionaryInternal<TComp>() where TComp : IComponent
+        {
+            var comps = _entTraitArray[CompIdx.ArrayIndex<TComp>()];
+            DebugTools.Assert(comps != null, $"Unknown component: {typeof(TComp).Name}");
+            return comps;
+        }
 
         /// <inheritdoc />
         public int ComponentCount(EntityUid uid)

--- a/Robust.Shared/Threading/IParallelRobustJob.cs
+++ b/Robust.Shared/Threading/IParallelRobustJob.cs
@@ -1,3 +1,9 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Utility;
+
 namespace Robust.Shared.Threading;
 
 /// <summary>
@@ -52,3 +58,50 @@ public interface IParallelRobustJob : IParallelRangeRobustJob
 /// Good for jobs that can operate on ranges more efficiently (SIMD) than individual indices.
 /// </summary>
 public interface IParallelBulkRobustJob : IParallelRangeRobustJob;
+
+/// <summary>
+/// Represents a parallel job that processes individual entities.
+/// </summary>
+public interface IParallelEnumerateEntitiesRobustJob<TComp> : IParallelRangeRobustJob where TComp : IComponent
+{
+    EntityManager EntityManager { get; }
+
+    /// <summary>
+    /// Default implementation that executes the job for each index in the specified range.
+    /// </summary>
+    void IParallelRangeRobustJob.ExecuteRange(int startIndex, int endIndex)
+    {
+        var ent = EntityManager;
+
+        var metaQuery = ent.GetEntityQuery<MetaDataComponent>();
+        var dict = ent.GetComponentsDictionaryInternal<TComp>();
+
+        Debug.Assert(dict.Capacity >= endIndex, "Someone reduced the capacity of the dictionary.");
+        if (dict.Capacity < endIndex) // save us from possible out of range
+            return;
+
+        var entries = DictionaryHelper.GetEntries(dict);
+
+        for (var i = startIndex; i < endIndex; i++)
+        {
+            ref var entry = ref entries[i];
+            if (entry.Value != null) // in dict: entry.Next >= -1, BUT THIS IS A LIE
+            {
+                if (entry.Value.Deleted)
+                    continue;
+
+                if (!metaQuery.TryGetComponentInternal(entry.Key, out var metaComp) || metaComp.EntityPaused)
+                {
+                    continue;
+                }
+
+                Execute(entry.Key, (TComp)entry.Value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Executes the job for the specified component.
+    /// </summary>
+    void Execute(EntityUid uid, TComp component);
+}

--- a/Robust.Shared/Threading/ParallelManager.cs
+++ b/Robust.Shared/Threading/ParallelManager.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using Microsoft.Extensions.ObjectPool;
 using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
 
@@ -63,6 +64,21 @@ public interface IParallelManager
     /// <param name="amount">The total number of elements to process.</param>
     /// <returns>A wait handle that signals when the job is complete.</returns>
     WaitHandle Process(IParallelBulkRobustJob jobs, int amount);
+
+    /// <summary>
+    /// Takes in a parallel job and runs it
+    /// </summary>
+    public void ProcessNow<TComp>(IParallelEnumerateEntitiesRobustJob<TComp> jobs) where TComp : IComponent;
+
+    /// <summary>
+    /// Processes a robust job sequentially if desired.
+    /// </summary>
+    void ProcessSerialNow<TComp>(IParallelEnumerateEntitiesRobustJob<TComp> jobs) where TComp : IComponent;
+
+    /// <summary>
+    /// Takes in a parallel job and runs it without blocking.
+    /// </summary>
+    WaitHandle Process<TComp>(IParallelEnumerateEntitiesRobustJob<TComp> jobs) where TComp : IComponent;
 }
 
 internal interface IParallelManagerInternal : IParallelManager
@@ -74,6 +90,7 @@ internal sealed partial class ParallelManager : IParallelManagerInternal
 {
     [Dependency] private IConfigurationManager _cfg = default!;
     [Dependency] private ILogManager _logs = default!;
+    [Dependency] private EntityManager _entityManager = default!;
 
     public event Action? ParallelCountChanged;
     public int ParallelProcessCount { get; private set; }
@@ -163,17 +180,26 @@ internal sealed partial class ParallelManager : IParallelManagerInternal
     public void ProcessNow(IParallelBulkRobustJob jobs, int amount) =>
         ProcessNow((IParallelRangeRobustJob) jobs, amount);
 
+    public void ProcessNow<TComp>(IParallelEnumerateEntitiesRobustJob<TComp> jobs) where TComp : IComponent =>
+        ProcessNow((IParallelRangeRobustJob) jobs, _entityManager.DictionaryInternalCount<TComp>());
+
     public void ProcessSerialNow(IParallelRobustJob jobs, int amount) =>
         ProcessSerialNow((IParallelRangeRobustJob) jobs, amount);
 
     public void ProcessSerialNow(IParallelBulkRobustJob jobs, int amount) =>
         ProcessSerialNow((IParallelRangeRobustJob) jobs, amount);
 
+    public void ProcessSerialNow<TComp>(IParallelEnumerateEntitiesRobustJob<TComp> jobs) where TComp : IComponent =>
+        ProcessSerialNow((IParallelRangeRobustJob) jobs, _entityManager.DictionaryInternalCount<TComp>());
+
     public WaitHandle Process(IParallelRobustJob jobs, int amount) =>
         Process((IParallelRangeRobustJob) jobs, amount);
 
     public WaitHandle Process(IParallelBulkRobustJob jobs, int amount) =>
         Process((IParallelRangeRobustJob) jobs, amount);
+
+    public WaitHandle Process<TComp>(IParallelEnumerateEntitiesRobustJob<TComp> jobs) where TComp : IComponent =>
+        Process((IParallelRangeRobustJob) jobs, _entityManager.DictionaryInternalCount<TComp>());
 
     public void ProcessNow(IParallelRangeRobustJob job, int amount)
     {

--- a/Robust.Shared/Utility/DictionaryHelper.cs
+++ b/Robust.Shared/Utility/DictionaryHelper.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Robust.Shared.Utility;
+
+// unsafe magic fuckery
+internal static class DictionaryHelper
+{
+    private static readonly Func<Dictionary<object, object>, int> _getInnerCount;
+
+    static DictionaryHelper()
+    {
+        var _count = typeof(Dictionary<object, object>).GetField("_count", BindingFlags.NonPublic | BindingFlags.Instance);
+        var dy = new DynamicMethod("Get_Count", typeof(int), [typeof(Dictionary<object, object>)]);
+        var il = dy.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _count!);
+        il.Emit(OpCodes.Ret);
+        _getInnerCount = dy.CreateDelegate<Func<Dictionary<object, object>, int>>();
+        Debug.Assert(_getInnerCount(new Dictionary<object, object> { {new(), new()} }) == 1);
+    }
+
+    internal static Entry<TKey, TValue>[] GetEntries<TKey, TValue>(Dictionary<TKey, TValue> dictionary) where TKey : notnull
+    {
+        return Unsafe.As<Dictionary<TKey, TValue>, DictionaryLayout<TKey, TValue>>(ref dictionary).Entries;
+    }
+
+    internal static int GetCount<TKey, TValue>(Dictionary<TKey, TValue> dictionary) where TKey : notnull
+    {
+        return _getInnerCount(Unsafe.As<Dictionary<TKey, TValue>, Dictionary<object, object>>(ref dictionary));
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal sealed class DictionaryLayout<TKey, TValue>
+    {
+        public int[] Buckets = null!;
+        public Entry<TKey, TValue>[] Entries = null!;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct Entry<TKey, TValue>
+    {
+        public uint HashCode;
+        public int Next;
+        public TKey Key;
+        public TValue? Value;
+    }
+}


### PR DESCRIPTION
Adds IParallelEnumerateEntitiesRobustJob<TComp>, which allows parallel iteration of all entities with the TComp component.
Implentations is ass and pure unsafe shit.
It can be used as "HOW NOT TO DO".

Benchmark result:
| Method                                  | N     | Mean           | Error         | StdDev        | Median         |
|---------------------------------------- |------ |---------------:|--------------:|--------------:|---------------:|
| ComponentManipulationStruct             | 1     |       7.188 ns |     0.1103 ns |     0.0978 ns |       7.137 ns |
| ComponentManipulationQuery              | 1     |      42.439 ns |     0.7595 ns |     0.8442 ns |      42.095 ns |
| ComponentManipulationParallelJob        | 1     |      27.375 ns |     0.5758 ns |     0.8618 ns |      27.171 ns |
| ComponentManipulationParallelEnumEntJob | 1     |      45.582 ns |     0.8672 ns |     0.8112 ns |      45.415 ns |
| ComponentManipulationStruct             | 10    |      45.073 ns |     0.0885 ns |     0.0739 ns |      45.059 ns |
| ComponentManipulationQuery              | 10    |     133.758 ns |     2.6427 ns |     3.4363 ns |     132.862 ns |
| ComponentManipulationParallelJob        | 10    |      98.073 ns |     1.9450 ns |     2.1619 ns |      97.798 ns |
| ComponentManipulationParallelEnumEntJob | 10    |      78.721 ns |     0.1316 ns |     0.1028 ns |      78.727 ns |
| ComponentManipulationStruct             | 100   |     466.349 ns |     6.5542 ns |     5.8101 ns |     463.728 ns |
| ComponentManipulationQuery              | 100   |   1,114.605 ns |    21.8316 ns |    27.6100 ns |   1,097.313 ns |
| ComponentManipulationParallelJob        | 100   |   7,366.354 ns |    90.9375 ns |    85.0630 ns |   7,368.766 ns |
| ComponentManipulationParallelEnumEntJob | 100   |   6,110.475 ns |    75.0421 ns |    66.5228 ns |   6,109.910 ns |
| ComponentManipulationStruct             | 1000  |   7,234.635 ns |   141.8323 ns |   125.7307 ns |   7,166.861 ns |
| ComponentManipulationQuery              | 1000  |  14,983.837 ns |   130.0979 ns |   115.3284 ns |  14,932.688 ns |
| ComponentManipulationParallelJob        | 1000  |  32,056.157 ns |   591.6674 ns |   633.0775 ns |  32,020.108 ns |
| ComponentManipulationParallelEnumEntJob | 1000  |  10,586.043 ns |   123.5864 ns |   115.6028 ns |  10,596.428 ns |
| ComponentManipulationStruct             | 10000 | 106,257.338 ns |   792.1391 ns |   618.4501 ns | 106,179.504 ns |
| ComponentManipulationQuery              | 10000 | 207,478.523 ns | 3,497.2791 ns | 3,271.3571 ns | 207,345.276 ns |
| ComponentManipulationParallelJob        | 10000 | 237,478.034 ns | 4,109.6350 ns | 3,844.1552 ns | 236,079.370 ns |
| ComponentManipulationParallelEnumEntJob | 10000 |  46,959.080 ns |   180.5389 ns |   168.8762 ns |  46,964.868 ns |

Also with a screenshot, because github does not know how to create readable tables for mobile layout (skill issue btw)
<img width="940" height="533" alt="image" src="https://github.com/user-attachments/assets/00b86199-b083-4a55-8204-ae9a1886d4ef" />

I don't know in which cases there may be so many Entities to experience a performance increase, but if you use this together with heavy calculations, you probably won't need 3,000 live Entities to see an increase in performance. (or my implementation is bullshit) Si maybe PR can be closed, idk.