### PR TITLE
Update to player toolshed command

### DIFF
--- a/Resources/Locale/en-US/commands.ftl
+++ b/Resources/Locale/en-US/commands.ftl
@@ -16,6 +16,7 @@ cmd-parse-failure-grid = {$arg} is not a valid grid.
 cmd-parse-failure-cultureinfo = "{$arg}" is not valid CultureInfo.
 cmd-parse-failure-entity-exist = UID {$arg} does not correspond to an existing entity.
 cmd-parse-failure-session = There is no session with username: {$username}
+cmd-parse-failure-session-guid = There is no session with the GUID: {$guid}
 
 cmd-error-file-not-found = Could not find file: {$file}.
 cmd-error-dir-not-found = Could not find directory: {$dir}.

--- a/Robust.Server/Toolshed/Commands/Players/PlayersCommand.cs
+++ b/Robust.Server/Toolshed/Commands/Players/PlayersCommand.cs
@@ -34,26 +34,17 @@ public sealed partial class PlayerCommand : ToolshedCommand
         return ctx.Session!;
     }
 
+    /*
+     * Pass in ICommonSession to get the... passed... ICommonSession...
+     * Look that seems really stupid (because it is) but the Toolshed parser doesn't let you just type in a session
+     * name at the start of a command, so immediate IS required in order to pipe to other commands. Luckily, Toolshed
+     * DOES have a parser for ICommonSession that even comes with autocomplete. So as insane as it looks here to just
+     * have a function that returns the exact thing you're passing to it, it's more efficient (and convenient)
+     * than parsing a username string. Toolshed is fucking weird, man.
+     */
     [CommandImplementation("imm")]
-    public ICommonSession Immediate(IInvocationContext ctx, string username)
-    {
-        _playerManager.TryGetSessionByUsername(username, out var session);
-
-        if (session is null)
-        {
-            if (Guid.TryParse(username, out var guid))
-            {
-                _playerManager.TryGetSessionById(new NetUserId(guid), out session);
-            }
-        }
-
-        if (session is null)
-        {
-            ctx.ReportError(new NoSuchPlayerError(username));
-        }
-
-        return session!;
-    }
+    public ICommonSession Immediate(IInvocationContext ctx, ICommonSession session) =>
+        session;
 
     [CommandImplementation("entity")]
     public IEnumerable<EntityUid> GetPlayerEntity([PipedArgument] IEnumerable<ICommonSession> sessions)
@@ -65,12 +56,6 @@ public sealed partial class PlayerCommand : ToolshedCommand
     public EntityUid GetPlayerEntity([PipedArgument] ICommonSession sessions)
     {
         return sessions.AttachedEntity ?? default;
-    }
-
-    [CommandImplementation("entity")]
-    public EntityUid GetPlayerEntity(IInvocationContext ctx, string username)
-    {
-        return GetPlayerEntity(Immediate(ctx, username));
     }
 }
 

--- a/Robust.Server/Toolshed/Commands/Players/PlayersCommand.cs
+++ b/Robust.Server/Toolshed/Commands/Players/PlayersCommand.cs
@@ -57,6 +57,12 @@ public sealed partial class PlayerCommand : ToolshedCommand
     {
         return sessions.AttachedEntity ?? default;
     }
+
+    [CommandImplementation("entity")]
+    public EntityUid GetPlayerEntity(IInvocationContext ctx, ICommonSession sessions)
+    {
+        return sessions.AttachedEntity ?? default;
+    }
 }
 
 public record struct NoSuchPlayerError(string Username) : IConError

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -204,7 +204,7 @@ public static class CompletionHelper
     {
         IoCManager.Resolve(ref players);
 
-        var playerOptions = players.Sessions.Select(p => new CompletionOption(p.Name));
+        var playerOptions = players.Sessions.Select(p => new CompletionOption(p.Name, p.UserId.UserId.ToString()));
         return sorted ? playerOptions.OrderBy(o => o.Value) : playerOptions;
     }
 

--- a/Robust.Shared/Toolshed/TypeParsers/SessionTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/SessionTypeParser.cs
@@ -1,9 +1,13 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Robust.Shared.Console;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Maths;
+using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Toolshed.Errors;
 using Robust.Shared.Toolshed.Syntax;
@@ -36,6 +40,19 @@ internal sealed partial class SessionTypeParser : TypeParser<ICommonSession>
             return true;
         }
 
+        if (Guid.TryParse(word, out var guid))
+        {
+            if (_player.TryGetSessionById(new NetUserId(guid), out session))
+            {
+                result = session;
+                return true;
+            }
+
+            ctx.Error = new InvalidGuid(Loc, guid);
+            ctx.Error.Contextualize(ctx.Input, (start, ctx.Index));
+            return false;
+        }
+
         ctx.Error = new InvalidUsername(Loc, word);
         ctx.Error.Contextualize(ctx.Input, (start, ctx.Index));
         return false;
@@ -43,7 +60,12 @@ internal sealed partial class SessionTypeParser : TypeParser<ICommonSession>
 
     public override CompletionResult TryAutocomplete(ParserContext parserContext, CommandArgument? arg)
     {
-        var opts = CompletionHelper.SessionNames(true, _player);
+        var nameOpts = CompletionHelper.SessionNames(true, _player).ToList();
+        var guidOpts = _player.Sessions
+            .Select(session => new CompletionOption(session.UserId.UserId.ToString(), session.Name))
+            .ToList();
+        var opts = nameOpts.Concat(guidOpts).ToList(); // Combined list, with Guids sorted after all the names.
+
         return CompletionResult.FromHintOptions(opts, GetArgHint(arg));
     }
 
@@ -54,6 +76,17 @@ internal sealed partial class SessionTypeParser : TypeParser<ICommonSession>
             return FormattedMessage.FromUnformatted(Loc.GetString("cmd-parse-failure-session", ("username", Username)));
         }
 
+        public string? Expression { get; set; }
+        public Vector2i? IssueSpan { get; set; }
+        public StackTrace? Trace { get; set; }
+    }
+
+    public record InvalidGuid(ILocalizationManager Loc, Guid Guid) : IConError
+    {
+        public FormattedMessage DescribeInner()
+        {
+            return FormattedMessage.FromUnformatted(Loc.GetString("cmd-parse-failure-session-guid", ("guid", Guid)));
+        }
         public string? Expression { get; set; }
         public Vector2i? IssueSpan { get; set; }
         public StackTrace? Trace { get; set; }


### PR DESCRIPTION
As per the comment, Toolshed can just, inherently parse ICommonSession, but due to how the system works `player:imm` IS still needed since you can't just start a command with a session name. That being said, there's no real reason to parse a username string when you can just, pass it an ICommonSession directly and then return the exact thing you passed in, which then allows it to be piped into something else as per usual.
The main benefit here is being able to use autocompletion like basically any other instance of needing to pass in ICommonSession.