### PR TITLE
Support ordered multi-registrar component events

### DIFF
--- a/Robust.Shared.IntegrationTests/GameObjects/EntityEventBusTests.MultiRegistrar.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/EntityEventBusTests.MultiRegistrar.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Reflection;
+using Robust.UnitTesting.Server;
+
+namespace Robust.UnitTesting.Shared.GameObjects
+{
+    internal sealed partial class EntityEventBusTests
+    {
+        private static (EntityEventBus Bus, EntityUid Uid, Action Attach) MultiRegistrarFactory()
+        {
+            var sim = RobustServerSimulation
+                .NewSimulation()
+                .RegisterComponents(f => f.RegisterClass<OrderAComponent>())
+                .InitializeInstance();
+
+            var entMan = sim.Resolve<EntityManager>();
+            var uid = entMan.Spawn();
+            var comp = entMan.AddComponent<OrderAComponent>(uid);
+            var bus = entMan.EventBusInternal;
+            bus.ClearSubscriptions();
+
+            var reg = sim.Resolve<IComponentFactory>().GetRegistration(CompIdx.Index<OrderAComponent>());
+
+            void Attach()
+            {
+                bus.LockSubscriptions();
+                bus.OnEntityAdded(uid);
+                bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(comp, uid), reg));
+            }
+
+            return (bus, uid, Attach);
+        }
+
+        [Test]
+        public void MultipleRegistrarsSubscribeToSameCompEvent()
+        {
+            var (bus, uid, attach) = MultiRegistrarFactory();
+
+            var calls = new List<string>();
+            void HandlerA(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("A");
+            void HandlerB(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("B");
+
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerA, typeof(RegistrarA));
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerB, typeof(RegistrarB), after: new[] { typeof(RegistrarA) });
+            attach();
+
+            bus.RaiseLocalEvent(uid, new TestEvent(0));
+
+            Assert.That(calls, Is.EqualTo(new[] { "A", "B" }));
+        }
+
+        [Test]
+        public void SecondRegistrarCanRunBeforeTheFirst()
+        {
+            var (bus, uid, attach) = MultiRegistrarFactory();
+
+            var calls = new List<string>();
+            void HandlerA(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("A");
+            void HandlerB(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("B");
+
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerA, typeof(RegistrarA));
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerB, typeof(RegistrarB), before: new[] { typeof(RegistrarA) });
+            attach();
+
+            bus.RaiseLocalEvent(uid, new TestEvent(0));
+
+            Assert.That(calls, Is.EqualTo(new[] { "B", "A" }));
+        }
+
+        [Test]
+        public void FirstRegistrarMayDeclareTheOrderInstead()
+        {
+            var (bus, uid, attach) = MultiRegistrarFactory();
+
+            var calls = new List<string>();
+            void HandlerA(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("A");
+            void HandlerB(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("B");
+
+            // Either side of the pair may be the one to declare the order
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerA, typeof(RegistrarA), before: new[] { typeof(RegistrarB) });
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerB, typeof(RegistrarB));
+            attach();
+
+            bus.RaiseLocalEvent(uid, new TestEvent(0));
+
+            Assert.That(calls, Is.EqualTo(new[] { "A", "B" }));
+        }
+
+        [Test]
+        public void StackedRegistrarsMustDeclareAnOrder()
+        {
+            var (bus, _, _) = MultiRegistrarFactory();
+
+            void Handler(EntityUid _, OrderAComponent _1, TestEvent _2) { }
+
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarA));
+
+            // No order relative to RegistrarA at all
+            Assert.Throws<InvalidOperationException>(
+                () => bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarB)));
+
+            // Ordered but against an unrelated registrar
+            Assert.Throws<InvalidOperationException>(
+                () => bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarC), after: new[] { typeof(RegistrarD) }));
+        }
+
+        [Test]
+        public void ThirdRegistrarMustOrderAgainstBothOthers()
+        {
+            var (bus, _, _) = MultiRegistrarFactory();
+
+            void Handler(EntityUid _, OrderAComponent _1, TestEvent _2) { }
+
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarA));
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarB), after: new[] { typeof(RegistrarA) });
+
+            // Ordering against B alone leaves C's order relative to A undeclared
+            Assert.Throws<InvalidOperationException>(
+                () => bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarC), after: new[] { typeof(RegistrarB) }));
+
+            Assert.DoesNotThrow(
+                () => bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarC), after: new[] { typeof(RegistrarA), typeof(RegistrarB) }));
+        }
+
+        [Test]
+        public void SameRegistrarCannotSubscribeTwiceToSameCompEvent()
+        {
+            var (bus, _, _) = MultiRegistrarFactory();
+
+            void Handler(EntityUid _, OrderAComponent _1, TestEvent _2) { }
+
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarA));
+
+            Assert.Throws<InvalidOperationException>(
+                () => bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarA)));
+        }
+
+        [Test]
+        public void UnownedSubscriptionsCannotStack()
+        {
+            var (bus, _, _) = MultiRegistrarFactory();
+
+            void Handler(EntityUid _, OrderAComponent _1, TestEvent _2) { }
+
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler);
+
+            Assert.Throws<InvalidOperationException>(
+                () => bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarA)));
+
+            var (otherBus, _, _) = MultiRegistrarFactory();
+            otherBus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarA));
+
+            Assert.Throws<InvalidOperationException>(
+                () => otherBus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler));
+        }
+
+        [Test]
+        public void UnsubscribeByOwnerKeepsOtherRegistrars()
+        {
+            var (bus, uid, attach) = MultiRegistrarFactory();
+
+            var calls = new List<string>();
+            void HandlerA(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("A");
+            void HandlerB(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("B");
+            void HandlerC(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("C");
+
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerA, typeof(RegistrarA));
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerB, typeof(RegistrarB), after: new[] { typeof(RegistrarA) });
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerC, typeof(RegistrarC), after: new[] { typeof(RegistrarA), typeof(RegistrarB) });
+
+            bus.UnsubscribeLocalEvent<OrderAComponent, TestEvent>(typeof(RegistrarB));
+            bus.UnsubscribeLocalEvent<OrderAComponent, TestEvent>(typeof(RegistrarA));
+
+            bus.UnsubscribeLocalEvent<OrderAComponent, TestEvent>(typeof(RegistrarD));
+
+            attach();
+            bus.RaiseLocalEvent(uid, new TestEvent(0));
+
+            Assert.That(calls, Is.EqualTo(new[] { "C" }));
+        }
+
+        [Test]
+        public void UnsubscribeByOwnerRemovesLastRegistrar()
+        {
+            var (bus, uid, attach) = MultiRegistrarFactory();
+
+            var called = false;
+            void Handler(EntityUid _, OrderAComponent _1, TestEvent _2) => called = true;
+
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(Handler, typeof(RegistrarA));
+            bus.UnsubscribeLocalEvent<OrderAComponent, TestEvent>(typeof(RegistrarA));
+
+            attach();
+            bus.RaiseLocalEvent(uid, new TestEvent(0));
+
+            Assert.That(called, Is.False);
+        }
+
+        [Test]
+        public void UnsubscribeWithoutOwnerRemovesEveryRegistrar()
+        {
+            var (bus, uid, attach) = MultiRegistrarFactory();
+
+            var calls = new List<string>();
+            void HandlerA(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("A");
+            void HandlerB(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("B");
+
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerA, typeof(RegistrarA));
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerB, typeof(RegistrarB), after: new[] { typeof(RegistrarA) });
+            bus.UnsubscribeLocalEvent<OrderAComponent, TestEvent>();
+
+            attach();
+            bus.RaiseLocalEvent(uid, new TestEvent(0));
+
+            Assert.That(calls, Is.Empty);
+        }
+
+        [Test]
+        public void StackedHandlerSkippedWhenComponentRemoved()
+        {
+            var sim = RobustServerSimulation
+                .NewSimulation()
+                .RegisterComponents(f => f.RegisterClass<OrderAComponent>())
+                .InitializeInstance();
+
+            var entMan = sim.Resolve<EntityManager>();
+            var uid = entMan.Spawn();
+            var comp = entMan.AddComponent<OrderAComponent>(uid);
+            var bus = entMan.EventBusInternal;
+            bus.ClearSubscriptions();
+
+            var reg = sim.Resolve<IComponentFactory>().GetRegistration(CompIdx.Index<OrderAComponent>());
+
+            var calls = new List<string>();
+
+            void HandlerA(EntityUid _, OrderAComponent _1, TestEvent _2)
+            {
+                calls.Add("A");
+                entMan.RemoveComponent<OrderAComponent>(uid);
+            }
+
+            void HandlerB(EntityUid _, OrderAComponent _1, TestEvent _2) => calls.Add("B");
+
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerA, typeof(RegistrarA));
+            bus.SubscribeLocalEvent<OrderAComponent, TestEvent>(HandlerB, typeof(RegistrarB), after: new[] { typeof(RegistrarA) });
+
+            bus.LockSubscriptions();
+            bus.OnEntityAdded(uid);
+            bus.OnComponentAdded(new AddedComponentEventArgs(new ComponentEventArgs(comp, uid), reg));
+
+            bus.RaiseLocalEvent(uid, new TestEvent(0));
+
+            Assert.That(calls, Is.EqualTo(new[] { "A" }));
+        }
+
+        [Test]
+        public void MultipleSystemsSubscribeToSameCompEvent()
+        {
+            var simulation = RobustServerSimulation
+                .NewSimulation()
+                .RegisterComponents(factory => factory.RegisterClass<DummyComponent>())
+                .RegisterEntitySystems(factory =>
+                {
+                    factory.LoadExtraSystemType<MultiSubOneSystem>();
+                    factory.LoadExtraSystemType<MultiSubTwoSystem>();
+                })
+                .InitializeInstance();
+
+            var map = simulation.CreateMap().MapId;
+            var entity = simulation.SpawnEntity(null, new MapCoordinates(0, 0, map));
+            IoCManager.Resolve<IEntityManager>().AddComponent<DummyComponent>(entity);
+
+            var testEvent = new TestStructEvent { TestNumber = 5 };
+            simulation.Resolve<IEntityManager>().EventBus.RaiseLocalEvent(entity, ref testEvent);
+
+            Assert.That(testEvent.TestNumber, Is.EqualTo(11));
+        }
+
+        [Reflect(false)]
+        private sealed class MultiSubOneSystem : EntitySystem
+        {
+            public override void Initialize()
+            {
+                SubscribeLocalEvent<DummyComponent, TestStructEvent>(OnEvent);
+            }
+
+            private void OnEvent(EntityUid uid, DummyComponent component, ref TestStructEvent args)
+            {
+                args.TestNumber *= 2;
+            }
+        }
+
+        [Reflect(false)]
+        private sealed class MultiSubTwoSystem : EntitySystem
+        {
+            public override void Initialize()
+            {
+                SubscribeLocalEvent<DummyComponent, TestStructEvent>(OnEvent, after: new[] { typeof(MultiSubOneSystem) });
+            }
+
+            private void OnEvent(EntityUid uid, DummyComponent component, ref TestStructEvent args)
+            {
+                args.TestNumber++;
+            }
+        }
+
+        private sealed class RegistrarA;
+
+        private sealed class RegistrarB;
+
+        private sealed class RegistrarC;
+
+        private sealed class RegistrarD;
+    }
+}

--- a/Robust.Shared/GameObjects/EntityEventBus.Common.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Common.cs
@@ -36,16 +36,23 @@ internal sealed partial class EntityEventBus : IEventBus
     /// <see cref="CompIdx.Value"/>, while the dictionary is indexed by the event type. This does not include events
     /// with the <see cref="ComponentEventAttribute"/>, unless <see cref="ComponentEventAttribute.Exclusive"/> is false.
     /// </summary>
+    /// <remarks>
+    /// The dictionary value is the <i>head</i> of a singly linked list of registrations, chained through
+    /// <see cref="DirectedRegistration.Next"/> in subscription order. Several registrars may subscribe to the same
+    /// component &amp; event pair provided they order themselves against each other, but any single registrar may
+    /// only subscribe to a given pair once. See EntAddSubscription for the exact rules.
+    /// </remarks>
     private FrozenDictionary<Type, DirectedRegistration>[] _eventSubs = default!;
 
     /// <summary>
-    /// Variant of <see cref="_eventSubs"/> that only includes events with the <see cref="ComponentEventAttribute"/>
+    /// Variant of <see cref="_eventSubs"/> that only includes events with the <see cref="ComponentEventAttribute"/>.
+    /// Unlike <see cref="_eventSubs"/>, these are always limited to a single handler.
     /// </summary>
     private FrozenDictionary<Type, DirectedEventHandler>[] _compEventSubs = default!;
 
     // pre-freeze event subscription data
     private Dictionary<Type, DirectedRegistration>?[] _eventSubsUnfrozen = [];
-    private Dictionary<Type, DirectedEventHandler>?[] _compEventSubsUnfrozen = [];
+    private Dictionary<Type, CompEventRegistration>?[] _compEventSubsUnfrozen = [];
 
     /// <summary>
     /// Inverse of <see cref="_eventSubs"/>, mapping event types to sets of components.
@@ -88,6 +95,13 @@ internal sealed partial class EntityEventBus : IEventBus
             subs.OrderingUpToDate = false;
         }
     }
+
+    /// <summary>
+    /// Pre-freeze entry for <see cref="_compEventSubs"/>. Tracks the registrar alongside the handler so that
+    /// unsubscribing cannot remove a handler belonging to somebody else. The owner is dropped when freezing, as it is
+    /// only needed while subscriptions are still mutable
+    /// </summary>
+    private readonly record struct CompEventRegistration(DirectedEventHandler Handler, Type? Owner);
 
     /// <summary>
     /// Information for a single event type handled by EventBus. Not specific to broadcast registrations.

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -59,7 +59,24 @@ namespace Robust.Shared.GameObjects
 
         #endregion
 
+        /// <summary>
+        /// Removes <b>every</b> subscription to <typeparamref name="TEvent"/> on <typeparamref name="TComp"/>,
+        /// no matter which registrar added them.
+        /// </summary>
+        /// <seealso cref="UnsubscribeLocalEvent{TComp,TEvent}(Type)"/>
         void UnsubscribeLocalEvent<TComp, TEvent>()
+            where TComp : IComponent
+            where TEvent : notnull;
+
+        /// <summary>
+        /// Removes only the subscription that <paramref name="owner"/> registered, leaving subscriptions that other
+        /// registrars made to the same component &amp; event pair intact. Does nothing if that registrar has no
+        /// subscription.
+        /// </summary>
+        /// <param name="owner">
+        /// The <c>orderType</c> that was passed when subscribing, generally the subscribing system's type.
+        /// </param>
+        void UnsubscribeLocalEvent<TComp, TEvent>(Type owner)
             where TComp : IComponent
             where TEvent : notnull;
 
@@ -313,6 +330,23 @@ namespace Robust.Shared.GameObjects
             where TComp : IComponent
             where TEvent : notnull
         {
+            EntRemoveSubscription<TComp, TEvent>(null);
+        }
+
+        /// <inheritdoc />
+        public void UnsubscribeLocalEvent<TComp, TEvent>(Type owner)
+            where TComp : IComponent
+            where TEvent : notnull
+        {
+            ArgumentNullException.ThrowIfNull(owner);
+            EntRemoveSubscription<TComp, TEvent>(owner);
+        }
+
+        /// <param name="owner">Registrar whose subscription to remove, or null to remove all of them.</param>
+        private void EntRemoveSubscription<TComp, TEvent>(Type? owner)
+            where TComp : IComponent
+            where TEvent : notnull
+        {
             if (!_comFac.TryGetRegistration(typeof(TComp), out _))
             {
                 if (!IgnoreUnregisteredComponents)
@@ -325,12 +359,60 @@ namespace Robust.Shared.GameObjects
                 throw new InvalidOperationException("Subscription locked.");
 
             var i = CompIdx.ArrayIndex<TComp>();
+            var eventType = typeof(TEvent);
+            var compSubs = _eventSubsUnfrozen[i]!;
+            var compEventSubs = _compEventSubsUnfrozen[i]!;
 
-            _eventSubsUnfrozen[i]!.Remove(typeof(TEvent));
-            _compEventSubsUnfrozen[i]!.Remove(typeof(TEvent));
+            if (owner == null)
+            {
+                compSubs.Remove(eventType);
+                compEventSubs.Remove(eventType);
+            }
+            else
+            {
+                if (compEventSubs.TryGetValue(eventType, out var compEvent) && compEvent.Owner == owner)
+                    compEventSubs.Remove(eventType);
 
-            if (_eventSubsInv.TryGetValue(typeof(TEvent), out var t))
+                RemoveOwnedSubscription(compSubs, eventType, owner);
+            }
+
+            // Other registrars may still be subscribed in which case the component has to stay in the inverse map
+            if (!compSubs.ContainsKey(eventType) && _eventSubsInv.TryGetValue(eventType, out var t))
                 t.Remove(CompIdx.Index<TComp>());
+        }
+
+        /// <summary>
+        /// Unlink the registration belonging to <paramref name="owner"/> from a chain leaving the rest of it alone
+        /// </summary>
+        private static void RemoveOwnedSubscription(
+            Dictionary<Type, DirectedRegistration> compSubs,
+            Type eventType,
+            Type owner)
+        {
+            if (!compSubs.TryGetValue(eventType, out var head))
+                return;
+
+            if (head.Owner == owner)
+            {
+                if (head.Next == null)
+                    compSubs.Remove(eventType);
+                else
+                    compSubs[eventType] = head.Next;
+
+                head.Next = null;
+                return;
+            }
+
+            for (var reg = head; reg.Next != null; reg = reg.Next)
+            {
+                if (reg.Next.Owner != owner)
+                    continue;
+
+                var removed = reg.Next;
+                reg.Next = removed.Next;
+                removed.Next = null;
+                return;
+            }
         }
 
         private void ComFacOnComponentsAdded(ComponentRegistration[] regs)
@@ -370,7 +452,7 @@ namespace Robust.Shared.GameObjects
                 .ToArray();
 
             _compEventSubs = TrimNull(_compEventSubsUnfrozen)
-                .Select(dict => dict?.ToFrozenDictionary()!)
+                .Select(dict => dict?.ToFrozenDictionary(x => x.Key, x => x.Value.Handler)!)
                 .ToArray();
 
             CalcOrdering();
@@ -403,8 +485,8 @@ namespace Robust.Shared.GameObjects
 
             if (eventType.GetCustomAttribute<ComponentEventAttribute>() is { } attr)
             {
-                if (!_compEventSubsUnfrozen[compType.Value]!.TryAdd(eventType, handler))
-                    throw new InvalidOperationException($"Duplicate Subscriptions for comp={compTypeObj}, event={eventType.Name}");
+                if (!_compEventSubsUnfrozen[compType.Value]!.TryAdd(eventType, new CompEventRegistration(handler, orderType)))
+                    throw new InvalidOperationException(DuplicateSubMessage(compTypeObj, eventType, orderType));
 
                 // An exclusive component-event is only raised via RaiseComponentEvent, hence it don't need a normal
                 // directed event subscription
@@ -413,13 +495,96 @@ namespace Robust.Shared.GameObjects
             }
 
             var orderData = orderType == null ? null : CreateOrderingData(orderType, before, after);
-            var reg = new DirectedRegistration(orderData, handler);
+            var reg = new DirectedRegistration(orderData, handler, orderType);
 
-            if (!_eventSubsUnfrozen[compType.Value]!.TryAdd(eventType, reg))
-                throw new InvalidOperationException($"Duplicate Subscriptions for comp={compTypeObj}, event={eventType.Name}");
+            var compSubs = _eventSubsUnfrozen[compType.Value]!;
+            if (compSubs.TryGetValue(eventType, out var head))
+                AppendSubscription(head, reg, compTypeObj, eventType);
+            else
+                compSubs.Add(eventType, reg);
 
             RegisterCommon(eventType, reg.Ordering, out _);
             _eventSubsInv.GetOrNew(eventType).Add(compType);
+        }
+
+        /// <summary>
+        /// Append a registration to the end of an existing chain for the same component &amp; event pair.
+        /// </summary>
+        /// <remarks>
+        /// Several registrars stacking on one pair is allowed, but every pair of them must declare an explicit order,
+        /// as a chain's dispatch order would otherwise silently depend on system initialization order. Only the first
+        /// registrar may omit ordering, which leaves it running first unless a later one asks to go before it.
+        /// A single registrar may not stack on itself at all, ordering is keyed on the registrar type, so its two
+        /// subscriptions could neither be told apart nor be ordered relative to each other. Subscriptions made
+        /// straight on the bus without an order type have no identity either, and likewise never stack.
+        /// </remarks>
+        private static void AppendSubscription(
+            DirectedRegistration head,
+            DirectedRegistration reg,
+            Type compTypeObj,
+            Type eventType)
+        {
+            var last = head;
+            while (true)
+            {
+                if (reg.Owner == null || last.Owner == null || last.Owner == reg.Owner)
+                    throw new InvalidOperationException(DuplicateSubMessage(compTypeObj, eventType, reg.Owner));
+
+                if (!DeclaresOrder(reg, last))
+                    throw new InvalidOperationException(UnorderedSubMessage(compTypeObj, eventType, reg, last));
+
+                if (last.Next == null)
+                    break;
+
+                last = last.Next;
+            }
+
+            last.Next = reg;
+        }
+
+        /// <summary>
+        /// Whether the relative order of two registrations is pinned down by either one's Before/After.
+        /// </summary>
+        private static bool DeclaresOrder(DirectedRegistration a, DirectedRegistration b)
+        {
+            return References(a.Ordering, b.Owner) || References(b.Ordering, a.Owner);
+
+            static bool References(OrderingData? ordering, Type? owner)
+            {
+                return ordering != null
+                       && (Array.IndexOf(ordering.Before, owner) >= 0
+                           || Array.IndexOf(ordering.After, owner) >= 0);
+            }
+        }
+
+        private static string DuplicateSubMessage(Type componentType, Type eventType, Type? owner)
+        {
+            var registrar = owner?.Name ?? "unordered subscription";
+            return $"Duplicate subscription: comp={componentType.Name}, event={eventType.Name}, registrar={registrar}.";
+        }
+
+        private static string UnorderedSubMessage(
+            Type componentType,
+            Type eventType,
+            DirectedRegistration registration,
+            DirectedRegistration existing)
+        {
+            return
+                $"{registration.Owner!.Name} and {existing.Owner!.Name} subscribe to " +
+                $"comp={componentType.Name}, event={eventType.Name} without declaring an order. " +
+                $"Specify before/after: typeof({existing.Owner.Name}).";
+        }
+
+        /// <summary>
+        /// Walk a chain of directed registrations, starting at <paramref name="reg"/>
+        /// </summary>
+        private static IEnumerable<DirectedRegistration> EnumerateChain(DirectedRegistration? reg)
+        {
+            while (reg != null)
+            {
+                yield return reg;
+                reg = reg.Next;
+            }
         }
 
         private void EntAddEntity(EntityUid euid)
@@ -569,8 +734,19 @@ namespace Robust.Shared.GameObjects
             {
                 if (!_entMan.TryGetComponent(euid, compIdx, out var comp))
                     continue;
+
                 var compSubs = _eventSubs[compIdx.Value];
-                compSubs[eventType].Handler(euid, comp, ref args);
+
+                // Requiring explicit ordering on stacked subscriptions means any chain longer than one makes its
+                // event ordered, so in practice this loop only ever walks a single registration here. It stays a
+                // loop anyway: it costs one null check on a hot path and keeps dispatch correct either way.
+                // Deleted is re-checked between handlers, as an earlier one may have removed the component.
+                DirectedRegistration? reg = compSubs[eventType];
+                do
+                {
+                    reg.Handler(euid, comp, ref args);
+                    reg = reg.Next;
+                } while (reg != null && !comp.Deleted);
             }
         }
 
@@ -594,15 +770,18 @@ namespace Robust.Shared.GameObjects
                 idx = entry.Next;
                 var comp = _entMan.GetComponentInternal(euid, entry.Component);
                 var compSubs = _eventSubs[entry.Component.Value];
-                var reg = compSubs[eventType];
 
-                found.Add(new OrderedEventDispatch(
-                    (ref Unit ev) =>
-                    {
-                        if (!comp.Deleted)
-                            reg.Handler(euid, comp, ref ev);
-                    },
-                    reg.Order));
+                for (DirectedRegistration? reg = compSubs[eventType]; reg != null; reg = reg.Next)
+                {
+                    var current = reg;
+                    found.Add(new OrderedEventDispatch(
+                        (ref Unit ev) =>
+                        {
+                            if (!comp.Deleted)
+                                current.Handler(euid, comp, ref ev);
+                        },
+                        current.Order));
+                }
             }
         }
 
@@ -641,10 +820,22 @@ namespace Robust.Shared.GameObjects
             _eventSubsInv = null!;
         }
 
-        internal sealed class DirectedRegistration(OrderingData? ordering, DirectedEventHandler handler)
+        internal sealed class DirectedRegistration(OrderingData? ordering, DirectedEventHandler handler, Type? owner)
             : OrderedRegistration(ordering)
         {
             public readonly DirectedEventHandler Handler = handler;
+
+            /// <summary>
+            /// The type that registered this subscription, generally the subscribing <see cref="EntitySystem"/>.
+            /// Used to stop a registrar from subscribing twice and to let it unsubscribe without clobbering the
+            /// other registrars. Null for subscriptions made straight on the bus with no ordering info.
+            /// </summary>
+            public readonly Type? Owner = owner;
+
+            /// <summary>
+            /// Next registration for the same component &amp; event pair, in subscription order. Null at the tail.
+            /// </summary>
+            public DirectedRegistration? Next;
 
             public void SetOrder(int order)
             {

--- a/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Directed.cs
@@ -737,16 +737,14 @@ namespace Robust.Shared.GameObjects
 
                 var compSubs = _eventSubs[compIdx.Value];
 
-                // Requiring explicit ordering on stacked subscriptions means any chain longer than one makes its
-                // event ordered, so in practice this loop only ever walks a single registration here. It stays a
-                // loop anyway: it costs one null check on a hot path and keeps dispatch correct either way.
-                // Deleted is re-checked between handlers, as an earlier one may have removed the component.
-                DirectedRegistration? reg = compSubs[eventType];
-                do
-                {
-                    reg.Handler(euid, comp, ref args);
-                    reg = reg.Next;
-                } while (reg != null && !comp.Deleted);
+                // Stacked subscriptions have to declare an order, which marks their event ordered, so a chain longer
+                // than one is only ever reached through EntCollectOrdered and there is nothing to walk here. Were that
+                // to stop holding, the extra handlers would silently never run, hence the assert. It is deliberately
+                // kept off the dispatch line, so that this method compiles down to exactly what it was before
+                // stacking existed; the repeated lookup only happens in DEBUG.
+                DebugTools.AssertNull(compSubs[eventType].Next);
+
+                compSubs[eventType].Handler(euid, comp, ref args);
             }
         }
 

--- a/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
+++ b/Robust.Shared/GameObjects/EntityEventBus.Ordering.cs
@@ -67,15 +67,20 @@ namespace Robust.Shared.GameObjects
                 regs = regs.Concat(comps
                     .Select(c => _eventSubs[c.Value])
                     .Where(c => c != null)
-                    .Select(c => c![eventType]));
+                    .SelectMany(c => EnumerateChain(c![eventType])));
             }
 
             // A hard problem in EventBus' design is that ordering is keyed on a single Type instance
             // (probably just the type of the EntitySystem).
-            // This is problematic if a system listens to the same directed event multiple times for the same component,
-            // as there are now two distinct subscriptions with the same key.
+            // This is problematic if a system listens to the same directed event on several components,
+            // as there are now multiple distinct subscriptions with the same key.
             // To solve this, I decided that *this is allowed*, but all ordering on the same key must be the same.
             // So you can't have different Before/After on two subscriptions to an event on the same system.
+            //
+            // The corollary is that two subscriptions sharing a key cannot be ordered relative to each other, and
+            // nothing can be slotted in between them. That is why a single registrar may not subscribe twice to the
+            // same component & event pair, and why registrars that do stack on one pair must order themselves
+            // explicitly. Both are enforced at subscription time, see EntAddSubscription.
             //
             // Group by ordering types, also filter out un-ordered ones.
 

--- a/Robust.Shared/GameObjects/EntitySystem.Subscriptions.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Subscriptions.cs
@@ -262,7 +262,7 @@ namespace Robust.Shared.GameObjects
         {
             public override void Unsubscribe(EntitySystem sys, IEventBus bus)
             {
-                bus.UnsubscribeLocalEvent<TComp, TBase>();
+                bus.UnsubscribeLocalEvent<TComp, TBase>(sys.GetType());
             }
         }
 


### PR DESCRIPTION
Directed subscriptions were capped at one handler per component & event pair
engine-wide, so a system could never subscribe to a pair another system had
already claimed. Now several can, as long as each declares an order against the
others with before/after the first to subscribe may omit it and runs first.

A single system subscribing to the same pair twice still throws, as does stacking
on [ComponentEvent]; neither can express an order.

Also adds UnsubscribeLocalEvent<TComp, TEvent>(Type owner) so a system shutting
down only drops its own handler instead of everyone's
