### PR TITLE
Add `cmd-replay-toggleui-desc` string

### DIFF
--- a/Resources/Locale/en-US/replays.ftl
+++ b/Resources/Locale/en-US/replays.ftl
@@ -33,6 +33,8 @@ cmd-replay-error-no-replay = Not currently playing a replay.
 cmd-replay-error-already-loaded = A replay is already loaded.
 cmd-replay-error-run-level = You cannot load a replay while connected to a server.
 
+cmd-replay-toggleui-desc = Toggles the replay control UI.
+
 # Recording commands
 
 cmd-replay-recording-start-desc = Starts a replay recording, optionally with some time limit.


### PR DESCRIPTION
Adds `cmd-replay-toggleui-desc` to `Resources/Locale/en-US/replays.ftl`. This command exists in RobustToolbox, but the description string for it was only added in [Space Station 14 itself](https://github.com/space-wizards/space-station-14/blob/34880bfd47aeb98acb8103ed14a552adc6edda96/Resources/Locale/en-US/replays/replays.ftl#L46).

If this was missing (as it was in OpenDream) then it would print a warning to the dev console on every character typed:
`[WARN] loc: Unknown messageId ("en-US"): "cmd-replay-toggleui-desc"`