### PR TITLE
Make disabled checkboxes greyed out

### DIFF
--- a/Robust.Client/UserInterface/Controls/CheckBox.cs
+++ b/Robust.Client/UserInterface/Controls/CheckBox.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.ViewVariables;
+﻿using Robust.Shared.Maths;
+using Robust.Shared.ViewVariables;
 using static Robust.Client.UserInterface.Controls.Label;
 
 namespace Robust.Client.UserInterface.Controls
@@ -44,7 +45,7 @@ namespace Robust.Client.UserInterface.Controls
         }
 
         private bool _leftAlign = true;
-        
+
         public CheckBox()
         {
             ToggleMode = true;
@@ -89,6 +90,8 @@ namespace Robust.Client.UserInterface.Controls
                 else
                     TextureRect.RemoveStyleClass(StyleClassCheckBoxChecked);
             }
+
+            Modulate = Disabled ? Color.LightGray : Color.White;
         }
 
         /// <summary>


### PR DESCRIPTION
Checkboxes currently do not have any different visuals for when they're disabled or not, so this PR adds it:

Enabled vs disabled:
<img width="54" height="115" alt="image" src="https://github.com/user-attachments/assets/c7d0934f-1eae-4f21-8711-8d0e24d75fa0" />
