### PR TITLE
Add global usings file to Robust.Shared.IntegrationTests

### DIFF
--- a/Robust.Shared.IntegrationTests/Usings.cs
+++ b/Robust.Shared.IntegrationTests/Usings.cs
@@ -1,0 +1,1 @@
+﻿global using Robust.Shared.Analyzers;


### PR DESCRIPTION
Added `Usings.cs` file to the root of `Robust.Shared.IntegrationTests/`, containing a single line:
```cs
global using Robust.Shared.Analyzers;
```
(Exactly the same as the other `Usings.cs`/`Using.cs` files found in other project directories)

This is needed so that any auto-generated EntitySystem event subscriptions (using the new event subscription attributes) have access to the `[MustCallBase]` attribute used in the generated code.