### PR TITLE
Fix RobustIntegrationTest not raising a OnConnecting event for dummy sessions

### DIFF
--- a/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.NetManager.cs
@@ -234,7 +234,7 @@ namespace Robust.UnitTesting
                 }
             }
 
-            private async Task<NetConnectingArgs> OnConnecting(IPEndPoint ip, NetUserData userData, LoginType loginType)
+            internal async Task<NetConnectingArgs> OnConnecting(IPEndPoint ip, NetUserData userData, LoginType loginType)
             {
                 var args = new NetConnectingArgs(userData, ip, loginType);
                 foreach (var conn in _connectingEvent)

--- a/Robust.UnitTesting/RobustIntegrationTest.cs
+++ b/Robust.UnitTesting/RobustIntegrationTest.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -913,7 +915,21 @@ namespace Robust.UnitTesting
                 _dummySessions.Add(userId, session);
 
                 session.ConnectedTime = DateTime.UtcNow;
-                await WaitPost(() => man.SetStatus(session, SessionStatus.Connected));
+                await WaitPost(() =>
+                {
+                    var userData = new NetUserData(userId, userName)
+                    {
+                        HWId = ImmutableArray<byte>.Empty,
+                        ModernHWIds = []
+                    };
+
+                    (NetMan as IntegrationNetManager)?.OnConnecting(
+                        new IPEndPoint(IPAddress.Loopback, 1212),
+                        userData,
+                        LoginType.GuestAssigned
+                    );
+                    man.SetStatus(session, SessionStatus.Connected);
+                });
 
                 return session;
             }


### PR DESCRIPTION
Guess who had to debug tests for hours with them randomly locking up for fun half-way through
This causes any code ever expecting a player row to exist for example to just die
The data used is the same RobustIntegrationTest uses elsewhere (loopback, port 1212, empty hwid, guest assigned)