### PR TITLE
Add IClyde.SetRelativeMouseMode

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* Added `IClyde.SetRelativeMouseMode`, which puts the primary window into SDL's relative mouse mode: the cursor is hidden and locked in place while mouse motion keeps being reported as deltas.
 
 ### Bugfixes
 

--- a/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Windowing.cs
@@ -455,6 +455,14 @@ namespace Robust.Client.Graphics.Clyde
             _windowing!.CursorSet(_mainWindow!, cursor);
         }
 
+        public bool SetRelativeMouseMode(bool enabled)
+        {
+            if (_windowing == null || _mainWindow == null)
+                return false;
+
+            return _windowing.SetRelativeMouseMode(_mainWindow, enabled);
+        }
+
         private void SetWindowSize(WindowReg reg, Vector2i size)
         {
             DebugTools.AssertNotNull(_windowing);

--- a/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
+++ b/Robust.Client/Graphics/Clyde/ClydeHeadless.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
@@ -237,6 +237,8 @@ namespace Robust.Client.Graphics.Clyde
         {
             // Nada.
         }
+
+        public bool SetRelativeMouseMode(bool enabled) => false;
 
         public void Screenshot(ScreenshotType type, CopyPixelsDelegate<Rgb24> callback, UIBox2i? subRegion = null)
         {

--- a/Robust.Client/Graphics/Clyde/Windowing/IWindowingImpl.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/IWindowingImpl.cs
@@ -68,6 +68,8 @@ namespace Robust.Client.Graphics.Clyde
 
             // IME
             void TextInputSetRect(WindowReg reg, UIBox2i rect, int cursor);
+            bool SetRelativeMouseMode(WindowReg reg, bool enabled);
+
             void TextInputStart(WindowReg reg);
             void TextInputStop(WindowReg reg);
             string GetDescription();

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
@@ -616,6 +616,17 @@ internal partial class Clyde
             SDL.SDL_SetTextInputArea(cmdTextInput.Window, ref rect, cmdTextInput.Cursor);
         }
 
+        public bool SetRelativeMouseMode(WindowReg reg, bool enabled)
+        {
+            SendCmd(new CmdSetRelativeMouseMode { Window = WinPtr(reg), Enabled = enabled });
+            return true;
+        }
+
+        private static void WinThreadSetRelativeMouseMode(CmdSetRelativeMouseMode cmd)
+        {
+            SDL.SDL_SetWindowRelativeMouseMode(cmd.Window, cmd.Enabled);
+        }
+
         public void TextInputStart(WindowReg reg)
         {
             SendCmd(new CmdTextInputStart { Window = WinPtr(reg) });

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.WindowThread.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.WindowThread.cs
@@ -136,6 +136,10 @@ internal partial class Clyde
                 case CmdTextInputStop cmd:
                     WinThreadStopTextInput(cmd);
                     break;
+
+                case CmdSetRelativeMouseMode cmd:
+                    WinThreadSetRelativeMouseMode(cmd);
+                    break;
             }
         }
 
@@ -332,6 +336,12 @@ internal partial class Clyde
         private sealed class CmdTextInputStop : CmdBase
         {
             public nint Window;
+        }
+
+        private sealed class CmdSetRelativeMouseMode : CmdBase
+        {
+            public nint Window;
+            public bool Enabled;
         }
 
         private sealed class CmdTextInputSetRect : CmdBase

--- a/Robust.Client/Graphics/IClyde.cs
+++ b/Robust.Client/Graphics/IClyde.cs
@@ -122,6 +122,8 @@ namespace Robust.Client.Graphics
         /// <exception cref="ObjectDisposedException">Thrown if the cursor object passed has been disposed.</exception>
         void SetCursor(ICursor? cursor);
 
+        bool SetRelativeMouseMode(bool enabled);
+
         /// <summary>
         ///     Make a screenshot of the game, next render frame.
         /// </summary>


### PR DESCRIPTION
Adds `bool SetRelativeMouseMode(bool enabled)` to `IClyde`. It puts the primary window into SDL's relative mouse mode: the cursor is hidden and locked in place, while mouse motion keeps arriving as deltas through `MouseMoveEventArgs.Relative`. Wraps `SDL_SetWindowRelativeMouseMode`, routed through `IWindowingImpl` and dispatched onto the window thread like the other window operations. Headless returns `false`.

Radial menus and click-drag camera controls need unbounded pointer input; with a normal cursor the user runs out of screen on whichever side it started near. Content cannot do this itself, since there is no API for cursor position and the sandbox rejects P/Invoke in content assemblies.
