### PR TITLE
Strip nullable annotations from component types when generating event subscriptions

### DIFF
--- a/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
+++ b/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
@@ -210,7 +210,7 @@ using JetBrains.Annotations;
             !TypeSymbolHelper.ImplementsInterface(componentType, IComponentTypeName))
             return null;
 
-        return [componentType.ToString(), eventType.ToString()];
+        return [componentType.WithNullableAnnotation(NullableAnnotation.NotAnnotated).ToString(), eventType.ToString()];
     }
 
     private static SubscriptionInfo? TryParseSubscription(


### PR DESCRIPTION
The EntitySystem event subscription generator now removes nullable annotations (`?`) from component types when generating `ComponentEventHandler`-based subscriptions.

So:
```cs
protected void OnEmagged(EntityUid uid, CryoPodComponent? cryoPodComponent, ref GotEmaggedEvent args)
```
now generates:
```cs
SubscribeLocalEvent<Content.Shared.Medical.Cryogenics.CryoPodComponent, Content.Shared.Emag.Systems.GotEmaggedEvent>(OnEmagged);
```
instead of:
```cs
SubscribeLocalEvent<Content.Shared.Medical.Cryogenics.CryoPodComponent?, Content.Shared.Emag.Systems.GotEmaggedEvent>(OnEmagged);
```

Fixes https://github.com/space-wizards/RobustToolbox/issues/6873.