### PR TITLE
refactor: added "EntityPrototypes by EntityCategoryPrototype" completion helper

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,4 @@
-﻿# Release notes for RobustToolbox.
+# Release notes for RobustToolbox.
 
 <!--
 NOTE: automatically updated sometimes by version.py.
@@ -55,6 +55,10 @@ END TEMPLATE-->
 
 
 ## 285.0.1
+
+### New features
+
+* `IPrototypeManager `now has a new method, `TryGetEntityPrototypesByCategory `. It returns a set of serialized entity prototypes that form part of the given entity category
 
 ### Bugfixes
 

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -275,12 +275,12 @@ public static class CompletionHelper
     }
 
     /// <summary>
-    /// Gets AutoComplete options from list of all loaded <see cref="EntityPrototypes"/>
+    /// Gets AutoComplete options from list of all loaded <see cref="EntityPrototype"/>
     /// filtered by provided <see cref="EntityCategoryPrototype"/>
     /// and substring (filter by StartsWith on <see cref="EntityPrototype.Description"/>
     /// and <see cref="EntityPrototype.ID"/>).
     /// </summary>
-    /// <param name="substring">
+    /// <param name="filterWith">
     /// Substring, by which to filter entity prototypes Id and description.
     /// Will not do filtering in case null was provided.
     /// </param>
@@ -288,7 +288,7 @@ public static class CompletionHelper
     /// <param name="prototype">Prototype manager to be used (in case it was provided).</param>
     /// <param name="limit">Amount of rows to return (in case source collection will have more rows after filtering applied).</param>
     public static IEnumerable<CompletionOption> EntityPrototypes(
-        string? substring,
+        string? filterWith,
         ProtoId<EntityCategoryPrototype> category,
         IPrototypeManager? prototype = null,
         int limit = 20
@@ -296,19 +296,17 @@ public static class CompletionHelper
     {
         IoCManager.Resolve(ref prototype);
 
-        if (!prototype.Categories.TryGetValue(category, out var found))
+        if (!prototype.TryGetEntityPrototypesByCategory(category, out var found))
             yield break;
 
-        var isEmpty = string.IsNullOrWhiteSpace(substring);
-        var i = 0;
-        while (i < limit)
+        var isTextFilterEmpty = string.IsNullOrWhiteSpace(filterWith);
+        for(var i = 0; i < limit && i < found.Count; i++)
         {
             var current = found[i];
             var description = current.Description;
-            if (!isEmpty && !description.StartsWith(substring!) && !current.ID.StartsWith(substring!))
+            if (!isTextFilterEmpty && !description.StartsWith(filterWith!) && !current.ID.StartsWith(filterWith!))
                 continue;
 
-            i++;
             yield return new CompletionOption(current.ID, description);
         }
     }

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -282,7 +282,7 @@ public static class CompletionHelper
     /// </summary>
     /// <param name="filterWith">
     /// Text to be used for filtering entity prototypes by <see cref="EntityPrototype.ID"/>
-    /// and <see cref="EntityPrototype.Description"/>. Will not do filtering in case null was provided.
+    /// and <see cref="EntityPrototype.Name"/>. Will not do filtering in case null was provided.
     /// </param>
     /// <param name="category">Get entity prototypes that belong to this category.</param>
     /// <param name="prototype">Prototype manager to be used (in case it was provided).</param>
@@ -306,14 +306,14 @@ public static class CompletionHelper
         {
             var current = found[index];
             index++;
-            var description = current.Description;
+            var name = current.Name;
             if (!isTextFilterEmpty
-                && !description.Contains(filterWith!, StringComparison.InvariantCultureIgnoreCase)
-                && !current.ID.Contains(filterWith!, StringComparison.InvariantCultureIgnoreCase))
+                && !current.ID.Contains(filterWith!, StringComparison.InvariantCultureIgnoreCase)
+                && !name.Contains(filterWith!, StringComparison.InvariantCultureIgnoreCase))
                 continue;
 
             returnedCount++;
-            yield return new CompletionOption(current.ID, description);
+            yield return new CompletionOption(current.ID, name);
         }
     }
 }

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -300,13 +300,19 @@ public static class CompletionHelper
             yield break;
 
         var isTextFilterEmpty = string.IsNullOrWhiteSpace(filterWith);
-        for(var i = 0; i < limit && i < found.Count; i++)
+        var index = 0;
+        var returnedCount = 0;
+        while (returnedCount < limit && index < found.Count)
         {
-            var current = found[i];
+            var current = found[index];
+            index++;
             var description = current.Description;
-            if (!isTextFilterEmpty && !description.StartsWith(filterWith!) && !current.ID.StartsWith(filterWith!))
+            if (!isTextFilterEmpty
+                && !description.Contains(filterWith!, StringComparison.InvariantCultureIgnoreCase)
+                && !current.ID.Contains(filterWith!, StringComparison.InvariantCultureIgnoreCase))
                 continue;
 
+            returnedCount++;
             yield return new CompletionOption(current.ID, description);
         }
     }

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
-using Robust.Shared.Collections;
 using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -274,5 +272,44 @@ public static class CompletionHelper
     {
         IoCManager.Resolve(ref entManager);
         return GetComponents<T>(text, entManager, limit).Select(o => new CompletionOption(o.NetString, o.EntityName));
+    }
+
+    /// <summary>
+    /// Gets AutoComplete options from list of all loaded <see cref="EntityPrototypes"/>
+    /// filtered by provided <see cref="EntityCategoryPrototype"/>
+    /// and substring (filter by StartsWith on <see cref="EntityPrototype.Description"/>
+    /// and <see cref="EntityPrototype.ID"/>).
+    /// </summary>
+    /// <param name="substring">
+    /// Substring, by which to filter entity prototypes Id and description.
+    /// Will not do filtering in case null was provided.
+    /// </param>
+    /// <param name="category">Get entity prototypes that belong to this category.</param>
+    /// <param name="prototype">Prototype manager to be used (in case it was provided).</param>
+    /// <param name="limit">Amount of rows to return (in case source collection will have more rows after filtering applied).</param>
+    public static IEnumerable<CompletionOption> EntityPrototypes(
+        string? substring,
+        ProtoId<EntityCategoryPrototype> category,
+        IPrototypeManager? prototype = null,
+        int limit = 20
+    )
+    {
+        IoCManager.Resolve(ref prototype);
+
+        if (!prototype.Categories.TryGetValue(category, out var found))
+            yield break;
+
+        var isEmpty = string.IsNullOrWhiteSpace(substring);
+        var i = 0;
+        while (i < limit)
+        {
+            var current = found[i];
+            var description = current.Description;
+            if (!isEmpty && !description.StartsWith(substring!) && !current.ID.StartsWith(substring!))
+                continue;
+
+            i++;
+            yield return new CompletionOption(current.ID, description);
+        }
     }
 }

--- a/Robust.Shared/Console/CompletionHelper.cs
+++ b/Robust.Shared/Console/CompletionHelper.cs
@@ -281,8 +281,8 @@ public static class CompletionHelper
     /// and <see cref="EntityPrototype.ID"/>).
     /// </summary>
     /// <param name="filterWith">
-    /// Substring, by which to filter entity prototypes Id and description.
-    /// Will not do filtering in case null was provided.
+    /// Text to be used for filtering entity prototypes by <see cref="EntityPrototype.ID"/>
+    /// and <see cref="EntityPrototype.Description"/>. Will not do filtering in case null was provided.
     /// </param>
     /// <param name="category">Get entity prototypes that belong to this category.</param>
     /// <param name="prototype">Prototype manager to be used (in case it was provided).</param>

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -567,12 +567,12 @@ public interface IPrototypeManager
     FrozenDictionary<ProtoId<EntityCategoryPrototype>, IReadOnlyList<EntityPrototype>> Categories { get; }
 
     /// <summary>
-    /// Tries to get list of <see cref="EntityPrototype"/> with provided category.
+    /// Attempts to get a list of <see cref="EntityPrototype"/> that belongs to the provided <see cref="EntityCategoryPrototype"/>.
     /// </summary>
-    /// <param name="category">Category to search for.</param>
-    /// <param name="prototypes">List of prototypes with category or null.</param>
-    /// <returns>True if provided category have respective list of prototypes, otherwise false.</returns>
-    bool TryGetEntityPrototypesByCategory(ProtoId<EntityCategoryPrototype> category, [NotNullWhen(true)]out IReadOnlyList<EntityPrototype>? prototypes);
+    /// <param name="category">Category id of the entity prototypes we want to get.</param>
+    /// <param name="prototypes">List of entity prototypes that form part category or null.</param>
+    /// <returns>True if the provided <see cref="EntityCategoryPrototype"/> id has a matching list of <see cref="EntityPrototype"/> False otherwise.</returns>
+    bool TryGetEntityPrototypesByCategory(ProtoId<EntityCategoryPrototype> category, [NotNullWhen(true)] out IReadOnlyList<EntityPrototype>? prototypes);
 }
 
 internal interface IPrototypeManagerInternal : IPrototypeManager

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -565,6 +565,14 @@ public interface IPrototypeManager
     /// Entity prototypes grouped by their categories.
     /// </summary>
     FrozenDictionary<ProtoId<EntityCategoryPrototype>, IReadOnlyList<EntityPrototype>> Categories { get; }
+
+    /// <summary>
+    /// Tries to get list of <see cref="EntityPrototype"/> with provided category.
+    /// </summary>
+    /// <param name="category">Category to search for.</param>
+    /// <param name="prototypes">List of prototypes with category or null.</param>
+    /// <returns>True if provided category have respective list of prototypes, otherwise false.</returns>
+    bool TryGetEntityPrototypesByCategory(ProtoId<EntityCategoryPrototype> category, [NotNullWhen(true)]out IReadOnlyList<EntityPrototype>? prototypes);
 }
 
 internal interface IPrototypeManagerInternal : IPrototypeManager

--- a/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
@@ -1,11 +1,12 @@
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Utility;
+using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
-using Robust.Shared.Serialization.Markdown.Sequence;
-using Robust.Shared.Serialization.Markdown.Value;
-using Robust.Shared.Utility;
 
 namespace Robust.Shared.Prototypes;
 
@@ -51,7 +52,8 @@ public abstract partial class PrototypeManager : IPrototypeManagerInternal
         // Ensure all categories have an entry in the dictionary, even if it is empty.
         foreach (var category in EnumeratePrototypes<EntityCategoryPrototype>())
         {
-            categories.GetOrNew(category.ID);
+            var list = categories.GetOrNew(category.ID);
+            list.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));
         }
 
         DebugTools.Assert(categories.Values.All(x => x.ToHashSet().Count == x.Count));

--- a/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
@@ -23,7 +23,13 @@ public abstract partial class PrototypeManager : IPrototypeManagerInternal
     /// <inheritdoc/>
     public bool TryGetEntityPrototypesByCategory(ProtoId<EntityCategoryPrototype> category, [NotNullWhen(true)] out IReadOnlyList<EntityPrototype>? prototypes)
     {
-        return Categories.TryGetValue(category, out prototypes);
+        var found = Categories.TryGetValue(category, out prototypes);
+        if (!found)
+        {
+            Sawmill.Error("Attempted to find entity prototypes with category '{Category}', but found no such category pre-cached.", category);
+        }
+
+        return found;
     }
 
     private void UpdateCategories()

--- a/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
@@ -1,9 +1,8 @@
-﻿using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
-using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Sequence;
 using Robust.Shared.Serialization.Markdown.Value;
 using Robust.Shared.Utility;
@@ -20,6 +19,12 @@ public abstract partial class PrototypeManager : IPrototypeManagerInternal
 
     public FrozenDictionary<ProtoId<EntityCategoryPrototype>, IReadOnlyList<EntityPrototype>> Categories { get; private set; }
         = FrozenDictionary<ProtoId<EntityCategoryPrototype>, IReadOnlyList<EntityPrototype>>.Empty;
+
+    /// <inheritdoc/>
+    public bool TryGetEntityPrototypesByCategory(ProtoId<EntityCategoryPrototype> category, [NotNullWhen(true)] out IReadOnlyList<EntityPrototype>? prototypes)
+    {
+        return Categories.TryGetValue(category, out prototypes);
+    }
 
     private void UpdateCategories()
     {


### PR DESCRIPTION
Required for https://github.com/space-wizards/space-station-14/pull/45061
Added EntityPrototypes that can be used to list EntityPrototypes based on provided EntityCategoryPrototype in commands.
* Adds limiter to not give whole list of items if its too big
* reuses IPrototypeManager.Categories which is already being filled and updated

Sample of usage

```
public sealed partial class StatusEffectCompletionParser : CustomCompletionParser<EntProtoId>
{
    private static readonly ProtoId<EntityCategoryPrototype> StatusEffectCategoryId = "StatusEffects";

    [Dependency] private IPrototypeManager _prototype = default!;

    public override CompletionResult? TryAutocomplete(ParserContext ctx, CommandArgument? arg)
    {
        var hint = ToolshedCommand.GetArgHint(arg, typeof(ProtoId<EntityPrototype>));
        var completionOptions = CompletionHelper.EntityPrototypes(ctx.GetWord(), StatusEffectCategoryId, _prototype);
        return CompletionResult.FromHintOptions(completionOptions, hint);
    }
}
```