### PR TITLE
Fix cross-compile CI for FreeBSD

### DIFF
--- a/.github/workflows/build-all-configurations.yml
+++ b/.github/workflows/build-all-configurations.yml
@@ -16,40 +16,9 @@ jobs:
   build:
     strategy:
       matrix:
-        include:
-          - runtime: win-x64
-            targetOS: Windows
-            allowFailure: false
-          - runtime: win-arm64
-            targetOS: Windows
-            allowFailure: false
-          - runtime: osx-x64
-            targetOS: MacOS
-            allowFailure: false
-          - runtime: osx-arm64
-            targetOS: MacOS
-            allowFailure: false
-          - runtime: linux-x64
-            targetOS: Linux
-            allowFailure: false
-          - runtime: linux-arm64
-            targetOS: Linux
-            allowFailure: false
-          - runtime: linux-musl-x64
-            targetOS: Linux
-            allowFailure: false
-          - runtime: linux-musl-arm64
-            targetOS: Linux
-            allowFailure: false
-          - runtime: freebsd-x64
-            targetOS: FreeBSD
-            allowFailure: true
-          - runtime: freebsd-arm64
-            targetOS: FreeBSD
-            allowFailure: true
+        targetOS: [Windows, Linux, MacOS]
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allowFailure }}
 
     steps:
       - uses: actions/checkout@v4.2.2
@@ -62,16 +31,32 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Install dependencies
-        run: dotnet restore --runtime ${{ matrix.runtime }} /p:TargetOS=${{ matrix.targetOS }}
-      - name: Build Debug Client
-        run: dotnet build Robust.Client/Robust.Client.csproj --no-restore --configuration Debug /p:WarningsAsErrors=nullable /p:TargetOS=${{ matrix.targetOS }} --runtime ${{ matrix.runtime }}
-      - name: Build Debug Server
-        run: dotnet build Robust.Server/Robust.Server.csproj --no-restore --configuration Debug /p:WarningsAsErrors=nullable /p:TargetOS=${{ matrix.targetOS }} --runtime ${{ matrix.runtime }}
-      - name: Build Tools Client
-        run: dotnet build Robust.Client/Robust.Client.csproj --no-restore --configuration Tools /p:WarningsAsErrors=nullable /p:TargetOS=${{ matrix.targetOS }} --runtime ${{ matrix.runtime }}
-      - name: Build Tools Server
-        run: dotnet build Robust.Server/Robust.Server.csproj --no-restore --configuration Tools /p:WarningsAsErrors=nullable /p:TargetOS=${{ matrix.targetOS }} --runtime ${{ matrix.runtime }}
-      - name: Build Release Client
-        run: dotnet build Robust.Client/Robust.Client.csproj --no-restore --configuration Release /p:WarningsAsErrors=nullable /p:TargetOS=${{ matrix.targetOS }} --runtime ${{ matrix.runtime }}
-      - name: Build Release Server
-        run: dotnet build Robust.Server/Robust.Server.csproj --no-restore --configuration Release /p:WarningsAsErrors=nullable /p:TargetOS=${{ matrix.targetOS }} --runtime ${{ matrix.runtime }}
+        run: dotnet restore
+      - name: Build Debug
+        run: dotnet build --no-restore --configuration Debug /p:WarningsAsErrors=nullable /p:TargetOS=${{ matrix.targetOS }}
+      - name: Build Tools
+        run: dotnet build --no-restore --configuration Tools /p:WarningsAsErrors=nullable /p:TargetOS=${{ matrix.targetOS }}
+      - name: Build Release
+        run: dotnet build --no-restore --configuration Release /p:WarningsAsErrors=nullable /p:TargetOS=${{ matrix.targetOS }}
+
+  cross-compile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse version
+        id: parse_version
+        shell: pwsh
+        run: |
+          $ver = [regex]::Match($env:GITHUB_REF, "refs/tags/v?(.+)").Groups[1].Value
+          echo ("::set-output name=version::{0}" -f $ver)
+
+      - uses: actions/checkout@v4.2.2
+        with:
+          submodules: true
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4.1.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Package client
+        run: Tools/package_client_build.py

--- a/.github/workflows/build-all-configurations.yml
+++ b/.github/workflows/build-all-configurations.yml
@@ -31,7 +31,7 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore /p:TargetOS=${{ matrix.targetOS }}
       - name: Build Debug
         run: dotnet build --no-restore --configuration Debug /p:WarningsAsErrors=nullable /p:TargetOS=${{ matrix.targetOS }}
       - name: Build Tools

--- a/.github/workflows/build-all-configurations.yml
+++ b/.github/workflows/build-all-configurations.yml
@@ -39,16 +39,22 @@ jobs:
       - name: Build Release
         run: dotnet build --no-restore --configuration Release /p:WarningsAsErrors=nullable /p:TargetOS=${{ matrix.targetOS }}
 
-  cross-compile:
+  publish-check:
+    name: Publish check (${{ matrix.rid }})
+    strategy:
+      fail-fast: false
+      matrix:
+        rid:
+          - win-x64
+          - win-arm64
+          - linux-x64
+          - linux-arm64
+          - osx-x64
+          - osx-arm64
+          - freebsd-x64
+          - freebsd-arm64
     runs-on: ubuntu-latest
     steps:
-      - name: Parse version
-        id: parse_version
-        shell: pwsh
-        run: |
-          $ver = [regex]::Match($env:GITHUB_REF, "refs/tags/v?(.+)").Groups[1].Value
-          echo ("::set-output name=version::{0}" -f $ver)
-
       - uses: actions/checkout@v4.2.2
         with:
           submodules: true
@@ -58,5 +64,23 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Package client
-        run: Tools/package_client_build.py
+      - name: Package client (${{ matrix.rid }})
+        shell: bash
+        run: |
+          set -o pipefail
+          mkdir -p ci-logs
+          Tools/package_client_build.py --platform ${{ matrix.rid }} 2>&1 | tee ci-logs/publish-${{ matrix.rid }}.log
+
+      - name: Clean generated package artifacts
+        if: always()
+        shell: bash
+        run: rm -rf bin release
+
+      - name: Upload publish log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-${{ matrix.rid }}-log
+          path: ci-logs/publish-${{ matrix.rid }}.log
+          retention-days: 7
+          if-no-files-found: warn

--- a/MSBuild/XamlIL.targets
+++ b/MSBuild/XamlIL.targets
@@ -15,10 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Robust.Client.NameGenerator\Robust.Client.NameGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Robust.Client.Injectors\Robust.Client.Injectors.csproj" ReferenceOutputAssembly="false">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Robust.Client.NameGenerator\Robust.Client.NameGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false">
+      <!-- Build-time tools run on the host, not the target runtime. This stops us trying to get runtime for FreeBSD which doesn't exist. -->
+      <GlobalPropertiesToRemove>RuntimeIdentifier;RestoreRuntimeIdentifier</GlobalPropertiesToRemove>
+    </ProjectReference>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Robust.Client.Injectors\Robust.Client.Injectors.csproj" ReferenceOutputAssembly="false" Condition="'$(RuntimeIdentifier)' == ''">
       <SetConfiguration Condition="'$(Configuration)' == 'DebugOpt'">Configuration=Debug</SetConfiguration>
       <SetConfiguration Condition="'$(Configuration)' == 'Tools'">Configuration=Release</SetConfiguration>
+      <GlobalPropertiesToRemove>RuntimeIdentifier;RestoreRuntimeIdentifier</GlobalPropertiesToRemove>
     </ProjectReference>
   </ItemGroup>
 
@@ -37,6 +41,16 @@
     Condition="'$(_RobustUseExternalMSBuild)' != 'true' And $(DesignTimeBuild) != true"
     TaskName="CompileRobustXamlTask"
     AssemblyFile="$(CompileRobustXamlTaskAssemblyFile)"/>
+  <Target
+    Name="BuildRobustClientInjectorsForRuntimeBuild"
+    Condition="'$(RuntimeIdentifier)' != '' And '$(_RobustForceInternalMSBuild)' != 'true'"
+    BeforeTargets="CompileRobustXaml">
+    <PropertyGroup>
+      <DOTNET_HOST_PATH Condition="'$(DOTNET_HOST_PATH)' == ''">dotnet</DOTNET_HOST_PATH>
+    </PropertyGroup>
+    <Exec
+      Command="&quot;$(DOTNET_HOST_PATH)&quot; build /nologo &quot;$(MSBuildThisFileDirectory)\..\Robust.Client.Injectors\Robust.Client.Injectors.csproj&quot; /p:Configuration=$(RobustInjectorsConfiguration) /p:TargetFramework=net10.0 /p:RuntimeIdentifier= /p:RestoreRuntimeIdentifier= /p:UseAppHost=false" />
+  </Target>
   <Target
     Name="CompileRobustXaml"
     Condition="Exists('@(IntermediateAssembly)')"


### PR DESCRIPTION
This reverts commit 3149158dde678cf7b0d255c605d22976a2e2fccc (#6848), then runs the actual build part of publish_client_builds.py.

FreeBSD was never intended to be a direct build target. Instead, it was supposed to be cross-compiled and shipped as a portable assembly so that signed engine builds would be available via the official launcher.

**This build will still fail, but it won't fail for the wrong reasons.**