### PR TITLE
 Make ComponentTreeEntry faster

### DIFF
--- a/Robust.Shared/Physics/ComponentTreeEntry.cs
+++ b/Robust.Shared/Physics/ComponentTreeEntry.cs
@@ -25,6 +25,16 @@ public readonly struct ComponentTreeEntry<T> : IEquatable<ComponentTreeEntry<T>>
         return Uid.Equals(other.Uid);
     }
 
+    public override bool Equals(object? obj)
+    {
+        return obj is ComponentTreeEntry<T> other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return Uid.GetHashCode();
+    }
+
     public readonly void Deconstruct(out T component, out TransformComponent xform)
     {
         component = Component;


### PR DESCRIPTION
It didnt implement GetHashCode and one of the most expensive operations was the hashset lookup

I estimate its like ~30% faster or something by roughly comparing the usages of QueryAabb in an overlay before and after, though there may be some noise
Before:
<img width="636" height="162" alt="image" src="https://github.com/user-attachments/assets/c3f59c05-4155-4c24-aaa2-78a12733c731" />

After:
<img width="894" height="209" alt="image" src="https://github.com/user-attachments/assets/c03a64d4-2832-4546-90e8-72d757d2c3be" />
