### PR TITLE
Fix Text Outline

### DIFF
--- a/Robust.Client/Graphics/FontManager.cs
+++ b/Robust.Client/Graphics/FontManager.cs
@@ -115,7 +115,7 @@ namespace Robust.Client.Graphics
             var descent = -ftFace.Size.Metrics.Descender.ToInt32();
             var lineHeight = ftFace.Size.Metrics.Height.ToInt32();
 
-            var data = new ScaledFontData(ascent, descent, ascent + descent, lineHeight);
+            var data = new ScaledFontData(ascent, descent, ascent + descent, lineHeight, _library);
 
 
             return data;
@@ -163,8 +163,9 @@ namespace Robust.Client.Graphics
             face.LoadGlyph(glyph, LoadFlags.Default, LoadTarget.Normal);
 
             using var sourceGlyph = face.Glyph.GetGlyph();
-            using var stroker = new Stroker(_library);
+            var stroker = scaled.Stroker;
             stroker.Set(radius, StrokerLineCap.Round, StrokerLineJoin.Round, Fixed16Dot16.FromInt32(0));
+            stroker.Rewind();
             using var strokedGlyph = sourceGlyph.StrokeBorder(stroker, false, true);
             strokedGlyph.ToBitmap(RenderMode.Normal, new FTVector26Dot6(0, 0), true);
 
@@ -332,6 +333,8 @@ namespace Robust.Client.Graphics
                     {
                         ownedTexture.Dispose();
                     }
+
+                    scaleData.Value.Stroker.Dispose();
                 }
                 _scaledData.Clear();
             }
@@ -437,17 +440,19 @@ namespace Robust.Client.Graphics
 
         private sealed class ScaledFontData
         {
-            public ScaledFontData(int ascent, int descent, int height, int lineHeight)
+            public ScaledFontData(int ascent, int descent, int height, int lineHeight, Library library)
             {
                 Ascent = ascent;
                 Descent = descent;
                 Height = height;
                 LineHeight = lineHeight;
+                Stroker = new Stroker(library);
             }
 
             public readonly List<OwnedTexture> AtlasTextures = new();
             public readonly Dictionary<uint, GlyphInfo> GlyphInfos = new();
             public readonly Dictionary<(uint Glyph, int Radius), OutlinedGlyphInfo> OutlinedGlyphInfos = new();
+            public readonly Stroker Stroker;
             public readonly int Ascent;
             public readonly int Descent;
             public readonly int Height;

--- a/Robust.Client/UserInterface/Controls/Label.cs
+++ b/Robust.Client/UserInterface/Controls/Label.cs
@@ -220,6 +220,7 @@ namespace Robust.Client.UserInterface.Controls
             var newlines = 0;
             var font = ActualFont;
             var actualFontColor = ActualFontColor;
+            var actualFontOutline = ActualFontOutline;
 
             Vector2 CalcBaseline()
             {
@@ -255,7 +256,7 @@ namespace Robust.Client.UserInterface.Controls
                     baseLine = CalcBaseline();
                 }
 
-                var advance = font.DrawChar(handle, rune, baseLine, UIScale, actualFontColor, outline: ActualFontOutline);
+                var advance = font.DrawChar(handle, rune, baseLine, UIScale, actualFontColor, outline: actualFontOutline);
                 baseLine += new Vector2(advance, 0);
             }
         }


### PR DESCRIPTION
Attempt to optimize the changes in #6832

1. `Stroker` is now reused for each `ScaledFontData`
2. `ActualFontOutline` is now calculated once per `Draw` (oops)