### PR TITLE
Do not serialize components pending removal

### DIFF
--- a/Robust.Shared.IntegrationTests/EntitySerialization/PendingComponentRemovalSerializationTest.cs
+++ b/Robust.Shared.IntegrationTests/EntitySerialization/PendingComponentRemovalSerializationTest.cs
@@ -1,127 +1,49 @@
 using NUnit.Framework;
 using Robust.Shared.EntitySerialization.Systems;
 using Robust.Shared.GameObjects;
-using Robust.Shared.IoC;
 using Robust.Shared.Map;
-using Robust.Shared.Reflection;
-using Robust.Shared.Serialization.Markdown.Mapping;
-using Robust.Shared.Serialization.Markdown.Sequence;
-using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Utility;
 
 namespace Robust.UnitTesting.Shared.EntitySerialization;
 
 [TestFixture]
-internal sealed partial class PendingComponentRemovalSerializationTest : RobustIntegrationTest
+internal sealed class PendingComponentRemovalSerializationTest : RobustIntegrationTest
 {
-    private const string InputComponentName = "PendingRemovalInput";
-    private const string ActiveComponentName = "PendingRemovalActive";
-    private const string PrototypeId = "PendingRemovalSerializationPrototype";
-    private const string TestPrototype = $"""
-        - type: entity
-          id: {PrototypeId}
-          components:
-          - type: {InputComponentName}
-        """;
-
     [Test]
-    public async Task PendingComponentAfterPausedMapLoadIsNotSerialized()
+    public async Task PendingComponentIsNotSerialized()
     {
-        var options = new ServerIntegrationOptions
-        {
-            Pool = false,
-            ExtraPrototypes = TestPrototype,
-        };
-        options.BeforeRegisterComponents += () =>
-        {
-            var factory = IoCManager.Resolve<IComponentFactory>();
-            factory.RegisterClass<PendingRemovalInputComponent>();
-            factory.RegisterClass<PendingRemovalActiveComponent>();
-        };
-        options.BeforeStart += () =>
-        {
-            var systemManager = IoCManager.Resolve<IEntitySystemManager>();
-            systemManager.LoadExtraSystemType<PendingRemovalSerializationSystem>();
-        };
-
-        var server = StartServer(options);
+        var server = StartServer();
         await server.WaitIdleAsync();
 
-        var mapSystem = server.System<SharedMapSystem>();
+        var entMan = server.EntMan;
         var loader = server.System<MapLoaderSystem>();
-        var testSystem = server.System<PendingRemovalSerializationSystem>();
-        var source = string.Empty;
+        var mapSystem = server.System<SharedMapSystem>();
+        var path = new ResPath($"{nameof(PendingComponentIsNotSerialized)}.yml");
+        MapId mapId = default;
 
-        await server.WaitAssertion(() =>
+        await server.WaitPost(() =>
         {
-            var map = mapSystem.CreateMap(out var mapId, runMapInit: false);
-            var uid = server.EntMan.SpawnEntity(PrototypeId, new MapCoordinates(0, 0, mapId));
+            mapSystem.CreateMap(out mapId);
+            var uid = entMan.SpawnEntity(null, new MapCoordinates(0, 0, mapId));
+            var component = entMan.AddComponent<PendingRemovalTestComponent>(uid);
 
-            // Pre-map-init entities are paused, so the active component is absent from the original save.
-            Assert.That(server.EntMan.GetComponent<MetaDataComponent>(uid).EntityPaused, Is.True);
-            Assert.That(server.EntMan.HasComponent<PendingRemovalActiveComponent>(uid), Is.False);
-
-            using var writer = new StringWriter();
-            Assert.That(loader.TrySaveMap(map, writer), Is.True);
-            source = writer.ToString();
-
-            server.EntMan.DeleteEntity(map);
+            // Deferred removals are processed at the end of the tick. Saving before then used to serialize the
+            // component even though it had already been queued for removal.
+            entMan.RemoveComponentDeferred(uid, component);
+            Assert.That(entMan.Count<PendingRemovalTestComponent>(), Is.EqualTo(1));
+            Assert.That(loader.TrySaveMap(mapId, path), Is.True);
         });
 
-        MappingDataNode serialized = default!;
-        await server.WaitAssertion(() =>
-        {
-            using var reader = new StringReader(source);
-            Assert.That(loader.TryLoadMap(reader, nameof(PendingComponentAfterPausedMapLoadIsNotSerialized),
-                out var loadedMap, out _), Is.True);
+        // Let the deferred removal finish, then remove the original map before loading the saved one.
+        await server.WaitRunTicks(1);
+        Assert.That(entMan.Count<PendingRemovalTestComponent>(), Is.EqualTo(0));
+        await server.WaitPost(() => mapSystem.DeleteMap(mapId));
 
-            // Loading starts the entity before restoring its paused state. This temporarily adds the active component,
-            // then EntityPausedEvent queues it for deferred removal.
-            Assert.That(testSystem.ActiveComponentsAdded, Is.EqualTo(1));
-            Assert.That(testSystem.ActiveComponentsQueuedForRemoval, Is.EqualTo(1));
-
-            (serialized, _) = loader.SerializeEntitiesRecursive([loadedMap!.Value.Owner]);
-        });
-
-        Assert.That(HasSerializedComponent(serialized, ActiveComponentName), Is.False);
+        // If the pending component was serialized, loading the map will add it back.
+        await server.WaitPost(() => Assert.That(loader.TryLoadMap(path, out _, out _), Is.True));
+        Assert.That(entMan.Count<PendingRemovalTestComponent>(), Is.EqualTo(0));
     }
-
-    private static bool HasSerializedComponent(MappingDataNode serialized, string componentName)
-    {
-        return serialized.Get<SequenceDataNode>("entities")
-            .Cast<MappingDataNode>()
-            .SelectMany(group => group.Get<SequenceDataNode>("entities").Cast<MappingDataNode>())
-            .Any(entity => entity.TryGet<SequenceDataNode>("components", out var components)
-                && components.Cast<MappingDataNode>()
-                    .Any(component => component.Get<ValueDataNode>("type").Value == componentName));
-    }
-
-    [Reflect(false)]
-    private sealed partial class PendingRemovalSerializationSystem : EntitySystem
-    {
-        public int ActiveComponentsAdded { get; private set; }
-        public int ActiveComponentsQueuedForRemoval { get; private set; }
-
-        [SubscribeLocalEvent]
-        private void OnStartup(Entity<PendingRemovalInputComponent> entity, ref ComponentStartup args)
-        {
-            if (Paused(entity))
-                return;
-
-            EnsureComp<PendingRemovalActiveComponent>(entity);
-            ActiveComponentsAdded++;
-        }
-
-        [SubscribeLocalEvent]
-        private void OnPaused(Entity<PendingRemovalActiveComponent> entity, ref EntityPausedEvent args)
-        {
-            RemCompDeferred<PendingRemovalActiveComponent>(entity);
-            ActiveComponentsQueuedForRemoval++;
-        }
-    }
-
-    [ComponentProtoName(InputComponentName)]
-    private sealed partial class PendingRemovalInputComponent : Component;
-
-    [ComponentProtoName(ActiveComponentName)]
-    private sealed partial class PendingRemovalActiveComponent : Component;
 }
+
+[RegisterComponent]
+internal sealed partial class PendingRemovalTestComponent : Component;

--- a/Robust.Shared.IntegrationTests/EntitySerialization/PendingComponentRemovalSerializationTest.cs
+++ b/Robust.Shared.IntegrationTests/EntitySerialization/PendingComponentRemovalSerializationTest.cs
@@ -1,0 +1,127 @@
+using NUnit.Framework;
+using Robust.Shared.EntitySerialization.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Reflection;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Value;
+
+namespace Robust.UnitTesting.Shared.EntitySerialization;
+
+[TestFixture]
+internal sealed partial class PendingComponentRemovalSerializationTest : RobustIntegrationTest
+{
+    private const string InputComponentName = "PendingRemovalInput";
+    private const string ActiveComponentName = "PendingRemovalActive";
+    private const string PrototypeId = "PendingRemovalSerializationPrototype";
+    private const string TestPrototype = $"""
+        - type: entity
+          id: {PrototypeId}
+          components:
+          - type: {InputComponentName}
+        """;
+
+    [Test]
+    public async Task PendingComponentAfterPausedMapLoadIsNotSerialized()
+    {
+        var options = new ServerIntegrationOptions
+        {
+            Pool = false,
+            ExtraPrototypes = TestPrototype,
+        };
+        options.BeforeRegisterComponents += () =>
+        {
+            var factory = IoCManager.Resolve<IComponentFactory>();
+            factory.RegisterClass<PendingRemovalInputComponent>();
+            factory.RegisterClass<PendingRemovalActiveComponent>();
+        };
+        options.BeforeStart += () =>
+        {
+            var systemManager = IoCManager.Resolve<IEntitySystemManager>();
+            systemManager.LoadExtraSystemType<PendingRemovalSerializationSystem>();
+        };
+
+        var server = StartServer(options);
+        await server.WaitIdleAsync();
+
+        var mapSystem = server.System<SharedMapSystem>();
+        var loader = server.System<MapLoaderSystem>();
+        var testSystem = server.System<PendingRemovalSerializationSystem>();
+        var source = string.Empty;
+
+        await server.WaitAssertion(() =>
+        {
+            var map = mapSystem.CreateMap(out var mapId, runMapInit: false);
+            var uid = server.EntMan.SpawnEntity(PrototypeId, new MapCoordinates(0, 0, mapId));
+
+            // Pre-map-init entities are paused, so the active component is absent from the original save.
+            Assert.That(server.EntMan.GetComponent<MetaDataComponent>(uid).EntityPaused, Is.True);
+            Assert.That(server.EntMan.HasComponent<PendingRemovalActiveComponent>(uid), Is.False);
+
+            using var writer = new StringWriter();
+            Assert.That(loader.TrySaveMap(map, writer), Is.True);
+            source = writer.ToString();
+
+            server.EntMan.DeleteEntity(map);
+        });
+
+        MappingDataNode serialized = default!;
+        await server.WaitAssertion(() =>
+        {
+            using var reader = new StringReader(source);
+            Assert.That(loader.TryLoadMap(reader, nameof(PendingComponentAfterPausedMapLoadIsNotSerialized),
+                out var loadedMap, out _), Is.True);
+
+            // Loading starts the entity before restoring its paused state. This temporarily adds the active component,
+            // then EntityPausedEvent queues it for deferred removal.
+            Assert.That(testSystem.ActiveComponentsAdded, Is.EqualTo(1));
+            Assert.That(testSystem.ActiveComponentsQueuedForRemoval, Is.EqualTo(1));
+
+            (serialized, _) = loader.SerializeEntitiesRecursive([loadedMap!.Value.Owner]);
+        });
+
+        Assert.That(HasSerializedComponent(serialized, ActiveComponentName), Is.False);
+    }
+
+    private static bool HasSerializedComponent(MappingDataNode serialized, string componentName)
+    {
+        return serialized.Get<SequenceDataNode>("entities")
+            .Cast<MappingDataNode>()
+            .SelectMany(group => group.Get<SequenceDataNode>("entities").Cast<MappingDataNode>())
+            .Any(entity => entity.TryGet<SequenceDataNode>("components", out var components)
+                && components.Cast<MappingDataNode>()
+                    .Any(component => component.Get<ValueDataNode>("type").Value == componentName));
+    }
+
+    [Reflect(false)]
+    private sealed partial class PendingRemovalSerializationSystem : EntitySystem
+    {
+        public int ActiveComponentsAdded { get; private set; }
+        public int ActiveComponentsQueuedForRemoval { get; private set; }
+
+        [SubscribeLocalEvent]
+        private void OnStartup(Entity<PendingRemovalInputComponent> entity, ref ComponentStartup args)
+        {
+            if (Paused(entity))
+                return;
+
+            EnsureComp<PendingRemovalActiveComponent>(entity);
+            ActiveComponentsAdded++;
+        }
+
+        [SubscribeLocalEvent]
+        private void OnPaused(Entity<PendingRemovalActiveComponent> entity, ref EntityPausedEvent args)
+        {
+            RemCompDeferred<PendingRemovalActiveComponent>(entity);
+            ActiveComponentsQueuedForRemoval++;
+        }
+    }
+
+    [ComponentProtoName(InputComponentName)]
+    private sealed partial class PendingRemovalInputComponent : Component;
+
+    [ComponentProtoName(ActiveComponentName)]
+    private sealed partial class PendingRemovalActiveComponent : Component;
+}

--- a/Robust.Shared/EntitySerialization/EntitySerializer.cs
+++ b/Robust.Shared/EntitySerialization/EntitySerializer.cs
@@ -581,7 +581,8 @@ public sealed partial class EntitySerializer : ISerializationContext,
         {
             // try comp instead of has-comp as it checks whether the component is supposed to have been
             // deleted.
-            if (EntMan.TryGetComponent(uid, comp.Component.GetType(), out _))
+            if (EntMan.TryGetComponent(uid, comp.Component.GetType(), out var component)
+                && !EntMan.IsComponentPendingRemoval(component))
                 continue;
 
             missingComponents ??= new();
@@ -629,6 +630,9 @@ public sealed partial class EntitySerializer : ISerializationContext,
     {
         foreach (var component in EntMan.GetComponentsInternal(uid))
         {
+            if (EntMan.IsComponentPendingRemoval(component))
+                continue;
+
             var compType = component.GetType();
 
             var reg = _factory.GetRegistration(compType);

--- a/Robust.Shared/GameObjects/EntityManager.Components.cs
+++ b/Robust.Shared/GameObjects/EntityManager.Components.cs
@@ -518,6 +518,14 @@ namespace Robust.Shared.GameObjects
             RemoveComponentDeferred(component, owner, false);
         }
 
+        /// <summary>
+        /// Returns whether a component is being removed or is queued for deferred removal.
+        /// </summary>
+        internal bool IsComponentPendingRemoval(IComponent component)
+        {
+            return component.LifeStage >= ComponentLifeStage.Stopping || _deleteSet.Contains(component);
+        }
+
         private static IEnumerable<IComponent> InSafeOrder(IEnumerable<IComponent> comps, bool forCreation = false)
         {
             static int Sequence(IComponent x)


### PR DESCRIPTION
Prevents components queued for deferred removal from being serialized before the end of the tick.

This fixes the SaveLoadSave failure exposed by space-wizards/space-station-14#44831 and replaces the content-side workaround attempted in space-wizards/space-station-14#44836.

Resolves #6890.