### PR TITLE
Skip matrix transforms for simple matrix models

### DIFF
--- a/Robust.Benchmarks/Graphics/ModelTransformBenchmark.cs
+++ b/Robust.Benchmarks/Graphics/ModelTransformBenchmark.cs
@@ -1,0 +1,78 @@
+using System.Numerics;
+using BenchmarkDotNet.Attributes;
+
+namespace Robust.Benchmarks.Graphics;
+
+[MemoryDiagnoser]
+public class ModelTransformBenchmark
+{
+    private readonly Vector2 _bottomLeft = new(-64f, -32f);
+    private readonly Vector2 _bottomRight = new(64f, -32f);
+    private readonly Vector2 _topRight = new(64f, 32f);
+    private Matrix3x2 _currentModel;
+    private Vector2 _currentModelTranslation;
+    private bool _currentModelIsTranslation;
+    private Matrix3x2 _translationModel;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _translationModel = Matrix3x2.CreateTranslation(420f, 69f);
+        SetModelTransform(_translationModel);
+    }
+
+    [Benchmark]
+    public Vector2 CacheAndTranslate()
+    {
+        SetModelTransform(_translationModel);
+        return TransformWithCachedPath();
+    }
+
+    [Benchmark]
+    public Vector2 Translate()
+    {
+        var translation = new Vector2(_translationModel.M31, _translationModel.M32);
+        var bottomLeft = _bottomLeft + translation;
+        var bottomRight = _bottomRight + translation;
+        var topRight = _topRight + translation;
+        return topRight + bottomLeft - bottomRight;
+    }
+
+    [Benchmark(Baseline = true)]
+    public Vector2 AlwaysTransform()
+    {
+        var bottomLeft = Vector2.Transform(_bottomLeft, _translationModel);
+        var bottomRight = Vector2.Transform(_bottomRight, _translationModel);
+        var topRight = Vector2.Transform(_topRight, _translationModel);
+        return topRight + bottomLeft - bottomRight;
+    }
+
+    private void SetModelTransform(in Matrix3x2 matrix)
+    {
+        _currentModel = matrix;
+        _currentModelTranslation = new Vector2(matrix.M31, matrix.M32);
+        _currentModelIsTranslation = matrix.M11 == 1f && matrix.M12 == 0f &&
+                                     matrix.M21 == 0f && matrix.M22 == 1f;
+    }
+
+    private Vector2 TransformWithCachedPath()
+    {
+        Vector2 bottomLeft;
+        Vector2 bottomRight;
+        Vector2 topRight;
+        if (_currentModelIsTranslation)
+        {
+            bottomLeft = _bottomLeft + _currentModelTranslation;
+            bottomRight = _bottomRight + _currentModelTranslation;
+            topRight = _topRight + _currentModelTranslation;
+        }
+        else
+        {
+            bottomLeft = Vector2.Transform(_bottomLeft, _currentModel);
+            bottomRight = Vector2.Transform(_bottomRight, _currentModel);
+            topRight = Vector2.Transform(_topRight, _currentModel);
+        }
+
+        return topRight + bottomLeft - bottomRight;
+    }
+}

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -61,6 +61,15 @@ namespace Robust.Client.Graphics.Clyde
         // Some is applied while the batch is being created (e.g. simple texture draw calls).
         // For DrawPrimitives OTOH the model matrix is passed along with the render command so is applied in the shader.
         private Matrix3x2 _currentMatrixModel = Matrix3x2.Identity;
+        private Vector2 _currentMatrixModelTranslation;
+        private ModelTransformType _currentMatrixModelTransformType = ModelTransformType.Identity;
+
+        private enum ModelTransformType : byte
+        {
+            Identity,
+            Translation,
+            General,
+        }
 
         // Buffers and data for the batching system. Written into during (queue) and processed during (submit).
         private readonly Vertex2D[] BatchVertexData = new Vertex2D[MaxBatchQuads * 4];
@@ -365,7 +374,7 @@ namespace Robust.Client.Graphics.Clyde
             FlushBatchQueue();
 
             // Reset renderer state.
-            _currentMatrixModel = Matrix3x2.Identity;
+            DrawSetModelTransform(Matrix3x2.Identity);
             _queuedShaderInstance = _defaultShader;
             SetScissorFull(null);
         }
@@ -575,6 +584,13 @@ namespace Robust.Client.Graphics.Clyde
         private void DrawSetModelTransform(in Matrix3x2 matrix)
         {
             _currentMatrixModel = matrix;
+            _currentMatrixModelTranslation = new Vector2(matrix.M31, matrix.M32);
+            _currentMatrixModelTransformType = matrix.M11 == 1f && matrix.M12 == 0f &&
+                                               matrix.M21 == 0f && matrix.M22 == 1f
+                ? _currentMatrixModelTranslation == Vector2.Zero
+                    ? ModelTransformType.Identity
+                    : ModelTransformType.Translation
+                : ModelTransformType.General;
         }
 
         private Matrix3x2 DrawGetModelTransform()
@@ -611,11 +627,21 @@ namespace Robust.Client.Graphics.Clyde
             EnsureBatchSpaceAvailable(4, GetQuadBatchIndexCount());
             EnsureBatchState(texture, true, GetQuadBatchPrimitiveType(), _queuedShader);
 
-            // TODO RENDERING
-            // It's probably better to do this on the GPU.
-            bl = Vector2.Transform(bl, _currentMatrixModel);
-            br = Vector2.Transform(br, _currentMatrixModel);
-            tr = Vector2.Transform(tr, _currentMatrixModel);
+            if (_currentMatrixModelTransformType == ModelTransformType.Translation)
+            {
+                bl += _currentMatrixModelTranslation;
+                br += _currentMatrixModelTranslation;
+                tr += _currentMatrixModelTranslation;
+            }
+            else if (_currentMatrixModelTransformType == ModelTransformType.General)
+            {
+                // TODO RENDERING
+                // It's probably better to do this on the GPU.
+                bl = Vector2.Transform(bl, _currentMatrixModel);
+                br = Vector2.Transform(br, _currentMatrixModel);
+                tr = Vector2.Transform(tr, _currentMatrixModel);
+            }
+
             tl = tr + bl - br;
 
             // TODO: split batch if necessary.
@@ -661,6 +687,9 @@ namespace Robust.Client.Graphics.Clyde
             var primitiveType = GetQuadBatchPrimitiveType();
             var indexCount = GetQuadBatchIndexCount();
             var rectIndex = 0;
+            var modelMatrix = _currentMatrixModel;
+            var modelTransformType = _currentMatrixModelTransformType;
+            var modelTranslation = _currentMatrixModelTranslation;
 
             while (rectIndex < rects.Length)
             {
@@ -692,14 +721,45 @@ namespace Robust.Client.Graphics.Clyde
                     if (applyModulation)
                         color *= modulate;
 
-                    // Can probably SIMD this more somehow but future concern.
                     var quad = rect.Quad;
-                    var transform = quad.Transform * _currentMatrixModel;
+                    var box = quad.Box;
+                    Vector2 bl;
+                    Vector2 br;
+                    Vector2 tl;
+                    Vector2 tr;
+                    if (modelTransformType != ModelTransformType.General && quad.Rotation == Angle.Zero)
+                    {
+                        bl = box.BottomLeft;
+                        br = box.BottomRight;
+                        tl = box.TopLeft;
+                        tr = box.TopRight;
 
-                    var bl = Vector2.Transform(quad.Box.BottomLeft, transform);
-                    var br = Vector2.Transform(quad.Box.BottomRight, transform);
-                    var tr = Vector2.Transform(quad.Box.TopRight, transform);
-                    var tl = tr + bl - br;
+                        if (modelTransformType == ModelTransformType.Translation)
+                        {
+                            bl += modelTranslation;
+                            br += modelTranslation;
+                            tl += modelTranslation;
+                            tr += modelTranslation;
+                        }
+                    }
+                    else
+                    {
+                        var transform = quad.Transform;
+                        if (modelTransformType == ModelTransformType.Translation)
+                        {
+                            transform.M31 += modelTranslation.X;
+                            transform.M32 += modelTranslation.Y;
+                        }
+                        else if (modelTransformType == ModelTransformType.General)
+                        {
+                            transform *= modelMatrix;
+                        }
+
+                        bl = Vector2.Transform(box.BottomLeft, transform);
+                        br = Vector2.Transform(box.BottomRight, transform);
+                        tr = Vector2.Transform(box.TopRight, transform);
+                        tl = tr + bl - br;
+                    }
 
                     var vIdx = BatchVertexIndex;
                     BatchVertexData[vIdx + 0] = new Vertex2D(bl, texCoords.BottomLeft, Vector2.Zero, color);
@@ -745,6 +805,9 @@ namespace Robust.Client.Graphics.Clyde
             var primitiveType = GetQuadBatchPrimitiveType();
             var indexCount = GetQuadBatchIndexCount();
             var rectIndex = 0;
+            var modelMatrix = _currentMatrixModel;
+            var modelTransformType = _currentMatrixModelTransformType;
+            var modelTranslation = _currentMatrixModelTranslation;
 
             while (rectIndex < rects.Length)
             {
@@ -778,10 +841,31 @@ namespace Robust.Client.Graphics.Clyde
 
                     var box = rect.Rect;
 
-                    var bl = Vector2.Transform(box.BottomLeft, _currentMatrixModel);
-                    var br = Vector2.Transform(box.BottomRight, _currentMatrixModel);
-                    var tr = Vector2.Transform(box.TopRight, _currentMatrixModel);
-                    var tl = tr + bl - br;
+                    Vector2 bl;
+                    Vector2 br;
+                    Vector2 tl;
+                    Vector2 tr;
+                    if (modelTransformType == ModelTransformType.Translation)
+                    {
+                        bl = box.BottomLeft + modelTranslation;
+                        br = box.BottomRight + modelTranslation;
+                        tl = box.TopLeft + modelTranslation;
+                        tr = box.TopRight + modelTranslation;
+                    }
+                    else if (modelTransformType == ModelTransformType.General)
+                    {
+                        bl = Vector2.Transform(box.BottomLeft, modelMatrix);
+                        br = Vector2.Transform(box.BottomRight, modelMatrix);
+                        tr = Vector2.Transform(box.TopRight, modelMatrix);
+                        tl = tr + bl - br;
+                    }
+                    else
+                    {
+                        bl = box.BottomLeft;
+                        br = box.BottomRight;
+                        tl = box.TopLeft;
+                        tr = box.TopRight;
+                    }
 
                     var vIdx = BatchVertexIndex;
                     BatchVertexData[vIdx + 0] = new Vertex2D(bl, texCoords.BottomLeft, Vector2.Zero, color);
@@ -893,8 +977,16 @@ namespace Robust.Client.Graphics.Clyde
             EnsureBatchSpaceAvailable(2, 0);
             EnsureBatchState(_stockTextureWhite.TextureId, false, BatchPrimitiveType.LineList, _queuedShader);
 
-            a = Vector2.Transform(a, _currentMatrixModel);
-            b = Vector2.Transform(b, _currentMatrixModel);
+            if (_currentMatrixModelTransformType == ModelTransformType.Translation)
+            {
+                a += _currentMatrixModelTranslation;
+                b += _currentMatrixModelTranslation;
+            }
+            else if (_currentMatrixModelTransformType == ModelTransformType.General)
+            {
+                a = Vector2.Transform(a, _currentMatrixModel);
+                b = Vector2.Transform(b, _currentMatrixModel);
+            }
 
             // TODO: split batch if necessary.
             var vIdx = BatchVertexIndex;
@@ -1116,7 +1208,7 @@ namespace Robust.Client.Graphics.Clyde
             _queuedRenderCommands.Clear();
             _currentViewport = null;
             _lightingReady = false;
-            _currentMatrixModel = Matrix3x2.Identity;
+            DrawSetModelTransform(Matrix3x2.Identity);
             SetScissorFull(null);
             BindRenderTargetFull(_mainWindow!.RenderTarget);
             _batchMetaData = null;


### PR DESCRIPTION
Matrix transforms are expensive. Skips them in cases such as:
- 99.999999% of UI rendering
- Most overlay draw calls

Caching is more expensive where the cache is invalid, but is faster where it's valid.

```
| Method            | Mean      | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------ |----------:|----------:|----------:|------:|--------:|----------:|------------:|
| CacheAndTranslate | 1.8892 ns | 3.6130 ns | 0.1980 ns |  1.60 |    0.20 |         - |          NA |
| Translate         | 0.4342 ns | 1.9395 ns | 0.1063 ns |  0.37 |    0.08 |         - |          NA |
| AlwaysTransform   | 1.1902 ns | 2.1147 ns | 0.1159 ns |  1.01 |    0.12 |         - |          NA |
```

I THINK it gets me a couple more frames ingame but honestly the FPS is so noisy it's hard to tell and I don't expect it to be a major benefit.