### PR TITLE
Cache texture UVs

### DIFF
--- a/Robust.Benchmarks/Graphics/AtlasTextureUvBenchmark.cs
+++ b/Robust.Benchmarks/Graphics/AtlasTextureUvBenchmark.cs
@@ -1,0 +1,94 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using Robust.Client.Graphics;
+using Robust.Shared.Graphics;
+using Robust.Shared.Maths;
+using ClydeRenderer = Robust.Client.Graphics.Clyde.Clyde;
+
+namespace Robust.Benchmarks.Graphics;
+
+[MemoryDiagnoser]
+public class AtlasTextureUvBenchmark
+{
+    private AtlasTexture _atlas = default!;
+    private Texture _texture = default!;
+    private UIBox2? _subRegion;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var sourceTexture = new ClydeRenderer.ClydeTexture((ClydeHandle) 42, (256, 256), false, null!);
+        GC.SuppressFinalize(sourceTexture);
+        _atlas = new AtlasTexture(sourceTexture, UIBox2.FromDimensions(48, 80, 16, 16));
+        _texture = _atlas;
+        _subRegion = null;
+    }
+
+    [Benchmark(Baseline = true)]
+    public DrawCall LegacyAtlasPath()
+    {
+        var sourceTexture = ExtractTexture(_texture, in _subRegion, out var region);
+        return new DrawCall((long) sourceTexture.TextureId, CalculateUvs(sourceTexture, region));
+    }
+
+    [Benchmark]
+    public DrawCall TextureCallerToAtlasOverload()
+    {
+        return DrawCached(_texture, in _subRegion);
+    }
+
+    [Benchmark]
+    public DrawCall StaticallyTypedAtlasCaller()
+    {
+        return DrawCached(_atlas);
+    }
+
+    private static DrawCall DrawCached(Texture texture, in UIBox2? subRegion)
+    {
+        if (subRegion == null && texture is AtlasTexture atlas)
+            return DrawCached(atlas);
+
+        var fallbackTexture = ExtractTexture(texture, in subRegion, out var region);
+        return new DrawCall((long) fallbackTexture.TextureId, CalculateUvs(fallbackTexture, region));
+    }
+
+    private static DrawCall DrawCached(AtlasTexture texture)
+    {
+        return new DrawCall((long) texture.ClydeTexture.TextureId, texture.NormalizedSubRegion);
+    }
+
+    private static ClydeRenderer.ClydeTexture ExtractTexture(Texture texture, in UIBox2? subRegion, out UIBox2 region)
+    {
+        if (texture is AtlasTexture atlas)
+        {
+            texture = atlas.SourceTexture;
+            if (subRegion.HasValue)
+            {
+                var offset = atlas.SubRegion.TopLeft;
+                region = new UIBox2(subRegion.Value.TopLeft + offset, subRegion.Value.BottomRight + offset);
+            }
+            else
+            {
+                region = atlas.SubRegion;
+            }
+        }
+        else
+        {
+            region = subRegion ?? new UIBox2(0, 0, texture.Width, texture.Height);
+        }
+
+        return (ClydeRenderer.ClydeTexture) texture;
+    }
+
+    private static Box2 CalculateUvs(Texture texture, UIBox2 region)
+    {
+        var (width, height) = texture.Size;
+        return new Box2(
+            region.Left / width,
+            (height - region.Bottom) / height,
+            region.Right / width,
+            (height - region.Top) / height);
+    }
+
+    public readonly record struct DrawCall(long TextureId, Box2 TexCoords);
+}

--- a/Robust.Benchmarks/Graphics/AtlasTextureUvBenchmark.cs
+++ b/Robust.Benchmarks/Graphics/AtlasTextureUvBenchmark.cs
@@ -54,7 +54,7 @@ public class AtlasTextureUvBenchmark
 
     private static DrawCall DrawCached(AtlasTexture texture)
     {
-        return new DrawCall((long) texture.ClydeTexture.TextureId, texture.NormalizedSubRegion);
+        return new DrawCall((long) texture.ClydeTexture!.TextureId, texture.NormalizedSubRegion);
     }
 
     private static ClydeRenderer.ClydeTexture ExtractTexture(Texture texture, in UIBox2? subRegion, out UIBox2 region)

--- a/Robust.Benchmarks/Robust.Benchmarks.csproj
+++ b/Robust.Benchmarks/Robust.Benchmarks.csproj
@@ -9,6 +9,7 @@
       <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Robust.Client\Robust.Client.csproj" />
     <ProjectReference Include="..\Robust.Server.Testing\Robust.Server.Testing.csproj" />
     <ProjectReference Include="..\Robust.Server\Robust.Server.csproj" />
     <ProjectReference Include="..\Robust.Shared.Maths\Robust.Shared.Maths.csproj" />

--- a/Robust.Client.Tests/Graphics/AtlasTextureTest.cs
+++ b/Robust.Client.Tests/Graphics/AtlasTextureTest.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using Robust.Client.Graphics;
+using Robust.Shared.Maths;
+
+namespace Robust.Client.Tests.Graphics;
+
+[TestFixture]
+public sealed class AtlasTextureTest
+{
+    [Test]
+    public void AllowsNonClydeSourceTextures()
+    {
+        var source = new TestTexture((64, 64));
+        var atlas = new AtlasTexture(source, UIBox2.FromDimensions(8, 16, 32, 32));
+
+        Assert.That(atlas.SourceTexture, Is.SameAs(source));
+        Assert.That(atlas.ClydeTexture, Is.Null);
+    }
+
+    private sealed class TestTexture(Vector2i size) : Texture(size)
+    {
+        public override Color GetPixel(int x, int y)
+        {
+            return Color.Black;
+        }
+    }
+}

--- a/Robust.Client/Graphics/AtlasTexture.cs
+++ b/Robust.Client/Graphics/AtlasTexture.cs
@@ -21,7 +21,8 @@ namespace Robust.Client.Graphics
             DebugTools.Assert(SubRegion.Top >= 0);
 
             SubRegion = subRegion;
-            ClydeTexture = (ClydeTextureImpl) texture;
+            SourceTexture = texture;
+            ClydeTexture = texture as ClydeTextureImpl;
 
             var (width, height) = texture.Size;
             NormalizedSubRegion = new Box2(
@@ -34,12 +35,14 @@ namespace Robust.Client.Graphics
         /// <summary>
         ///     The texture this texture is a sub region of.
         /// </summary>
-        public Texture SourceTexture => ClydeTexture;
+        public Texture SourceTexture { get; }
 
         /// <summary>
         ///     The Clyde texture backing this atlas texture.
         /// </summary>
-        internal ClydeTextureImpl ClydeTexture { get; }
+        // Headless Clyde uses dummy textures. They are never drawn through the regular renderer,
+        // but atlas creation must still work for resources loaded by headless tests.
+        internal ClydeTextureImpl? ClydeTexture { get; }
 
         /// <summary>
         ///     Our sub region within our source, in pixel coordinates.

--- a/Robust.Client/Graphics/AtlasTexture.cs
+++ b/Robust.Client/Graphics/AtlasTexture.cs
@@ -2,6 +2,7 @@ using JetBrains.Annotations;
 using Robust.Shared.Graphics;
 using Robust.Shared.Maths;
 using Robust.Shared.Utility;
+using ClydeTextureImpl = Robust.Client.Graphics.Clyde.Clyde.ClydeTexture;
 
 namespace Robust.Client.Graphics
 {
@@ -20,18 +21,35 @@ namespace Robust.Client.Graphics
             DebugTools.Assert(SubRegion.Top >= 0);
 
             SubRegion = subRegion;
-            SourceTexture = texture;
+            ClydeTexture = (ClydeTextureImpl) texture;
+
+            var (width, height) = texture.Size;
+            NormalizedSubRegion = new Box2(
+                subRegion.Left / width,
+                (height - subRegion.Bottom) / height,
+                subRegion.Right / width,
+                (height - subRegion.Top) / height);
         }
 
         /// <summary>
         ///     The texture this texture is a sub region of.
         /// </summary>
-        public Texture SourceTexture { get; }
+        public Texture SourceTexture => ClydeTexture;
+
+        /// <summary>
+        ///     The Clyde texture backing this atlas texture.
+        /// </summary>
+        internal ClydeTextureImpl ClydeTexture { get; }
 
         /// <summary>
         ///     Our sub region within our source, in pixel coordinates.
         /// </summary>
         public UIBox2 SubRegion { get; }
+
+        /// <summary>
+        ///     Our sub region within the source texture, normalized for rendering.
+        /// </summary>
+        internal Box2 NormalizedSubRegion { get; }
 
         public override Color GetPixel(int x, int y)
         {

--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -86,7 +86,7 @@ namespace Robust.Client.Graphics.Clyde
                 in Color modulate)
             {
                 var texCoords = texture.NormalizedSubRegion;
-                _clyde.DrawTexture(texture.ClydeTexture.TextureId, bl, br, tl, tr, in modulate,
+                _clyde.DrawTexture(texture.ClydeTexture!.TextureId, bl, br, tl, tr, in modulate,
                     in texCoords);
             }
 
@@ -122,7 +122,7 @@ namespace Robust.Client.Graphics.Clyde
                 Color modulate)
             {
                 var texCoords = texture.NormalizedSubRegion;
-                _clyde.DrawTexture(texture.ClydeTexture.TextureId, bl, br, tl, tr, in modulate,
+                _clyde.DrawTexture(texture.ClydeTexture!.TextureId, bl, br, tl, tr, in modulate,
                     in texCoords);
             }
 
@@ -143,7 +143,7 @@ namespace Robust.Client.Graphics.Clyde
                 Color modulate)
             {
                 var texCoords = texture.NormalizedSubRegion;
-                _clyde.DrawTextureBatch(texture.ClydeTexture.TextureId, rects, modulate,
+                _clyde.DrawTextureBatch(texture.ClydeTexture!.TextureId, rects, modulate,
                     in texCoords);
             }
 
@@ -163,7 +163,7 @@ namespace Robust.Client.Graphics.Clyde
             public void DrawTextureWorldBatchUnmodulated(AtlasTexture texture, ReadOnlySpan<WorldTextureRect> rects)
             {
                 var texCoords = texture.NormalizedSubRegion;
-                _clyde.DrawTextureBatchUnmodulated(texture.ClydeTexture.TextureId, rects,
+                _clyde.DrawTextureBatchUnmodulated(texture.ClydeTexture!.TextureId, rects,
                     in texCoords);
             }
 
@@ -202,7 +202,7 @@ namespace Robust.Client.Graphics.Clyde
                         sr = atlas.SubRegion;
                     }
 
-                    return atlas.ClydeTexture;
+                    return atlas.ClydeTexture!;
                 }
 
                 sr = subRegion ?? new UIBox2(0, 0, texture.Width, texture.Height);

--- a/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.RenderHandle.cs
@@ -68,12 +68,26 @@ namespace Robust.Client.Graphics.Clyde
             public void DrawTextureScreen(Texture texture, Vector2 bl, Vector2 br, Vector2 tl, Vector2 tr,
                 in Color modulate, in UIBox2? subRegion)
             {
+                if (subRegion == null && texture is AtlasTexture atlas)
+                {
+                    DrawTextureScreen(atlas, bl, br, tl, tr, in modulate);
+                    return;
+                }
+
                 var clydeTexture = ExtractTexture(texture, in subRegion, out var csr);
 
                 var (w, h) = clydeTexture.Size;
                 var sr = new Box2(csr.Left / w, (h - csr.Bottom) / h, csr.Right / w, (h - csr.Top) / h);
 
                 _clyde.DrawTexture(clydeTexture.TextureId, bl, br, tl, tr, in modulate, in sr);
+            }
+
+            public void DrawTextureScreen(AtlasTexture texture, Vector2 bl, Vector2 br, Vector2 tl, Vector2 tr,
+                in Color modulate)
+            {
+                var texCoords = texture.NormalizedSubRegion;
+                _clyde.DrawTexture(texture.ClydeTexture.TextureId, bl, br, tl, tr, in modulate,
+                    in texCoords);
             }
 
             /// <summary>
@@ -91,6 +105,12 @@ namespace Robust.Client.Graphics.Clyde
             public void DrawTextureWorld(Texture texture, Vector2 bl, Vector2 br, Vector2 tl, Vector2 tr,
                 Color modulate, in UIBox2? subRegion)
             {
+                if (subRegion == null && texture is AtlasTexture atlas)
+                {
+                    DrawTextureWorld(atlas, bl, br, tl, tr, modulate);
+                    return;
+                }
+
                 var clydeTexture = ExtractTexture(texture, in subRegion, out var csr);
 
                 var sr = WorldTextureBoundsToUV(clydeTexture, csr);
@@ -98,18 +118,53 @@ namespace Robust.Client.Graphics.Clyde
                 _clyde.DrawTexture(clydeTexture.TextureId, bl, br, tl, tr, in modulate, in sr);
             }
 
+            public void DrawTextureWorld(AtlasTexture texture, Vector2 bl, Vector2 br, Vector2 tl, Vector2 tr,
+                Color modulate)
+            {
+                var texCoords = texture.NormalizedSubRegion;
+                _clyde.DrawTexture(texture.ClydeTexture.TextureId, bl, br, tl, tr, in modulate,
+                    in texCoords);
+            }
+
             public void DrawTextureWorldBatch(Texture texture, ReadOnlySpan<WorldTextureRect> rects, Color modulate)
             {
+                if (texture is AtlasTexture atlas)
+                {
+                    DrawTextureWorldBatch(atlas, rects, modulate);
+                    return;
+                }
+
                 var clydeTexture = ExtractTexture(texture, null, out var csr);
                 var sr = WorldTextureBoundsToUV(clydeTexture, csr);
                 _clyde.DrawTextureBatch(clydeTexture.TextureId, rects, modulate, in sr);
             }
 
+            public void DrawTextureWorldBatch(AtlasTexture texture, ReadOnlySpan<WorldTextureRect> rects,
+                Color modulate)
+            {
+                var texCoords = texture.NormalizedSubRegion;
+                _clyde.DrawTextureBatch(texture.ClydeTexture.TextureId, rects, modulate,
+                    in texCoords);
+            }
+
             public void DrawTextureWorldBatchUnmodulated(Texture texture, ReadOnlySpan<WorldTextureRect> rects)
             {
+                if (texture is AtlasTexture atlas)
+                {
+                    DrawTextureWorldBatchUnmodulated(atlas, rects);
+                    return;
+                }
+
                 var clydeTexture = ExtractTexture(texture, null, out var csr);
                 var sr = WorldTextureBoundsToUV(clydeTexture, csr);
                 _clyde.DrawTextureBatchUnmodulated(clydeTexture.TextureId, rects, in sr);
+            }
+
+            public void DrawTextureWorldBatchUnmodulated(AtlasTexture texture, ReadOnlySpan<WorldTextureRect> rects)
+            {
+                var texCoords = texture.NormalizedSubRegion;
+                _clyde.DrawTextureBatchUnmodulated(texture.ClydeTexture.TextureId, rects,
+                    in texCoords);
             }
 
             public void DrawRectWorldBatch(ReadOnlySpan<WorldRect> rects, Color modulate)
@@ -135,7 +190,6 @@ namespace Robust.Client.Graphics.Clyde
             {
                 if (texture is AtlasTexture atlas)
                 {
-                    texture = atlas.SourceTexture;
                     if (subRegion.HasValue)
                     {
                         var offset = atlas.SubRegion.TopLeft;
@@ -147,14 +201,12 @@ namespace Robust.Client.Graphics.Clyde
                     {
                         sr = atlas.SubRegion;
                     }
-                }
-                else
-                {
-                    sr = subRegion ?? new UIBox2(0, 0, texture.Width, texture.Height);
+
+                    return atlas.ClydeTexture;
                 }
 
-                var clydeTexture = (ClydeTexture) texture;
-                return clydeTexture;
+                sr = subRegion ?? new UIBox2(0, 0, texture.Width, texture.Height);
+                return (ClydeTexture) texture;
             }
 
             public void RenderInRenderTarget(IRenderTarget target, Action a, Color? clearColor)


### PR DESCRIPTION
O(0) beats doing basic maths operations. Followup work to make some hot drawing paths (fonts + RSIs) use the AtlasTexture methods instead.

```
| Method                       | Mean      | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
|----------------------------- |----------:|----------:|----------:|------:|--------:|----------:|------------:|
| LegacyAtlasPath              | 3.7133 ns | 3.2663 ns | 0.1790 ns |  1.00 |    0.06 |         - |          NA |
| TextureCallerToAtlasOverload | 1.5157 ns | 4.8221 ns | 0.2643 ns |  0.41 |    0.06 |         - |          NA |
| StaticallyTypedAtlasCaller   | 0.6359 ns | 2.0769 ns | 0.1138 ns |  0.17 |    0.03 |         - |          NA |
```