### PR TITLE
Replays: stream replay history from disk instead of holding the whole replay in RAM

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,11 +35,11 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* `ReplayData` no longer exposes the `States`/`Messages` lists; use `Count`, `GetState(index)` and `GetMessages(index)` instead. Replay history is now provided lazily through the new `IReplayDataProvider` interface, and `IReplayLoadManager.GenerateCheckpointsAsync` is no longer part of the public API.
 
 ### New features
 
-*None yet*
+* The replay client now streams replay history from disk instead of keeping the entire deserialized replay resident in RAM, both while loading (history is streamed block-by-block through checkpoint generation) and during playback (data blocks are lazily re-read through a small LRU window, configurable via the `replay.loaded_block_window` cvar). Measured on an 861 MB, 1h38m replay this halves load time and cuts peak memory from ~22 GB to ~12 GB.
 
 ### Bugfixes
 

--- a/Robust.Client/Replays/Loading/BufferedReplayDataProvider.cs
+++ b/Robust.Client/Replays/Loading/BufferedReplayDataProvider.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Robust.Shared.GameStates;
+using Robust.Shared.Log;
+using Robust.Shared.Replays;
+using Robust.Shared.Serialization;
+using Robust.Shared.Upload;
+using Robust.Shared.Utility;
+
+namespace Robust.Client.Replays.Loading;
+
+/// <summary>
+/// A windowed <see cref="IReplayDataProvider"/>: instead of keeping every <see cref="GameState"/> and
+/// <see cref="ReplayMessage"/> resident, it keeps only a small number of recently-used data blocks
+/// loaded and lazily (re)reads blocks from the replay file on demand.
+/// </summary>
+/// <remarks>
+/// Each block corresponds to one <c>data_N</c> file in the replay (≈1 MB uncompressed). When playing
+/// back linearly a block boundary is crossed only every few seconds, so the synchronous decompress +
+/// deserialize cost is negligible and no background prefetch thread is needed. Jumping around (scrubbing)
+/// loads whichever blocks lie between the nearest checkpoint and the target tick; older blocks are
+/// evicted once the window limit is exceeded.
+/// </remarks>
+public sealed class BufferedReplayDataProvider : IReplayDataProvider
+{
+    /// <summary>
+    /// Describes where a contiguous run of ticks lives: which file and the index range it covers.
+    /// </summary>
+    public readonly struct BlockMeta
+    {
+        public readonly ResPath FileName;
+        public readonly int Start;
+        public readonly int Count;
+
+        public BlockMeta(ResPath fileName, int start, int count)
+        {
+            FileName = fileName;
+            Start = start;
+            Count = count;
+        }
+    }
+
+    private sealed class LoadedBlock
+    {
+        public readonly GameState[] States;
+        public readonly ReplayMessage[] Messages;
+
+        public LoadedBlock(GameState[] states, ReplayMessage[] messages)
+        {
+            States = states;
+            Messages = messages;
+        }
+    }
+
+    private readonly IReplayFileReader _fileReader;
+    private readonly IRobustSerializer _serializer;
+    private readonly ISawmill _sawmill;
+    private readonly BlockMeta[] _blocks;
+    private readonly int[] _blockStarts; // parallel to _blocks, for binary search
+    private readonly int _maxLoadedBlocks;
+
+    private readonly Dictionary<int, LoadedBlock> _loaded = new();
+    private readonly Dictionary<int, LinkedListNode<int>> _lruNodes = new();
+    private readonly LinkedList<int> _lru = new(); // most-recently-used at the front
+
+    private bool _disposed;
+
+    public int Count { get; }
+
+    public BufferedReplayDataProvider(
+        IReplayFileReader fileReader,
+        IRobustSerializer serializer,
+        BlockMeta[] blocks,
+        int count,
+        int maxLoadedBlocks,
+        ISawmill sawmill)
+    {
+        _fileReader = fileReader;
+        _serializer = serializer;
+        _blocks = blocks;
+        _sawmill = sawmill;
+        Count = count;
+        _maxLoadedBlocks = Math.Max(2, maxLoadedBlocks);
+
+        _blockStarts = new int[blocks.Length];
+        for (var i = 0; i < blocks.Length; i++)
+            _blockStarts[i] = blocks[i].Start;
+    }
+
+    public GameState GetState(int index)
+    {
+        var blockIdx = ResolveBlockIndex(index);
+        var block = GetOrLoad(blockIdx);
+        return block.States[index - _blocks[blockIdx].Start];
+    }
+
+    public ReplayMessage GetMessages(int index)
+    {
+        var blockIdx = ResolveBlockIndex(index);
+        var block = GetOrLoad(blockIdx);
+        return block.Messages[index - _blocks[blockIdx].Start];
+    }
+
+    private int ResolveBlockIndex(int index)
+    {
+        if (index < 0 || index >= Count)
+            throw new ArgumentOutOfRangeException(nameof(index), index, $"Replay tick index out of range [0, {Count}).");
+
+        // Find the block whose [Start, Start+Count) range contains index.
+        var i = Array.BinarySearch(_blockStarts, index);
+        if (i < 0)
+            i = ~i - 1; // index falls inside the block that starts before it
+        return i;
+    }
+
+    private LoadedBlock GetOrLoad(int blockIdx)
+    {
+        if (_loaded.TryGetValue(blockIdx, out var block))
+        {
+            Touch(blockIdx);
+            return block;
+        }
+
+        block = LoadBlock(_blocks[blockIdx]);
+        _loaded[blockIdx] = block;
+        _lruNodes[blockIdx] = _lru.AddFirst(blockIdx);
+        Evict();
+        return block;
+    }
+
+    private void Touch(int blockIdx)
+    {
+        var node = _lruNodes[blockIdx];
+        if (node.Previous == null)
+            return; // already most-recent
+        _lru.Remove(node);
+        _lru.AddFirst(node);
+    }
+
+    private void Evict()
+    {
+        while (_loaded.Count > _maxLoadedBlocks)
+        {
+            var lru = _lru.Last!;
+            _lru.RemoveLast();
+            _loaded.Remove(lru.Value);
+            _lruNodes.Remove(lru.Value);
+        }
+    }
+
+    private LoadedBlock LoadBlock(in BlockMeta meta)
+    {
+        using var fileStream = _fileReader.Open(meta.FileName);
+        using var decompressStream = new ZStdDecompressStream(fileStream, false);
+
+        var intBuf = new byte[4];
+        fileStream.ReadExactly(intBuf);
+        var uncompressedSize = BitConverter.ToInt32(intBuf);
+
+        var ms = new MemoryStream(uncompressedSize);
+        decompressStream.CopyTo(ms);
+        ms.Position = 0;
+
+        var states = new GameState[meta.Count];
+        var messages = new ReplayMessage[meta.Count];
+
+        var i = 0;
+        while (ms.Position < ms.Length)
+        {
+            _serializer.DeserializeDirect(ms, out GameState state);
+            _serializer.DeserializeDirect(ms, out ReplayMessage msg);
+            FilterUploadMessages(msg);
+            states[i] = state;
+            messages[i] = msg;
+            i++;
+        }
+
+        DebugTools.AssertEqual(i, meta.Count);
+        return new LoadedBlock(states, messages);
+    }
+
+    /// <summary>
+    /// Prototype and resource uploads are consumed once during checkpoint generation (they are removed
+    /// from the message list there via RemoveSwap). When a block is re-read for playback we must drop
+    /// them again, otherwise they would be re-dispatched and the playback code asserts they are absent.
+    /// All other message types (cvar changes, PVS leaves, entity events) are required for playback.
+    /// </summary>
+    private static void FilterUploadMessages(ReplayMessage msg)
+    {
+        msg.Messages.RemoveAll(static m =>
+            m is ReplayPrototypeUploadMsg
+            || m is SharedNetworkResourceManager.ReplayResourceUploadMsg);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+
+        _loaded.Clear();
+        _lruNodes.Clear();
+        _lru.Clear();
+        _fileReader.Dispose();
+    }
+}

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.Checkpoints.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.Checkpoints.cs
@@ -48,7 +48,7 @@ public sealed partial class ReplayLoadManager
     private async Task<(CheckpointState[], TimeSpan[])> GenerateCheckpointsAsync(
         ReplayMessage? initMessages,
         HashSet<string> initialCvars,
-        IAsyncEnumerable<(GameState State, ReplayMessage Messages)> history,
+        IEnumerable<(GameState State, ReplayMessage Messages)> history,
         HistoryStreamStats stats,
         LoadReplayCallback callback)
     {
@@ -94,8 +94,8 @@ public sealed partial class ReplayLoadManager
 
         // The history arrives as a lazy block-by-block stream (see StreamHistory); it is consumed exactly
         // once, strictly in tick order, so nothing behind the cursor stays reachable from here.
-        await using var historyEnumerator = history.GetAsyncEnumerator();
-        if (!await historyEnumerator.MoveNextAsync())
+        using var historyEnumerator = history.GetEnumerator();
+        if (!historyEnumerator.MoveNext())
             throw new Exception("Replay contains no game states");
 
         var (state0, messages0) = historyEnumerator.Current;
@@ -171,11 +171,13 @@ public sealed partial class ReplayLoadManager
 
         var modifiedEntities = new Dictionary<NetEntity, UpdateScratchData>();
         var i = 0;
-        while (await historyEnumerator.MoveNextAsync())
+        while (historyEnumerator.MoveNext())
         {
             i++;
+            // Progress is reported in data-block units: the total tick count is unknown while streaming.
+            // BlocksRead is incremented once a block's last tick has been yielded, so +1 = the current block.
             if (i % 10 == 0)
-                await callback(stats.BlocksRead, stats.TotalBlocks, LoadingState.ProcessingFiles, false);
+                await callback(Math.Min(stats.BlocksRead + 1, stats.TotalBlocks), stats.TotalBlocks, LoadingState.ProcessingFiles, false);
 
             var lastState = curState;
             (curState, var curMessages) = historyEnumerator.Current;

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.Checkpoints.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.Checkpoints.cs
@@ -45,11 +45,11 @@ public sealed partial class ReplayLoadManager
         }
     }
 
-    public async Task<(CheckpointState[], TimeSpan[])> GenerateCheckpointsAsync(
+    private async Task<(CheckpointState[], TimeSpan[])> GenerateCheckpointsAsync(
         ReplayMessage? initMessages,
         HashSet<string> initialCvars,
-        List<GameState> states,
-        List<ReplayMessage> messages,
+        IAsyncEnumerable<(GameState State, ReplayMessage Messages)> history,
+        HistoryStreamStats stats,
         LoadReplayCallback callback)
     {
         // Given a set of states [0 to X], [X to X+1], [X+1 to X+2]..., this method  will generate additional states
@@ -90,8 +90,15 @@ public sealed partial class ReplayLoadManager
         }
 
         var timeBase = _timing.TimeBase;
-        var checkPoints = new List<CheckpointState>(1 + states.Count / _checkpointInterval);
-        var state0 = states[0];
+        var checkPoints = new List<CheckpointState>();
+
+        // The history arrives as a lazy block-by-block stream (see StreamHistory); it is consumed exactly
+        // once, strictly in tick order, so nothing behind the cursor stays reachable from here.
+        await using var historyEnumerator = history.GetAsyncEnumerator();
+        if (!await historyEnumerator.MoveNextAsync())
+            throw new Exception("Replay contains no game states");
+
+        var (state0, messages0) = historyEnumerator.Current;
 
         // Get all initial prototypes
         var prototypes = new Dictionary<Type, HashSet<string>>();
@@ -112,7 +119,7 @@ public sealed partial class ReplayLoadManager
 
         if (initMessages != null)
             UpdateMessages(initMessages, uploadedFiles, prototypes, cvars, detachQueue, ref timeBase, true);
-        UpdateMessages(messages[0], uploadedFiles, prototypes, cvars, detachQueue, ref timeBase, true);
+        UpdateMessages(messages0, uploadedFiles, prototypes, cvars, detachQueue, ref timeBase, true);
 
         var entSpan = state0.EntityStates.Value;
         Dictionary<NetEntity, EntityState> entStates = new(entSpan.Count);
@@ -124,7 +131,7 @@ public sealed partial class ReplayLoadManager
 
         ProcessQueue(GameTick.MaxValue, detachQueue, detached, entStates);
 
-        await callback(0, states.Count, LoadingState.ProcessingFiles, true);
+        await callback(0, stats.TotalBlocks, LoadingState.ProcessingFiles, true);
         var playerSpan = state0.PlayerStates.Value;
         Dictionary<NetUserId, SessionState> playerStates = new(playerSpan.Count);
         foreach (var player in playerSpan)
@@ -150,8 +157,7 @@ public sealed partial class ReplayLoadManager
             return timeBase.Item1 + (tick.Value - timeBase.Item2.Value) * period;
         }
 
-        var serverTime = new TimeSpan[states.Count];
-        serverTime[0] = TimeSpan.Zero;
+        var serverTime = new List<TimeSpan> { TimeSpan.Zero };
         var initialTime = GetTime(state0.ToSequence);
 
         var ticksSinceLastCheckpoint = 0;
@@ -164,21 +170,23 @@ public sealed partial class ReplayLoadManager
         var stats_due_state = 0;
 
         var modifiedEntities = new Dictionary<NetEntity, UpdateScratchData>();
-        for (var i = 1; i < states.Count; i++)
+        var i = 0;
+        while (await historyEnumerator.MoveNextAsync())
         {
+            i++;
             if (i % 10 == 0)
-                await callback(i, states.Count, LoadingState.ProcessingFiles, false);
+                await callback(stats.BlocksRead, stats.TotalBlocks, LoadingState.ProcessingFiles, false);
 
             var lastState = curState;
-            curState = states[i];
+            (curState, var curMessages) = historyEnumerator.Current;
             DebugTools.Assert(curState.FromSequence <= lastState.ToSequence);
 
             UpdatePlayerStates(curState.PlayerStates.Span, playerStates);
             UpdateEntityStates(curState.EntityStates.Span, entStates, modifiedEntities, ref spawnedTracker, ref stateTracker, detached);
-            UpdateMessages(messages[i], uploadedFiles, prototypes, cvars, detachQueue, ref timeBase);
+            UpdateMessages(curMessages, uploadedFiles, prototypes, cvars, detachQueue, ref timeBase);
             ProcessQueue(curState.ToSequence, detachQueue, detached, entStates);
             UpdateDeletions(curState.EntityDeletions, entStates, detached, modifiedEntities);
-            serverTime[i] = GetTime(curState.ToSequence) - initialTime;
+            serverTime.Add(GetTime(curState.ToSequence) - initialTime);
             ticksSinceLastCheckpoint++;
 
             // Don't create checkpoints too frequently no matter the circumstance
@@ -219,10 +227,10 @@ public sealed partial class ReplayLoadManager
             checkPoints.Add(new CheckpointState(newState, timeBase, cvars, i, detached));
         }
 
-        _sawmill.Info($"Finished generating {checkPoints.Count} checkpoints. Elapsed time: {st.Elapsed}. Checkpoint every {(float)states.Count / checkPoints.Count} ticks on average");
+        _sawmill.Info($"Finished generating {checkPoints.Count} checkpoints. Elapsed time: {st.Elapsed}. Checkpoint every {(float)serverTime.Count / checkPoints.Count} ticks on average");
         _sawmill.Info($"Checkpoint stats - Spawning: {stats_due_spawned} StateChanges: {stats_due_state} Ticks: {stats_due_ticks}. ");
-        await callback(states.Count, states.Count, LoadingState.ProcessingFiles, false);
-        return (checkPoints.ToArray(), serverTime);
+        await callback(stats.TotalBlocks, stats.TotalBlocks, LoadingState.ProcessingFiles, false);
+        return (checkPoints.ToArray(), serverTime.ToArray());
     }
 
     private void ProcessQueue(

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.Read.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.Read.cs
@@ -19,7 +19,6 @@ namespace Robust.Client.Replays.Loading;
 
 public sealed partial class ReplayLoadManager
 {
-    [SuppressMessage("ReSharper", "UseAwaitUsing")]
     public async Task<ReplayData> LoadReplayAsync(IReplayFileReader fileReader, LoadReplayCallback callback)
     {
         // NOTE: fileReader is NOT disposed here. Ownership is transferred to the BufferedReplayDataProvider
@@ -32,50 +31,130 @@ public sealed partial class ReplayLoadManager
             throw new Exception($"Invalid runlevel: {_client.RunLevel}.");
 
         _timing.Paused = true;
-        List<GameState> states = new();
-        List<ReplayMessage> messages = new();
 
         var compressionContext = new ZStdCompressionContext();
         var metaData = LoadMetadata(fileReader);
 
         var totalData = fileReader.AllFiles.Count(x => x.Filename.StartsWith(DataFilePrefix));
 
+        // Init messages are consumed at the very start of checkpoint generation, so load them up front.
+        var initData = LoadInitFile(fileReader, compressionContext);
+        compressionContext.Dispose();
+
         // Index of which data file backs which range of tick indices, so the provider can re-read blocks
         // lazily during playback instead of keeping everything resident.
         var blocks = new List<BufferedReplayDataProvider.BlockMeta>();
+        var stats = new HistoryStreamStats { TotalBlocks = totalData };
 
+        // The history is streamed block-by-block straight into checkpoint generation: at no point does the
+        // whole deserialized replay sit in memory. Only the checkpoints (plus whatever per-entity states
+        // they share with the last-seen history) survive the pass.
+        var (checkpoints, serverTime) = await GenerateCheckpointsAsync(
+            initData,
+            metaData.CVars,
+            StreamHistory(fileReader, totalData, blocks, stats, callback),
+            stats,
+            callback);
+
+        _timing.Paused = false;
+
+        if (stats.TickCount == 0)
+            throw new Exception("Replay contains no game states");
+
+        var provider = new BufferedReplayDataProvider(
+            fileReader,
+            _serializer,
+            blocks.ToArray(),
+            stats.TickCount,
+            _loadedBlockWindow,
+            _sawmill);
+
+        // The streaming pass churns a lot of transient per-block data, some of which gets promoted to
+        // Gen2/LOH before dying. Compact once so playback starts with a tight heap. One-off cost.
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+        _sawmill.Info($"[BUFFER] Streamed load done. Managed heap now {GC.GetTotalMemory(false) / 1024.0 / 1024.0:N0} MB " +
+                      $"({blocks.Count} data blocks indexed, window={_loadedBlockWindow}, checkpoints={checkpoints.Length}). " +
+                      $"Remaining growth during playback is the live entity world, not replay history.");
+
+        return new ReplayData(
+            provider,
+            serverTime,
+            stats.FirstTick,
+            stats.LastTick,
+            metaData.StartTime,
+            metaData.Duration,
+            checkpoints,
+            initData,
+            metaData.ClientSide,
+            metaData.YamlData);
+    }
+
+    /// <summary>
+    /// Aggregates facts about the replay history that only become known while streaming through it.
+    /// Filled in by <see cref="StreamHistory"/> as the consumer advances the enumeration.
+    /// </summary>
+    private sealed class HistoryStreamStats
+    {
+        public GameTick FirstTick;
+        public GameTick LastTick;
+        public int TickCount;
+        public int BlocksRead;
+        public int TotalBlocks;
+    }
+
+    /// <summary>
+    /// Lazily decodes the replay history one data block at a time, yielding (state, messages) pairs in tick
+    /// order. Builds the <see cref="BufferedReplayDataProvider.BlockMeta"/> index as a side effect. Blocks
+    /// become garbage as soon as the consumer moves past them, keeping the load-time memory peak flat.
+    /// </summary>
+    [SuppressMessage("ReSharper", "UseAwaitUsing")]
+    private async IAsyncEnumerable<(GameState State, ReplayMessage Messages)> StreamHistory(
+        IReplayFileReader fileReader,
+        int totalData,
+        List<BufferedReplayDataProvider.BlockMeta> blocks,
+        HistoryStreamStats stats,
+        LoadReplayCallback callback)
+    {
         var i = 0;
         var intBuf = new byte[4];
         var name = new ResPath($"{DataFilePrefix}{i++}.{Ext}");
         while (fileReader.Exists(name))
         {
-            await callback(i+1, totalData, LoadingState.ReadingFiles, false);
+            await callback(i + 1, totalData, LoadingState.ReadingFiles, false);
 
-            var blockStart = states.Count;
+            var blockStart = stats.TickCount;
             var blockFile = name;
 
-            using var fileStream = fileReader.Open(name);
-            using var decompressStream = new ZStdDecompressStream(fileStream, false);
-
-            fileStream.ReadExactly(intBuf);
-            var uncompressedSize = BitConverter.ToInt32(intBuf);
-
-            var decompressedStream = new MemoryStream(uncompressedSize);
-            decompressStream.CopyTo(decompressedStream);
-            decompressedStream.Position = 0;
-            DebugTools.Assert(uncompressedSize == decompressedStream.Length);
-
-            while (decompressedStream.Position < decompressedStream.Length)
+            using (var fileStream = fileReader.Open(name))
+            using (var decompressStream = new ZStdDecompressStream(fileStream, false))
             {
-                _serializer.DeserializeDirect(decompressedStream, out GameState state);
-                _serializer.DeserializeDirect(decompressedStream, out ReplayMessage msg);
-                states.Add(state);
-                messages.Add(msg);
+                fileStream.ReadExactly(intBuf);
+                var uncompressedSize = BitConverter.ToInt32(intBuf);
+
+                var decompressedStream = new MemoryStream(uncompressedSize);
+                decompressStream.CopyTo(decompressedStream);
+                decompressedStream.Position = 0;
+                DebugTools.Assert(uncompressedSize == decompressedStream.Length);
+
+                while (decompressedStream.Position < decompressedStream.Length)
+                {
+                    _serializer.DeserializeDirect(decompressedStream, out GameState state);
+                    _serializer.DeserializeDirect(decompressedStream, out ReplayMessage msg);
+
+                    if (stats.TickCount == 0)
+                        stats.FirstTick = state.ToSequence;
+                    stats.LastTick = state.ToSequence;
+                    stats.TickCount++;
+
+                    yield return (state, msg);
+                }
             }
 
-            var blockCount = states.Count - blockStart;
+            var blockCount = stats.TickCount - blockStart;
             if (blockCount > 0)
                 blocks.Add(new BufferedReplayDataProvider.BlockMeta(blockFile, blockStart, blockCount));
+            stats.BlocksRead++;
 
             name = new ResPath($"{DataFilePrefix}{i++}.{Ext}");
         }
@@ -85,60 +164,6 @@ public sealed partial class ReplayLoadManager
             throw new Exception("Could not read expected amount of data files from replay");
 
         await callback(totalData, totalData, LoadingState.ReadingFiles, false);
-
-        var initData = LoadInitFile(fileReader, compressionContext);
-        compressionContext.Dispose();
-
-        var (checkpoints, serverTime) = await GenerateCheckpointsAsync(
-            initData,
-            metaData.CVars,
-            states, messages,
-            callback);
-
-        _timing.Paused = false;
-
-        // Capture what we need before dropping the in-memory lists; from here on states/messages are
-        // served lazily by the provider, which re-reads blocks from the (still-open) replay file and
-        // owns its lifetime.
-        var tickOffset = states[0].ToSequence;
-        var lastTick = states[^1].ToSequence;
-        var tickCount = states.Count;
-        var provider = new BufferedReplayDataProvider(
-            fileReader,
-            _serializer,
-            blocks.ToArray(),
-            tickCount,
-            _loadedBlockWindow,
-            _sawmill);
-
-        // Drop the full history. NOTE: nulling the local references is not enough — the async load/checkpoint
-        // call chain keeps other references to these list objects alive, so the elements would stay reachable.
-        // Clear() empties the lists from the inside (releasing every GameState/ReplayMessage) regardless of who
-        // else still holds the container. These objects survived the load into Gen2/LOH, so we then force a
-        // compacting collection to actually return the memory to the OS before playback begins. One-off cost.
-        states.Clear();
-        states.TrimExcess();
-        messages.Clear();
-        messages.TrimExcess();
-        states = null!;
-        messages = null!;
-        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
-
-        _sawmill.Info($"[BUFFER] History dropped. Managed heap now {GC.GetTotalMemory(false) / 1024.0 / 1024.0:N0} MB " +
-                      $"({blocks.Count} data blocks indexed, window={_loadedBlockWindow}, checkpoints={checkpoints.Length}). " +
-                      $"Remaining growth during playback is the live entity world, not replay history.");
-
-        return new ReplayData(
-            provider,
-            serverTime,
-            tickOffset,
-            lastTick,
-            metaData.StartTime,
-            metaData.Duration,
-            checkpoints,
-            initData,
-            metaData.ClientSide,
-            metaData.YamlData);
     }
 
     private ReplayMessage? LoadInitFile(

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.Read.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.Read.cs
@@ -52,7 +52,7 @@ public sealed partial class ReplayLoadManager
         var (checkpoints, serverTime) = await GenerateCheckpointsAsync(
             initData,
             metaData.CVars,
-            StreamHistory(fileReader, totalData, blocks, stats, callback),
+            StreamHistory(fileReader, totalData, blocks, stats),
             stats,
             callback);
 
@@ -107,22 +107,20 @@ public sealed partial class ReplayLoadManager
     /// Lazily decodes the replay history one data block at a time, yielding (state, messages) pairs in tick
     /// order. Builds the <see cref="BufferedReplayDataProvider.BlockMeta"/> index as a side effect. Blocks
     /// become garbage as soon as the consumer moves past them, keeping the load-time memory peak flat.
+    /// Loading-screen progress is reported solely by the consumer (checkpoint generation) so that the UI
+    /// does not flip between the reading/processing phases every block.
     /// </summary>
-    [SuppressMessage("ReSharper", "UseAwaitUsing")]
-    private async IAsyncEnumerable<(GameState State, ReplayMessage Messages)> StreamHistory(
+    private IEnumerable<(GameState State, ReplayMessage Messages)> StreamHistory(
         IReplayFileReader fileReader,
         int totalData,
         List<BufferedReplayDataProvider.BlockMeta> blocks,
-        HistoryStreamStats stats,
-        LoadReplayCallback callback)
+        HistoryStreamStats stats)
     {
         var i = 0;
         var intBuf = new byte[4];
         var name = new ResPath($"{DataFilePrefix}{i++}.{Ext}");
         while (fileReader.Exists(name))
         {
-            await callback(i + 1, totalData, LoadingState.ReadingFiles, false);
-
             var blockStart = stats.TickCount;
             var blockFile = name;
 
@@ -162,8 +160,6 @@ public sealed partial class ReplayLoadManager
         // Could happen if there's gaps in the numbers of the data.
         if (i - 1 != totalData)
             throw new Exception("Could not read expected amount of data files from replay");
-
-        await callback(totalData, totalData, LoadingState.ReadingFiles, false);
     }
 
     private ReplayMessage? LoadInitFile(

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.Read.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.Read.cs
@@ -22,7 +22,9 @@ public sealed partial class ReplayLoadManager
     [SuppressMessage("ReSharper", "UseAwaitUsing")]
     public async Task<ReplayData> LoadReplayAsync(IReplayFileReader fileReader, LoadReplayCallback callback)
     {
-        using var _ = fileReader;
+        // NOTE: fileReader is NOT disposed here. Ownership is transferred to the BufferedReplayDataProvider
+        // below, which keeps reading data blocks lazily during playback and disposes the reader when the
+        // replay is unloaded (ReplayPlaybackManager.StopReplay -> ReplayData.Dispose).
 
         if (_client.RunLevel == ClientRunLevel.Initialize)
             _client.StartSinglePlayer();
@@ -38,12 +40,19 @@ public sealed partial class ReplayLoadManager
 
         var totalData = fileReader.AllFiles.Count(x => x.Filename.StartsWith(DataFilePrefix));
 
+        // Index of which data file backs which range of tick indices, so the provider can re-read blocks
+        // lazily during playback instead of keeping everything resident.
+        var blocks = new List<BufferedReplayDataProvider.BlockMeta>();
+
         var i = 0;
         var intBuf = new byte[4];
         var name = new ResPath($"{DataFilePrefix}{i++}.{Ext}");
         while (fileReader.Exists(name))
         {
             await callback(i+1, totalData, LoadingState.ReadingFiles, false);
+
+            var blockStart = states.Count;
+            var blockFile = name;
 
             using var fileStream = fileReader.Open(name);
             using var decompressStream = new ZStdDecompressStream(fileStream, false);
@@ -64,6 +73,10 @@ public sealed partial class ReplayLoadManager
                 messages.Add(msg);
             }
 
+            var blockCount = states.Count - blockStart;
+            if (blockCount > 0)
+                blocks.Add(new BufferedReplayDataProvider.BlockMeta(blockFile, blockStart, blockCount));
+
             name = new ResPath($"{DataFilePrefix}{i++}.{Ext}");
         }
 
@@ -83,11 +96,43 @@ public sealed partial class ReplayLoadManager
             callback);
 
         _timing.Paused = false;
+
+        // Capture what we need before dropping the in-memory lists; from here on states/messages are
+        // served lazily by the provider, which re-reads blocks from the (still-open) replay file and
+        // owns its lifetime.
+        var tickOffset = states[0].ToSequence;
+        var lastTick = states[^1].ToSequence;
+        var tickCount = states.Count;
+        var provider = new BufferedReplayDataProvider(
+            fileReader,
+            _serializer,
+            blocks.ToArray(),
+            tickCount,
+            _loadedBlockWindow,
+            _sawmill);
+
+        // Drop the full history. NOTE: nulling the local references is not enough — the async load/checkpoint
+        // call chain keeps other references to these list objects alive, so the elements would stay reachable.
+        // Clear() empties the lists from the inside (releasing every GameState/ReplayMessage) regardless of who
+        // else still holds the container. These objects survived the load into Gen2/LOH, so we then force a
+        // compacting collection to actually return the memory to the OS before playback begins. One-off cost.
+        states.Clear();
+        states.TrimExcess();
+        messages.Clear();
+        messages.TrimExcess();
+        states = null!;
+        messages = null!;
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+        _sawmill.Info($"[BUFFER] History dropped. Managed heap now {GC.GetTotalMemory(false) / 1024.0 / 1024.0:N0} MB " +
+                      $"({blocks.Count} data blocks indexed, window={_loadedBlockWindow}, checkpoints={checkpoints.Length}). " +
+                      $"Remaining growth during playback is the live entity world, not replay history.");
+
         return new ReplayData(
-            states,
-            messages,
+            provider,
             serverTime,
-            states[0].ToSequence,
+            tickOffset,
+            lastTick,
             metaData.StartTime,
             metaData.Duration,
             checkpoints,

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.Start.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.Start.cs
@@ -91,7 +91,7 @@ public sealed partial class ReplayLoadManager
         // TODO add progress bar / loading stage for this?
         await callback(0, total, LoadingState.Initializing, true);
         var nextIndex = checkpoint.Index + 1;
-        var next =  nextIndex < data.States.Count ? data.States[nextIndex] : null;
+        var next =  nextIndex < data.Count ? data.GetState(nextIndex) : null;
         _gameState.ClearDetachQueue();
         _gameState.ApplyGameState(checkpoint.State, next);
 

--- a/Robust.Client/Replays/Loading/ReplayLoadManager.cs
+++ b/Robust.Client/Replays/Loading/ReplayLoadManager.cs
@@ -36,6 +36,7 @@ public sealed partial class ReplayLoadManager : IReplayLoadManager
     private int _checkpointMinInterval;
     private int _checkpointEntitySpawnThreshold;
     private int _checkpointEntityStateThreshold;
+    private int _loadedBlockWindow;
     private ISawmill _sawmill = default!;
 
     public void Initialize()
@@ -50,6 +51,7 @@ public sealed partial class ReplayLoadManager : IReplayLoadManager
             true);
         _confMan.OnValueChanged(CVars.CheckpointEntityStateThreshold, value => _checkpointEntityStateThreshold = value,
             true);
+        _confMan.OnValueChanged(CVars.ReplayLoadedBlockWindow, value => _loadedBlockWindow = value, true);
         _metaId = _factory.GetRegistration(typeof(MetaDataComponent)).NetID!.Value;
         _sawmill = _logMan.GetSawmill("replay");
     }

--- a/Robust.Client/Replays/Playback/ReplayPlaybackManager.Checkpoint.cs
+++ b/Robust.Client/Replays/Playback/ReplayPlaybackManager.Checkpoint.cs
@@ -59,7 +59,7 @@ internal sealed partial class ReplayPlaybackManager
         DebugTools.Assert(replay.ClientSideRecording || checkpoint.Detached.Count == 0);
 
         var nextIndex = checkpoint.Index + 1;
-        var next =  nextIndex < replay.States.Count ? replay.States[nextIndex] : null;
+        var next =  nextIndex < replay.Count ? replay.GetState(nextIndex) : null;
         _gameState.PartialStateReset(checkpoint.FullState, false, false);
         _entMan.EntitySysManager.GetEntitySystem<ClientDirtySystem>().Reset();
         _entMan.EntitySysManager.GetEntitySystem<TransformSystem>().Reset();

--- a/Robust.Client/Replays/Playback/ReplayPlaybackManager.Time.cs
+++ b/Robust.Client/Replays/Playback/ReplayPlaybackManager.Time.cs
@@ -29,7 +29,7 @@ internal sealed partial class ReplayPlaybackManager
         }
 
         Playing &= !pausePlayback;
-        value = Math.Clamp(value, 0, Replay.States.Count - 1);
+        value = Math.Clamp(value, 0, Replay.Count - 1);
         if (value == Replay.CurrentIndex)
         {
             ScrubbingTarget = null;
@@ -115,7 +115,7 @@ internal sealed partial class ReplayPlaybackManager
             return 0;
 
         if (time >= Replay.ReplayTime[^1])
-            return Replay.States.Count - 1;
+            return Replay.Count - 1;
 
         var index = Array.BinarySearch(Replay.ReplayTime, time);
 

--- a/Robust.Client/Replays/Playback/ReplayPlaybackManager.Update.cs
+++ b/Robust.Client/Replays/Playback/ReplayPlaybackManager.Update.cs
@@ -26,7 +26,7 @@ internal sealed partial class ReplayPlaybackManager
         if (ScrubbingTarget != null)
             SetIndex(ScrubbingTarget.Value, false);
 
-        if (Replay.CurrentIndex + 1 >= Replay.States.Count)
+        if (Replay.CurrentIndex + 1 >= Replay.Count)
             Playing = false;
 
         // TODO REPLAYS do we actually need to do this?

--- a/Robust.Client/Replays/Playback/ReplayPlaybackManager.cs
+++ b/Robust.Client/Replays/Playback/ReplayPlaybackManager.cs
@@ -131,6 +131,7 @@ internal sealed partial class ReplayPlaybackManager : IReplayPlaybackManager
         if (Replay == null)
             return;
 
+        var replay = Replay;
         _playing = false;
         Replay.CurrentIndex = -1;
         Replay = null;
@@ -140,6 +141,9 @@ internal sealed partial class ReplayPlaybackManager : IReplayPlaybackManager
         // Unload any uploaded prototypes & resources.
         _netResMan.ClearResources();
         _protoMan.Reset();
+
+        // Release the windowed data provider and the underlying replay file handle.
+        replay.Dispose();
 
         ReplayPlaybackStopped?.Invoke();
     }

--- a/Robust.Client/Replays/UI/ReplayControlWidget.cs
+++ b/Robust.Client/Replays/UI/ReplayControlWidget.cs
@@ -87,8 +87,8 @@ public sealed partial class ReplayControlWidget : UIWidget // AKA Tardis - The f
         }
 
         var percentage = (100 * TickSlider.GetAsRatio()).ToString("F2");
-        var maxIndex = Math.Max(1, replay.States.Count - 1);
-        var state = replay.States[index];
+        var maxIndex = Math.Max(1, replay.Count - 1);
+        var state = replay.GetState(index);
         var replayTime = TimeSpan.FromSeconds(TickSlider.Value);
         var end = replay.Duration == null ? "N/A" : replay.Duration.Value.ToString(TimeFormat);
 
@@ -96,7 +96,7 @@ public sealed partial class ReplayControlWidget : UIWidget // AKA Tardis - The f
             ("current", index), ("total", maxIndex), ("percentage", percentage));
 
         TickLabel.Text = Loc.GetString("replay-time-box-tick-label",
-            ("current", state.ToSequence), ("total", replay.States[^1].ToSequence), ("percentage", percentage));
+            ("current", state.ToSequence), ("total", replay.LastTick), ("percentage", percentage));
 
         TimeLabel.Text = Loc.GetString("replay-time-box-replay-time-label",
             ("current", replayTime.ToString(TimeFormat)), ("end", end), ("percentage", percentage));

--- a/Robust.Shared/CVars.cs
+++ b/Robust.Shared/CVars.cs
@@ -1918,6 +1918,14 @@ namespace Robust.Shared
         public static readonly CVarDef<int> ReplayWriteChannelSize = CVarDef.Create("replay.write_channel_size", 5);
 
         /// <summary>
+        /// Number of replay data blocks (each ≈ one <c>data_N</c> file) the client keeps resident in memory
+        /// at once during playback. The full replay is no longer loaded entirely into RAM; blocks are read
+        /// lazily and evicted (LRU) once this window is exceeded. Higher values use more memory but reduce
+        /// re-reads when scrubbing back and forth. Minimum effective value is 2.
+        /// </summary>
+        public static readonly CVarDef<int> ReplayLoadedBlockWindow = CVarDef.Create("replay.loaded_block_window", 8);
+
+        /// <summary>
         /// Whether or not server-side replay recording is enabled.
         /// </summary>
         public static readonly CVarDef<bool> ReplayServerRecordingEnabled = CVarDef.Create(

--- a/Robust.Shared/Replays/IReplayDataProvider.cs
+++ b/Robust.Shared/Replays/IReplayDataProvider.cs
@@ -1,0 +1,31 @@
+using System;
+using Robust.Shared.GameStates;
+
+namespace Robust.Shared.Replays;
+
+/// <summary>
+/// Provides access to the per-tick game states and messages of a replay.
+/// </summary>
+/// <remarks>
+/// This abstraction exists so that the playback code does not need to keep the entire replay
+/// (all <see cref="GameState"/>s and <see cref="ReplayMessage"/>s) resident in memory at once. A
+/// large replay can deserialize to tens of gigabytes; the client provides a windowed implementation
+/// (<c>BufferedReplayDataProvider</c>) that only keeps a handful of data blocks loaded at a time.
+/// </remarks>
+public interface IReplayDataProvider : IDisposable
+{
+    /// <summary>
+    /// The total number of ticks (states/messages) in the replay.
+    /// </summary>
+    int Count { get; }
+
+    /// <summary>
+    /// Get the game state for a given tick index. May trigger a (synchronous) load from disk.
+    /// </summary>
+    GameState GetState(int index);
+
+    /// <summary>
+    /// Get the networked messages for a given tick index. May trigger a (synchronous) load from disk.
+    /// </summary>
+    ReplayMessage GetMessages(int index);
+}

--- a/Robust.Shared/Replays/ReplayData.cs
+++ b/Robust.Shared/Replays/ReplayData.cs
@@ -16,17 +16,28 @@ namespace Robust.Shared.Replays;
 /// <summary>
 ///     This class contains data read from some replay recording.
 /// </summary>
-public sealed class ReplayData
+public sealed class ReplayData : IDisposable
 {
     /// <summary>
-    /// List of game states for each tick.
+    /// Provides the per-tick game states and messages. Backed by a windowed loader so that the whole
+    /// replay does not have to stay resident in memory (see <c>BufferedReplayDataProvider</c>).
     /// </summary>
-    public readonly List<GameState> States;
+    private readonly IReplayDataProvider _provider;
 
     /// <summary>
-    /// List of all networked messages and variables that were sent each tick.
+    /// The total number of ticks (states/messages) in this recording.
     /// </summary>
-    public readonly List<ReplayMessage> Messages;
+    public int Count => _provider.Count;
+
+    /// <summary>
+    /// Get the game state for a given tick index. May trigger a synchronous load from disk.
+    /// </summary>
+    public GameState GetState(int index) => _provider.GetState(index);
+
+    /// <summary>
+    /// Get the networked messages for a given tick index. May trigger a synchronous load from disk.
+    /// </summary>
+    public ReplayMessage GetMessages(int index) => _provider.GetMessages(index);
 
     /// <summary>
     /// Replay recording time for each corresponding entry in <see cref="States"/>. Starts at 0.
@@ -41,6 +52,12 @@ public sealed class ReplayData
     /// The first tick in this recording.
     /// </summary>
     public readonly GameTick TickOffset;
+
+    /// <summary>
+    /// The end tick (<see cref="GameState.ToSequence"/>) of the last state in this recording. Cached at load
+    /// time so the UI does not have to fetch the final (out-of-window) data block every frame.
+    /// </summary>
+    public readonly GameTick LastTick;
 
     /// <summary>
     /// The sever's time when the recording was started.
@@ -69,9 +86,9 @@ public sealed class ReplayData
     public GameTick LastApplied { get; internal set; }
 
     public GameTick CurTick => new GameTick((uint) CurrentIndex + TickOffset.Value);
-    public GameState CurState => States[CurrentIndex];
-    public GameState? NextState => CurrentIndex + 1 < States.Count ? States[CurrentIndex + 1] : null;
-    public ReplayMessage CurMessages => Messages[CurrentIndex];
+    public GameState CurState => _provider.GetState(CurrentIndex);
+    public GameState? NextState => CurrentIndex + 1 < Count ? _provider.GetState(CurrentIndex + 1) : null;
+    public ReplayMessage CurMessages => _provider.GetMessages(CurrentIndex);
 
     public TimeSpan CurrentReplayTime => ReplayTime[CurrentIndex];
 
@@ -90,10 +107,10 @@ public sealed class ReplayData
     /// </summary>
     public ReplayMessage? InitialMessages;
 
-    public ReplayData(List<GameState> states,
-        List<ReplayMessage> messages,
+    public ReplayData(IReplayDataProvider provider,
         TimeSpan[] replayTime,
         GameTick tickOffset,
+        GameTick lastTick,
         TimeSpan startTime,
         TimeSpan? duration,
         CheckpointState[] checkpointStates,
@@ -101,10 +118,10 @@ public sealed class ReplayData
         bool clientSideRecording,
         MappingDataNode yamlData)
     {
-        States = states;
-        Messages = messages;
+        _provider = provider;
         ReplayTime = replayTime;
         TickOffset = tickOffset;
+        LastTick = lastTick;
         StartTime = startTime;
         Duration = duration;
         Checkpoints = checkpointStates;
@@ -117,6 +134,14 @@ public sealed class ReplayData
         {
             Recorder = new NetUserId(guid);
         }
+    }
+
+    /// <summary>
+    /// Releases the underlying data provider (and the replay file handle it owns).
+    /// </summary>
+    public void Dispose()
+    {
+        _provider.Dispose();
     }
 }
 


### PR DESCRIPTION
## About the PR

The replay client currently deserializes the entire replay (every `GameState` and `ReplayMessage` of every tick) into two lists and keeps them resident for the whole viewing session. On long rounds this is tens of gigabytes of managed heap: a 1h38m round from a ~100-player server (861 MB zip) peaks at ~22 GB and a machine with 32 GB of RAM goes into swap, with long Gen2 GC pauses on top.

This PR makes both loading and playback stream the replay history from disk instead:

- **Playback**: `ReplayData` no longer holds `States`/`Messages` lists. It reads through the new `IReplayDataProvider`; `BufferedReplayDataProvider` keeps an LRU window of decoded data blocks (one block = one `data_N` file, ≈1 MB uncompressed) and lazily re-reads/decompresses blocks on demand. During linear playback a block boundary is crossed every few seconds, so the synchronous decode cost is negligible; scrubbing loads whichever blocks lie between the nearest checkpoint and the target tick. Window size is configurable via the `replay.loaded_block_window` cvar (default 8).
- **Loading**: checkpoint generation consumes the history strictly sequentially, so the history is streamed into it block-by-block through an enumerator. Each block is decoded, processed, and becomes garbage as soon as the cursor moves past it — the full history never exists in memory at once. The block index for the provider and first/last tick metadata are collected during the same single pass.
- Loading-screen progress for the combined pass is reported in data-block units as a single phase (the previous separate read/process phases would otherwise alternate every block).

Only the checkpoints and the live game state stay resident. The provider owns the `IReplayFileReader` and disposes it when the replay is unloaded.

## Numbers

Same replay (861 MB zip, 1h38m round, ~151k ticks) and scenario (load, jump to the middle, play) on the same machine, before/after:

| metric | before | after |
| --- | --- | --- |
| peak private bytes | 21.9 GB | 12.2 GB |
| peak working set | 18.6 GB | 11.1 GB |
| load time until playable | ~4.8 min | ~2.8 min |

<img width="1000" height="780" alt="Memory profile of the same replay before and after this PR" src="https://github.com/user-attachments/assets/092f6620-352a-4445-970f-3be88e43e996" />

Loading gets ~2× faster because the GC no longer has to grow and repeatedly walk a multi-gigabyte history heap. The remaining memory growth with replay length is checkpoint data; a possible follow-up is spilling checkpoints to disk, which would make peak memory mostly independent of replay length.

## Breaking changes

- `ReplayData.States` / `ReplayData.Messages` are replaced by `Count`, `GetState(index)`, `GetMessages(index)`.
- `IReplayLoadManager.GenerateCheckpointsAsync` is no longer public (its signature had to change to consume a stream; content does not call it).

Release notes entries are included.

## Testing

- Played back server-side recordings (start-to-finish playback, pausing, scrubbing forward/backward across checkpoint boundaries, jumping to the middle from the lobby).
- Memory profiles above were measured with an external sampler on the live client process; managed-heap breakdowns were verified earlier with `GC.GetTotalMemory` instrumentation.
- `Robust.Client` builds cleanly on top of current master; the feature has been in daily use on a downstream fork (RMC-14-based) since June.
