### PR TITLE
New Feature: ``before`` and ``after`` support for subscriptions through attributes

### DIFF
--- a/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
+++ b/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
@@ -77,7 +77,9 @@ public class EntitySystemSubscriptionGenerator : IIncrementalGenerator
                     productionContext.CancellationToken.ThrowIfCancellationRequested();
                     var subscriptionMethod = method.Type.ToSubscriptionMethod();
                     var typeArgs = string.Join(", ", method.TypeArgs);
-                    subscriptionsSyntax.AppendLine($"        {subscriptionMethod}<{typeArgs}>({method.MethodName});");
+                    var before = string.Join(", ", method.Before.Select(t => $"typeof({t})"));
+                    var after = string.Join(", ", method.After.Select(t => $"typeof({t})"));
+                    subscriptionsSyntax.AppendLine($"        {subscriptionMethod}<{typeArgs}>({method.MethodName}, [{before}], [{after}]);");
                 }
 
                 var builder = new StringBuilder(@"
@@ -220,11 +222,23 @@ using JetBrains.Annotations;
     )
     {
         if (annotationName.ToSubscriptionType() is not { } subType ||
-            !AttributeHelper.HasAttribute(method, annotationName, out _) ||
+            !AttributeHelper.HasAttribute(method, annotationName, out var attribute) ||
             parseFunc(method) is not { } parameters)
             return null;
 
-        return new SubscriptionInfo(method.Name, subType, parameters);
+        var args = attribute.ConstructorArguments;
+        return new SubscriptionInfo(method.Name, subType, parameters, GetTypes(args[0]), GetTypes(args[1]));
+    }
+
+    /// <summary>
+    /// Gets an array of type names from the typed constant.
+    /// </summary>
+    private static ImmutableArray<string> GetTypes(TypedConstant constant)
+    {
+        if (constant.IsNull || constant.Kind != TypedConstantKind.Array)
+            return [];
+
+        return [.. constant.Values.Select(v => (v.Value as ITypeSymbol)!.ToDisplayString())];
     }
 
     /// Aggregates all of the <typeparamref name="T"/>s across all the given providers into a single array value
@@ -244,5 +258,5 @@ using JetBrains.Annotations;
 
     private record struct EntitySystemInfo(PartialTypeInfo Type, EquatableArray<SubscriptionInfo> Subscriptions);
 
-    private record struct SubscriptionInfo(string MethodName, SubscriptionType Type, EquatableArray<string> TypeArgs);
+    private record struct SubscriptionInfo(string MethodName, SubscriptionType Type, EquatableArray<string> TypeArgs, EquatableArray<string> Before, EquatableArray<string> After);
 }

--- a/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
+++ b/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
@@ -77,9 +77,11 @@ public class EntitySystemSubscriptionGenerator : IIncrementalGenerator
                     productionContext.CancellationToken.ThrowIfCancellationRequested();
                     var subscriptionMethod = method.Type.ToSubscriptionMethod();
                     var typeArgs = string.Join(", ", method.TypeArgs);
-                    var before = string.Join(", ", method.Before.Select(t => $"typeof({t})"));
-                    var after = string.Join(", ", method.After.Select(t => $"typeof({t})"));
-                    subscriptionsSyntax.AppendLine($"        {subscriptionMethod}<{typeArgs}>({method.MethodName}, [{before}], [{after}]);");
+
+                    var before = method.Before.HasValue ? ("[" + string.Join(", ", method.Before.Value.Select(t => $"typeof({t})")) + "]") : "null";
+                    var after = method.After.HasValue ? ("[" + string.Join(", ", method.After.Value.Select(t => $"typeof({t})")) + "]") : "null";
+
+                    subscriptionsSyntax.AppendLine($"        {subscriptionMethod}<{typeArgs}>({method.MethodName}, {before}, {after});");
                 }
 
                 var builder = new StringBuilder(@"
@@ -233,10 +235,10 @@ using JetBrains.Annotations;
     /// <summary>
     /// Gets an array of type names from the typed constant.
     /// </summary>
-    private static ImmutableArray<string> GetTypes(TypedConstant constant)
+    private static ImmutableArray<string>? GetTypes(TypedConstant constant)
     {
         if (constant.IsNull || constant.Kind != TypedConstantKind.Array)
-            return [];
+            return null;
 
         return [.. constant.Values.Select(v => (v.Value as ITypeSymbol)!.ToDisplayString())];
     }
@@ -258,5 +260,5 @@ using JetBrains.Annotations;
 
     private record struct EntitySystemInfo(PartialTypeInfo Type, EquatableArray<SubscriptionInfo> Subscriptions);
 
-    private record struct SubscriptionInfo(string MethodName, SubscriptionType Type, EquatableArray<string> TypeArgs, EquatableArray<string> Before, EquatableArray<string> After);
+    private record struct SubscriptionInfo(string MethodName, SubscriptionType Type, EquatableArray<string> TypeArgs, EquatableArray<string>? Before, EquatableArray<string>? After);
 }

--- a/Robust.Shared/Analyzers/EntitySystemSubscriptionsGeneratorAttributes.cs
+++ b/Robust.Shared/Analyzers/EntitySystemSubscriptionsGeneratorAttributes.cs
@@ -24,7 +24,18 @@ namespace Robust.Shared.Analyzers;
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
 [MeansImplicitUse]
-public sealed class SubscribeLocalEventAttribute : Attribute;
+public sealed class SubscribeLocalEventAttribute(Type[]? before = null, Type[]? after = null) : Attribute
+{
+    /// <summary>
+    /// Systems that this event subscription should run before.
+    /// </summary>
+    public readonly Type[]? Before = before;
+
+    /// <summary>
+    /// Systems that this event subscription should run after.
+    /// </summary>
+    public readonly Type[]? After = after;
+}
 
 /// <summary>
 /// This attribute indicates that the annotated method is a handler for an event subscription. Methods annotated with
@@ -41,7 +52,18 @@ public sealed class SubscribeLocalEventAttribute : Attribute;
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
 [MeansImplicitUse]
-public sealed class SubscribeNetworkEventAttribute : Attribute;
+public sealed class SubscribeNetworkEventAttribute(Type[]? before = null, Type[]? after = null) : Attribute
+{
+    /// <summary>
+    /// Systems that this event subscription should run before.
+    /// </summary>
+    public readonly Type[]? Before = before;
+
+    /// <summary>
+    /// Systems that this event subscription should run after.
+    /// </summary>
+    public readonly Type[]? After = after;
+}
 
 /// <summary>
 /// This attribute indicates that the annotated method is a handler for an event subscription. Methods annotated with
@@ -58,4 +80,15 @@ public sealed class SubscribeNetworkEventAttribute : Attribute;
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
 [MeansImplicitUse]
-public sealed class EventSubscriptionAttribute : Attribute;
+public sealed class EventSubscriptionAttribute(Type[]? before = null, Type[]? after = null) : Attribute
+{
+    /// <summary>
+    /// Systems that this event subscription should run before.
+    /// </summary>
+    public readonly Type[]? Before = before;
+
+    /// <summary>
+    /// Systems that this event subscription should run after.
+    /// </summary>
+    public readonly Type[]? After = after;
+}


### PR DESCRIPTION
Fixes #6706.

## Example subscription
```cs
[SubscribeLocalEvent([typeof(EmptyOnMachineDeconstructSystem), typeof(ItemSlotsSystem)])]
private void OnMachineDeconstructed(Entity<IdCardConsoleComponent> entity, ref MachineDeconstructedEvent args)
```

## Generated code
```cs

// <auto-generated />

using Robust.Shared.GameObjects;
using JetBrains.Annotations;

#pragma warning disable CS0618 // Type or member is obsolete: event handlers will have their own obsoletion warnings, dont need to dupe them

namespace Content.Server.Access.Systems;

public partial class IdCardConsoleSystem
{
    /// <inheritdoc />
    [MustCallBase]
    public override void AutoSubscriptions()
    {
        base.AutoSubscriptions();

        SubscribeLocalEvent<Content.Shared.Access.Components.IdCardConsoleComponent, Content.Shared.Construction.MachineDeconstructedEvent>(OnMachineDeconstructed, [typeof(Content.Server.Containers.EmptyOnMachineDeconstructSystem), typeof(Content.Shared.Containers.ItemSlots.ItemSlotsSystem)], null);

    }
}
```
