### PR TITLE
Add SCREEN_UV to shaders

### DIFF
--- a/Robust.Client/Graphics/Clyde/Clyde.Constants.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Constants.cs
@@ -15,13 +15,15 @@ namespace Robust.Client.Graphics.Clyde
         private const int UniITexturePixelSize = 2;
         private const int UniIMainTexture = 3;
         private const int UniILightTexture = 4;
-        private const int UniCount = 5;
+        private const int UniIScreenUvRect = 5;
+        private const int UniCount = 6;
 
         private const string UniModUV = "modifyUV";
         private const string UniModelMatrix = "modelMatrix";
         private const string UniTexturePixelSize = "TEXTURE_PIXEL_SIZE";
         private const string UniMainTexture = "TEXTURE";
         private const string UniLightTexture = "lightMap"; // TODO CLYDE consistent shader variable naming
+        private const string UniScreenUvRect = "SCREEN_UV_RECT";
         private const string UniProjViewMatrices = "projectionViewMatrices";
         private const string UniUniformConstants = "uniformConstants";
 

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -515,56 +515,65 @@ namespace Robust.Client.Graphics.Clyde
             IReadOnlyList<SpriteComponent.PostShaderEntry> postShaders)
         {
             var source = entityPostRenderTarget;
+            var screenUvRect = GetEntityPostShaderScreenUvRect(screenSize, roundedPos, spriteRenderTargetSize);
+            var oldScreenUvRect = _queuedScreenUvRect;
 
-            for (var i = 0; i < postShaders.Count; i++)
+            DrawSetScreenUvRect(screenUvRect);
+            try
             {
-                var finalPass = i == postShaders.Count - 1;
-                var shader = postShaders[i].Shader;
-
-                if (finalPass)
+                for (var i = 0; i < postShaders.Count; i++)
                 {
-                    DrawRenderTarget(renderTarget.Handle);
-                    _renderHandle.Viewport(Box2i.FromDimensions(Vector2i.Zero, screenSize));
-                    // The sprite has already been drawn into a transparent RT, so its color is already multiplied
-                    // by alpha. Use premultiplied blending for the final viewport composite to avoid applying
-                    // translucent sprite alpha twice. Stuff like an interaction outline would make the entire sprite double transparent.
-                    _renderHandle.UseShader(GetPremultipliedBlendShaderInstance(shader));
-                    CalcScreenMatrices(screenSize, out var finalProj, out var finalView);
-                    _renderHandle.SetProjView(finalProj, finalView);
+                    var finalPass = i == postShaders.Count - 1;
+                    var shader = postShaders[i].Shader;
+
+                    if (finalPass)
+                    {
+                        DrawRenderTarget(renderTarget.Handle);
+                        _renderHandle.Viewport(Box2i.FromDimensions(Vector2i.Zero, screenSize));
+                        // The sprite has already been drawn into a transparent RT, so its color is already multiplied
+                        // by alpha. Use premultiplied blending for the final viewport composite to avoid applying
+                        // translucent sprite alpha twice. Stuff like an interaction outline would make the entire sprite double transparent.
+                        _renderHandle.UseShader(GetPremultipliedBlendShaderInstance(shader));
+                        CalcScreenMatrices(screenSize, out var finalProj, out var finalView);
+                        _renderHandle.SetProjView(finalProj, finalView);
+                        _renderHandle.SetModelTransform(Matrix3x2.Identity);
+
+                        var rounded = roundedPos - spriteRenderTargetSize / 2;
+                        var finalBox = Box2i.FromDimensions(rounded, spriteRenderTargetSize);
+
+                        _renderHandle.DrawTextureScreen(source.Texture,
+                            finalBox.TopLeft, finalBox.TopRight, finalBox.BottomLeft, finalBox.BottomRight,
+                            Color.White, GetEntityPostRenderTargetSubRegion(source, spriteRenderTargetSize));
+                        continue;
+                    }
+
+                    DebugTools.AssertNotNull(entityPostRenderTarget2);
+                    var destination = source == entityPostRenderTarget ? entityPostRenderTarget2! : entityPostRenderTarget;
+
+                    _renderHandle.UseRenderTarget(destination);
+                    _renderHandle.Clear(default, 0, ClearBufferMask.ColorBufferBit);
+                    _renderHandle.Viewport(Box2i.FromDimensions(Vector2i.Zero, destination.Size));
+                    // Intermediate post-shader passes are texture transforms. Write the
+                    // shader output directly so stuff like alpha-cut passes do not get alpha-applied before the final viewport draw.
+                    // The easiest way to know if this happens is your sprite getting darker / changing from the multiple passes when it shouldn't be.
+                    _renderHandle.UseShader(GetNoBlendShaderInstance(shader));
+                    CalcScreenMatrices(destination.Size, out var intermediateProj, out var intermediateView);
+                    _renderHandle.SetProjView(intermediateProj, intermediateView);
                     _renderHandle.SetModelTransform(Matrix3x2.Identity);
 
-                    var rounded = roundedPos - spriteRenderTargetSize / 2;
-                    var finalBox = Box2i.FromDimensions(rounded, spriteRenderTargetSize);
-
+                    var intermediateBox = GetEntityPostRenderTargetBox(destination, spriteRenderTargetSize);
                     _renderHandle.DrawTextureScreen(source.Texture,
-                        finalBox.TopLeft, finalBox.TopRight, finalBox.BottomLeft, finalBox.BottomRight,
+                        intermediateBox.TopLeft, intermediateBox.TopRight, intermediateBox.BottomLeft, intermediateBox.BottomRight,
                         Color.White, GetEntityPostRenderTargetSubRegion(source, spriteRenderTargetSize));
-                    continue;
+
+                    source = destination;
                 }
-
-                DebugTools.AssertNotNull(entityPostRenderTarget2);
-                var destination = source == entityPostRenderTarget ? entityPostRenderTarget2! : entityPostRenderTarget;
-
-                _renderHandle.UseRenderTarget(destination);
-                _renderHandle.Clear(default, 0, ClearBufferMask.ColorBufferBit);
-                _renderHandle.Viewport(Box2i.FromDimensions(Vector2i.Zero, destination.Size));
-                // Intermediate post-shader passes are texture transforms. Write the
-                // shader output directly so stuff like alpha-cut passes do not get alpha-applied before the final viewport draw.
-                // The easiest way to know if this happens is your sprite getting darker / changing from the multiple passes when it shouldn't be.
-                _renderHandle.UseShader(GetNoBlendShaderInstance(shader));
-                CalcScreenMatrices(destination.Size, out var intermediateProj, out var intermediateView);
-                _renderHandle.SetProjView(intermediateProj, intermediateView);
-                _renderHandle.SetModelTransform(Matrix3x2.Identity);
-
-                var intermediateBox = GetEntityPostRenderTargetBox(destination, spriteRenderTargetSize);
-                _renderHandle.DrawTextureScreen(source.Texture,
-                    intermediateBox.TopLeft, intermediateBox.TopRight, intermediateBox.BottomLeft, intermediateBox.BottomRight,
-                    Color.White, GetEntityPostRenderTargetSubRegion(source, spriteRenderTargetSize));
-
-                source = destination;
+            }
+            finally
+            {
+                DrawSetScreenUvRect(oldScreenUvRect);
             }
         }
-
         private static UIBox2? GetEntityPostRenderTargetSubRegion(RenderTexture renderTarget, Vector2i size)
         {
             if (renderTarget.Size == size)
@@ -578,6 +587,20 @@ namespace Robust.Client.Graphics.Clyde
         {
             var offset = (renderTarget.Size - size) / 2;
             return Box2i.FromDimensions(offset, size);
+        }
+
+        private static Vector4 GetEntityPostShaderScreenUvRect(Vector2i screenSize, Vector2i roundedPos, Vector2i size)
+        {
+            var topLeft = roundedPos - size / 2;
+            var bottomRight = topLeft + size;
+
+            // SCREEN_UV follows gl_FragCoord / screenSize, so the y origin is bottom-left.
+            // SCREEN_UV_RECT is bottom-left/top-right because UV2.y is 0 at the quad bottom and 1 at the top.
+            return new Vector4(
+                topLeft.X / (float) screenSize.X,
+                1f - bottomRight.Y / (float) screenSize.Y,
+                bottomRight.X / (float) screenSize.X,
+                1f - topLeft.Y / (float) screenSize.Y);
         }
 
         private void DrawLoadingScreen(IRenderHandle handle)

--- a/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Helpers.cs
@@ -84,6 +84,7 @@ namespace Robust.Client.Graphics.Clyde
         {
             ProjViewUBO.Apply(program);
             UniformConstantsUBO.Apply(program);
+            program.SetUniformMaybe(UniIScreenUvRect, _queuedScreenUvRect);
             if (!_hasGLSrgb)
             {
                 program.SetUniformMaybe("SRGB_EMU_CONFIG",

--- a/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs
@@ -80,6 +80,9 @@ namespace Robust.Client.Graphics.Clyde
 
         private ClydeShaderInstance _queuedShaderInstance = default!;
 
+        private static readonly Vector4 DefaultScreenUvRect = new(0, 0, 1, 1);
+        private Vector4 _queuedScreenUvRect = DefaultScreenUvRect;
+
         // Current projection & view matrices that are being used ot render.
         // This gets updated to keep track during (queue) and (misc), but not during (submit).
         private Matrix3x2 _currentMatrixProj;
@@ -296,6 +299,7 @@ namespace Robust.Client.Graphics.Clyde
             program.SetUniformMaybe(UniIModelMatrix, command.ModelMatrix);
             // Reset ModUV to ensure it's identity and doesn't touch anything.
             program.SetUniformMaybe(UniIModUV, new Vector4(0, 0, 1, 1));
+            program.SetUniformMaybe(UniIScreenUvRect, command.ScreenUvRect);
 
             program.SetUniformMaybe(UniITexturePixelSize, Vector2.One / loadedTexture.Size);
 
@@ -367,6 +371,7 @@ namespace Robust.Client.Graphics.Clyde
             // Reset renderer state.
             _currentMatrixModel = Matrix3x2.Identity;
             _queuedShaderInstance = _defaultShader;
+            _queuedScreenUvRect = DefaultScreenUvRect;
             SetScissorFull(null);
         }
 
@@ -933,6 +938,15 @@ namespace Robust.Client.Graphics.Clyde
             _queuedShaderInstance = instance;
         }
 
+        private void DrawSetScreenUvRect(in Vector4 screenUvRect)
+        {
+            if (_queuedScreenUvRect == screenUvRect)
+                return;
+
+            BreakBatch();
+            _queuedScreenUvRect = screenUvRect;
+        }
+
         private void DrawClear(Color color, int stencil, ClearBufferMask mask)
         {
             BreakBatch();
@@ -977,7 +991,8 @@ namespace Robust.Client.Graphics.Clyde
                 if (metaData.TextureId == textureId &&
                     indexed == metaData.Indexed &&
                     metaData.PrimitiveType == primitiveType &&
-                    metaData.ShaderInstance == shaderInstance)
+                    metaData.ShaderInstance == shaderInstance &&
+                    metaData.ScreenUvRect == _queuedScreenUvRect)
                 {
                     // Data matches, don't have to do anything.
                     return;
@@ -989,7 +1004,7 @@ namespace Robust.Client.Graphics.Clyde
 
             // ... and start another.
             _batchMetaData = new BatchMetaData(textureId, indexed, primitiveType,
-                indexed ? BatchIndexIndex : BatchVertexIndex, shaderInstance);
+                indexed ? BatchIndexIndex : BatchVertexIndex, shaderInstance, _queuedScreenUvRect);
 
             /*
             if (textureId != default)
@@ -1022,6 +1037,7 @@ namespace Robust.Client.Graphics.Clyde
             command.DrawBatch.PrimitiveType = metaData.PrimitiveType;
             command.DrawBatch.TextureId = metaData.TextureId;
             command.DrawBatch.ShaderInstance = metaData.ShaderInstance;
+            command.DrawBatch.ScreenUvRect = metaData.ScreenUvRect;
 
             command.DrawBatch.Count = currentIndex - metaData.StartIndex;
             command.DrawBatch.ModelMatrix = Matrix3x2.Identity;
@@ -1079,6 +1095,7 @@ namespace Robust.Client.Graphics.Clyde
                 _currentBoundRenderTarget,
                 _currentRenderTarget,
                 _queuedShaderInstance,
+                _queuedScreenUvRect,
                 _currentScissorState,
                 _glCaps);
         }
@@ -1089,6 +1106,7 @@ namespace Robust.Client.Graphics.Clyde
             BindRenderTargetImmediate(state.BoundRenderTarget);
 
             _queuedShaderInstance = state.QueuedShaderInstance;
+            _queuedScreenUvRect = state.ScreenUvRect;
             _currentRenderTarget = state.RenderTarget;
             var (width, height) = state.BoundRenderTarget.Size;
             GL.Viewport(0, 0, width, height);
@@ -1121,6 +1139,7 @@ namespace Robust.Client.Graphics.Clyde
             BindRenderTargetFull(_mainWindow!.RenderTarget);
             _batchMetaData = null;
             _queuedShaderInstance = _defaultShader;
+            _queuedScreenUvRect = DefaultScreenUvRect;
 
             GL.Viewport(0, 0, _mainWindow!.FramebufferSize.X, _mainWindow!.FramebufferSize.Y);
         }
@@ -1197,6 +1216,8 @@ namespace Robust.Client.Graphics.Clyde
             public bool Indexed;
             public BatchPrimitiveType PrimitiveType;
 
+            public Vector4 ScreenUvRect;
+
             // TODO: this makes the render commands so much more large please remove.
             public Matrix3x2 ModelMatrix;
         }
@@ -1268,15 +1289,17 @@ namespace Robust.Client.Graphics.Clyde
             public readonly BatchPrimitiveType PrimitiveType;
             public readonly int StartIndex;
             public readonly ClydeHandle ShaderInstance;
+            public readonly Vector4 ScreenUvRect;
 
             public BatchMetaData(ClydeHandle textureId, bool indexed, BatchPrimitiveType primitiveType,
-                int startIndex, ClydeHandle shaderInstance)
+                int startIndex, ClydeHandle shaderInstance, Vector4 screenUvRect)
             {
                 TextureId = textureId;
                 Indexed = indexed;
                 PrimitiveType = primitiveType;
                 StartIndex = startIndex;
                 ShaderInstance = shaderInstance;
+                ScreenUvRect = screenUvRect;
             }
         }
 
@@ -1298,6 +1321,7 @@ namespace Robust.Client.Graphics.Clyde
             public readonly LoadedRenderTarget BoundRenderTarget;
             public readonly LoadedRenderTarget RenderTarget;
             public readonly ClydeShaderInstance QueuedShaderInstance;
+            public readonly Vector4 ScreenUvRect;
 
             public readonly UIBox2i? ScissorState;
 
@@ -1309,6 +1333,7 @@ namespace Robust.Client.Graphics.Clyde
                 LoadedRenderTarget boundRenderTarget,
                 LoadedRenderTarget renderTarget,
                 ClydeShaderInstance queuedShaderInstance,
+                Vector4 screenUvRect,
                 UIBox2i? scissorState,
                 GLCaps glcaps
                 )
@@ -1318,6 +1343,7 @@ namespace Robust.Client.Graphics.Clyde
                 BoundRenderTarget = boundRenderTarget;
                 RenderTarget = renderTarget;
                 QueuedShaderInstance = queuedShaderInstance;
+                ScreenUvRect = screenUvRect;
 
                 ScissorState = scissorState;
                 GLCaps = glcaps;

--- a/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
+++ b/Robust.Client/Graphics/Clyde/GLObjects/Clyde.ShaderProgram.cs
@@ -191,6 +191,9 @@ namespace Robust.Client.Graphics.Clyde
                     case UniITexturePixelSize:
                         name = UniTexturePixelSize;
                         break;
+                    case UniIScreenUvRect:
+                        name = UniScreenUvRect;
+                        break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }

--- a/Robust.Client/Graphics/Clyde/Shaders/base-default.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-default.frag
@@ -1,10 +1,14 @@
-// UV coordinates in texture-space. I.e., (0,0) is the corner of the texture currently being used to draw.
+﻿// UV coordinates in texture-space. I.e., (0,0) is the corner of the texture currently being used to draw.
 // When drawing a sprite from a texture atlas, (0,0) is the corner of the atlas, not the specific sprite being drawn.
 varying highp vec2 UV;
 
 // UV coordinates in quad-space. I.e., when drawing a sprite from a texture atlas (0,0) is the corner of the sprite
 // currently being drawn.
 varying highp vec2 UV2;
+
+// UV coordinates in viewport screen-space. For sprite post-shaders, this stays relative to the original viewport
+// even when the shader is rendered through an intermediate render target.
+varying highp vec2 SCREEN_UV;
 
 // TBH I'm not sure what this is for. I think it is scree  UV coordiantes, i.e., FRAGCOORD.xy * SCREEN_PIXEL_SIZE ?
 // TODO CLYDE Is this still needed?

--- a/Robust.Client/Graphics/Clyde/Shaders/base-default.vert
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-default.vert
@@ -8,6 +8,7 @@
 
 varying vec2 UV;
 varying vec2 UV2;
+varying vec2 SCREEN_UV;
 varying vec2 Pos;
 varying vec4 VtxModulate;
 
@@ -18,6 +19,7 @@ uniform mat3 modelMatrix;
 // Allows us to do texture atlassing with texture coordinates 0->1
 // Input texture coordinates get mapped to this range.
 uniform vec4 modifyUV;
+uniform vec4 SCREEN_UV_RECT;
 // TODO CLYDE Is this still needed?
 
 // [SHADER_HEADER_CODE]
@@ -40,6 +42,7 @@ void main()
     Pos = (VERTEX + 1.0) / 2.0;
     UV = mix(modifyUV.xy, modifyUV.zw, tCoord);
     UV2 = tCoord2;
+    SCREEN_UV = mix(SCREEN_UV_RECT.xy, SCREEN_UV_RECT.zw, tCoord2);
 
     // Negative modulation is being used as a hacky way to squeeze in lighting data.
     // I.e., negative modulation implies we ignore the lighting.

--- a/Robust.Client/Graphics/Clyde/Shaders/base-raw.frag
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-raw.frag
@@ -1,5 +1,6 @@
 varying highp vec2 UV;
 varying highp vec2 UV2;
+varying highp vec2 SCREEN_UV;
 
 // TODO CLYDE consistent shader variable naming
 uniform sampler2D lightMap;

--- a/Robust.Client/Graphics/Clyde/Shaders/base-raw.vert
+++ b/Robust.Client/Graphics/Clyde/Shaders/base-raw.vert
@@ -8,6 +8,7 @@
 
 varying vec2 UV;
 varying vec2 UV2;
+varying vec2 SCREEN_UV;
 
 // Maybe we should merge these CPU side.
 // idk yet.
@@ -16,6 +17,7 @@ uniform mat3 modelMatrix;
 // Allows us to do texture atlassing with texture coordinates 0->1
 // Input texture coordinates get mapped to this range.
 uniform vec4 modifyUV;
+uniform vec4 SCREEN_UV_RECT;
 
 vec2 pixel_snap(vec2 vertex)
 {
@@ -43,6 +45,7 @@ void main()
 
     UV = tCoord;
     UV2 = tCoord2;
+    SCREEN_UV = mix(SCREEN_UV_RECT.xy, SCREEN_UV_RECT.zw, tCoord2);
 
     // [SHADER_CODE]
 


### PR DESCRIPTION
Postshaders are being drawn without any knowledge of the screen texture and the stealth shader on content needs to know its screen coords unfortunately.