### PR TITLE
Remove redundant MsgEntity data

### DIFF
--- a/Robust.Shared/Network/Messages/MsgEntity.cs
+++ b/Robust.Shared/Network/Messages/MsgEntity.cs
@@ -18,8 +18,6 @@ namespace Robust.Shared.Network.Messages
         public EntityMessageType Type { get; set; }
 
         public EntityEventArgs SystemMessage { get; set; }
-        public EntityUid EntityUid { get; set; }
-        public uint NetId { get; set; }
         public uint Sequence { get; set; }
         public GameTick SourceTick { get; set; }
 


### PR DESCRIPTION
No idea how long these have been unused but it adds overhead to every single networked event in the game and didn't want to wait for my other PR.