### PR TITLE
Fix stickykeys bug

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -271,18 +271,18 @@ namespace Robust.Client.GameStates
 
         public void InputCommandDispatched(ClientFullInputCmdMessage clientMessage, FullInputCmdMessage message)
         {
+            message.InputSequence = _nextInputCmdSeq++;
+
             if (!IsPredictionEnabled)
             {
                 return;
             }
 
-            message.InputSequence = _nextInputCmdSeq;
             _pendingInputs.Enqueue(message);
 
             _inputManager.NetworkBindMap.TryGetKeyFunction(message.InputFunctionId, out var boundFunc);
             _sawmill.Debug(
-                $"CL> SENT tick={_timing.CurTick}, sub={_timing.TickFraction}, seq={_nextInputCmdSeq}, func={boundFunc.FunctionName}, state={message.State}");
-            _nextInputCmdSeq++;
+                $"CL> SENT tick={_timing.CurTick}, sub={_timing.TickFraction}, seq={message.InputSequence}, func={boundFunc.FunctionName}, state={message.State}");
         }
 
         public uint SystemMessageDispatched<T>(T message) where T : EntityEventArgs

--- a/Robust.Server.IntegrationTests/GameObjects/ServerEntityNetworkManagerTest.cs
+++ b/Robust.Server.IntegrationTests/GameObjects/ServerEntityNetworkManagerTest.cs
@@ -1,7 +1,10 @@
 using Moq;
 using NUnit.Framework;
+using Robust.Client.GameStates;
 using Robust.Server.GameObjects;
 using Robust.Shared.GameObjects;
+using Robust.Shared.Input;
+using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Network.Messages;
 using Robust.Shared.Timing;
@@ -41,6 +44,74 @@ namespace Robust.Server.IntegrationTests.GameObjects
             Assert.That(pq.Take(), Is.EqualTo(msgC));
             Assert.That(pq.Take(), Is.EqualTo(msgB));
             Assert.That(pq.Take(), Is.EqualTo(msgD));
+        }
+
+        [Test]
+        public void TestSequencedMessagesDoNotMoveBackwardsInTime()
+        {
+            var state = new ServerEntityManager.SequencedMessageState();
+            var channel = new Mock<INetChannel>().Object;
+            var function = new KeyFunctionId(0);
+            var down = new MsgEntity()
+            {
+                MsgChannel = channel,
+                Type = EntityMessageType.SystemMessage,
+                SystemMessage = new FullInputCmdMessage(
+                    new GameTick(120),
+                    0,
+                    function,
+                    BoundKeyState.Down,
+                    NetCoordinates.Invalid,
+                    ScreenCoordinates.Invalid,
+                    NetEntity.Invalid),
+                SourceTick = new GameTick(120),
+                Sequence = 100,
+            };
+            var up = new MsgEntity()
+            {
+                MsgChannel = channel,
+                Type = EntityMessageType.SystemMessage,
+                SystemMessage = new FullInputCmdMessage(
+                    new GameTick(115),
+                    0,
+                    function,
+                    BoundKeyState.Up,
+                    NetCoordinates.Invalid,
+                    ScreenCoordinates.Invalid,
+                    NetEntity.Invalid),
+                SourceTick = new GameTick(115),
+                Sequence = 101,
+            };
+
+            Assert.That(state.Queue(down), Is.True);
+            Assert.That(state.Queue(up), Is.True);
+            Assert.That(up.SourceTick, Is.EqualTo(down.SourceTick));
+
+            var pq = new PriorityQueue<MsgEntity>(new ServerEntityManager.MessageSequenceComparer())
+            {
+                down,
+                up,
+            };
+
+            Assert.That(pq.Take(), Is.EqualTo(down));
+            Assert.That(pq.Take(), Is.EqualTo(up));
+        }
+
+        [Test]
+        public void TestSequencedMessagesRejectStaleSequences()
+        {
+            var state = new ServerEntityManager.SequencedMessageState();
+
+            var first = new MsgEntity() {SourceTick = new GameTick(120), Sequence = 100};
+            var duplicate = new MsgEntity() {SourceTick = new GameTick(121), Sequence = 100};
+            var alreadyProcessed = new MsgEntity() {SourceTick = new GameTick(122), Sequence = 99};
+
+            Assert.That(state.Queue(first), Is.True);
+            Assert.That(state.Queue(duplicate), Is.False);
+
+            var processedState = new ServerEntityManager.SequencedMessageState();
+            Assert.That(processedState.MarkProcessed(100), Is.True);
+            Assert.That(processedState.Queue(alreadyProcessed), Is.False);
         }
     }
 }

--- a/Robust.Server/GameObjects/EntitySystems/InputSystem.cs
+++ b/Robust.Server/GameObjects/EntitySystems/InputSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Robust.Server.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.GameObjects;
@@ -51,8 +52,21 @@ namespace Robust.Server.GameObjects
 
             var session = eventArgs.SenderSession;
 
-            if (_lastProcessedInputCmd[session] < msg.InputSequence)
-                _lastProcessedInputCmd[session] = msg.InputSequence;
+            if (msg.InputSequence != 0)
+            {
+                ref var lastProcessedInput = ref CollectionsMarshal.GetValueRefOrAddDefault(
+                    _lastProcessedInputCmd,
+                    session,
+                    out _);
+
+                // Dump stale inputs so they don't overwrite current input state.
+                // Client increments its input sequence on every input but that doesn't guarantee the order the server receives
+                // them in.
+                if (msg.InputSequence <= lastProcessedInput)
+                    return;
+
+                lastProcessedInput = msg.InputSequence;
+            }
 
             // set state, only bound key functions get state changes
             var states = GetInputStates(session);

--- a/Robust.Server/GameObjects/ServerEntityManager.cs
+++ b/Robust.Server/GameObjects/ServerEntityManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using Prometheus;
 using Robust.Server.GameStates;
@@ -143,7 +144,8 @@ namespace Robust.Server.GameObjects
 
         private readonly PriorityQueue<MsgEntity> _queue = new(new MessageSequenceComparer());
 
-        private readonly Dictionary<ICommonSession, uint> _lastProcessedSequencesCmd =
+        // Sequenced client messages need scheduling state per session; SourceTick alone can reorder them.
+        private readonly Dictionary<ICommonSession, SequencedMessageState> _sequencedMessageStates =
             new();
 
         private bool _logLateMsgs;
@@ -187,7 +189,9 @@ namespace Robust.Server.GameObjects
 
         public uint GetLastMessageSequence(ICommonSession? session)
         {
-            return session == null ? default : _lastProcessedSequencesCmd.GetValueOrDefault(session);
+            return session != null && _sequencedMessageStates.TryGetValue(session, out var state)
+                ? state.LastProcessedSequence
+                : 0;
         }
 
         /// <inheritdoc />
@@ -234,7 +238,25 @@ namespace Robust.Server.GameObjects
                 }
             }
 
+            if (!QueueEntityNetworkMessage(message))
+                return;
+
             _queue.Add(message);
+        }
+
+        private bool QueueEntityNetworkMessage(MsgEntity message)
+        {
+            if (message.Sequence == 0 || !message.MsgChannel.IsConnected)
+                return true;
+
+            var player = _playerManager.GetSessionByChannel(message.MsgChannel);
+            ref var state = ref CollectionsMarshal.GetValueRefOrAddDefault(
+                _sequencedMessageStates,
+                player,
+                out _);
+
+            // Preserve reliable stream order while still using SourceTick as the eligibility tick.
+            return state.Queue(message);
         }
 
         private void DispatchEntityNetworkMessage(MsgEntity message)
@@ -249,10 +271,14 @@ namespace Robust.Server.GameObjects
 
             if (message.Sequence != 0)
             {
-                if (_lastProcessedSequencesCmd[player] < message.Sequence)
-                {
-                    _lastProcessedSequencesCmd[player] = message.Sequence;
-                }
+                ref var state = ref CollectionsMarshal.GetValueRefOrAddDefault(
+                    _sequencedMessageStates,
+                    player,
+                    out _);
+
+                // Stale queued messages must not overwrite newer input state.
+                if (!state.MarkProcessed(message.Sequence))
+                    return;
             }
 
 #if EXCEPTION_TOLERANCE
@@ -284,12 +310,70 @@ namespace Robust.Server.GameObjects
             switch (args.NewStatus)
             {
                 case SessionStatus.Connected:
-                    _lastProcessedSequencesCmd.Add(args.Session, 0);
+                    _sequencedMessageStates.Add(args.Session, default);
                     break;
 
                 case SessionStatus.Disconnected:
-                    _lastProcessedSequencesCmd.Remove(args.Session);
+                    _sequencedMessageStates.Remove(args.Session);
                     break;
+            }
+        }
+
+        /// <summary>
+        /// Per-session state for preserving client sequence order through SourceTick scheduling.
+        /// </summary>
+        internal struct SequencedMessageState
+        {
+            /// <summary>
+            /// Highest sequenced message that has been dispatched to systems.
+            /// </summary>
+            public uint LastProcessedSequence;
+
+            /// <summary>
+            /// Highest sequenced message admitted to the scheduling queue.
+            /// </summary>
+            public uint LastQueuedSequence;
+
+            /// <summary>
+            /// Last effective SourceTick assigned to a queued sequenced message.
+            /// </summary>
+            public GameTick LastScheduledTick;
+
+            /// <summary>
+            /// Validates a newly arrived sequenced message before queueing.
+            /// </summary>
+            public bool Queue(MsgEntity message)
+            {
+                if (message.Sequence == 0)
+                    return true;
+
+                if (message.Sequence <= LastProcessedSequence || message.Sequence <= LastQueuedSequence)
+                    return false;
+
+                if (message.SourceTick < LastScheduledTick)
+                {
+                    // Do not let a later sequence execute before an earlier message.
+                    message.SourceTick = LastScheduledTick;
+                }
+                else
+                {
+                    LastScheduledTick = message.SourceTick;
+                }
+
+                LastQueuedSequence = message.Sequence;
+                return true;
+            }
+
+            /// <summary>
+            /// Marks a queued sequenced message as dispatched, rejecting stale duplicates.
+            /// </summary>
+            public bool MarkProcessed(uint sequence)
+            {
+                if (sequence <= LastProcessedSequence)
+                    return false;
+
+                LastProcessedSequence = sequence;
+                return true;
             }
         }
 


### PR DESCRIPTION
- Client sends inputs with an always-incrementing uint.
- Server can receive these in any order and not necessarily for the same tick, so we drop any earlier ones we get (if for older ticks) so they don't overwrite the current state.

So there's 2 instances where client inputs get "stuck", one I know for a certainty:
- Losing window focus means SDL doesn't process inputs anymore so any held keys don't get released (see https://github.com/space-wizards/RobustToolbox/pull/6851).
- With network OR frame lag inputs seemingly get dropped. Part of the issue is MsgEntity is reliableordered (which wraps input commands) but with lag the client may not necessarily run states as per the normal path of input events simply going up, so we just rely on the InputSequence as the processing order.