### PR TITLE
Fix WordWrap bugs

### DIFF
--- a/Robust.Client.Tests/UserInterface/WordWrapTest.cs
+++ b/Robust.Client.Tests/UserInterface/WordWrapTest.cs
@@ -1,0 +1,89 @@
+using NUnit.Framework;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using System.Text;
+
+namespace Robust.Client.Tests.UserInterface;
+
+[Parallelizable(ParallelScope.All)]
+public sealed class WordWrapTest
+{
+    private List<int> GenerateBreaks(string s, int maxWidth)
+    {
+        var breaksOut = new List<int>();
+        var wrapper = new WordWrap(maxSizeX: maxWidth);
+
+        // For simplicity, assume every character has the same width, except for some special ones
+        var charMetrics = new CharMetrics (bearingX: 0, bearingY: 0, advance: 10, width: 10, height: 10);
+        var wideMetrics = new CharMetrics (bearingX: 0, bearingY: 0, advance: 25, width: 25, height: 10);
+        var narrowMetrics = new CharMetrics (bearingX: 0, bearingY: 0, advance: 6, width: 6, height: 10);
+
+        foreach (var r in s.EnumerateRunes())
+        {
+            wrapper.NextRune(r, out var breakLine, out var breakNewLine, out var skip);
+            if (breakLine != null)
+            {
+                breaksOut.Add(breakLine.Value);
+            }
+            if (breakNewLine != null)
+            {
+                breaksOut.Add(breakNewLine.Value);
+            }
+            if (skip)
+            {
+                continue;
+            }
+
+            var metrics = charMetrics;
+            if (r == new Rune('W'))
+            {
+                metrics = wideMetrics;
+            }
+            else if (r == new Rune('|'))
+            {
+                metrics = narrowMetrics;
+            }
+
+            wrapper.NextMetrics(metrics, out breakLine, out var abort);
+
+            if (breakLine != null)
+            {
+                breaksOut.Add(breakLine.Value);
+            }
+            if (abort)
+            {
+                return breaksOut;
+            }
+        }
+
+        return breaksOut;
+    }
+
+    [Test]
+    // Basic wrapping. First two words fit on one line, need a break to fit the third
+    //Breaks at:   v
+    [TestCase("1 3 123", 50, new int[]{4})]
+    // Basic wrapping, over more lines:
+    //Breaks at:   v     v
+    [TestCase("1 3 123 5 1234", 50, new int[]{4, 10})]
+    // Word doesn't fit on one line, need to break mid-word
+    //Breaks at:    v
+    [TestCase("12345123", 50, new int[]{5})]
+    // Word doesn't fit on *two* lines, needs two breaks mid-word
+    //Breaks at:    v    v
+    [TestCase("1234512345123", 50, new int[]{5, 10})]
+    // Same,  but with some words at the start
+    //Breaks at:   v    v    v
+    [TestCase("1 3 12345123451", 50, new int[]{4, 9, 14})]
+    // Can fit first two words on one line, need a break for the third word and needs splitting mid-word
+    //Breaks at:   v    v
+    [TestCase("1 3 12345123", 50, new int[]{4, 9})]
+    // Check for a debug assert in WordWrap. Second word needs an extra split on the last character
+    //Breaks at:   v   v
+    [TestCase("123 1|34W ", 50, new int[]{4, 8})]
+    public void TestSimpleWrapping(string s, int maxWidth, int[] expectedBreaks)
+    {
+        var breaks = GenerateBreaks(s, maxWidth);
+        Assert.That(breaks, Is.EqualTo(expectedBreaks));
+    }
+}

--- a/Robust.Client/UserInterface/WordWrap.cs
+++ b/Robust.Client/UserInterface/WordWrap.cs
@@ -25,9 +25,6 @@ internal struct WordWrap
     // The horizontal position of the text cursor.
     public int PosX;
     public Rune LastRune;
-    // If a word is larger than maxSizeX, we split it.
-    // We need to keep track of some data to split it into two words.
-    public (int breakIndex, int wordSizePixels)? ForceSplitData = null;
 
     public WordWrap(float maxSizeX)
     {
@@ -75,7 +72,6 @@ internal struct WordWrap
             //wordSize = 0;
             WordSizePixels = 0;
             WordStartBreakIndex = (BreakIndexCounter, PosX);
-            ForceSplitData = null;
 
             // Just manually handle newlines.
             if (rune == new Rune('\n'))
@@ -110,21 +106,15 @@ internal struct WordWrap
         // Break the "word" at the last word index
         if (WordStartBreakIndex.HasValue && oldWordSizePixels != 0)
         {
-            breakLine = WordStartBreakIndex!.Value.index;
+            breakLine = WordStartBreakIndex.Value.index;
             MaxUsedWidth = Math.Max(MaxUsedWidth, WordStartBreakIndex.Value.lineSize);
             PosX = WordSizePixels;
-        }
-
-        if (!ForceSplitData.HasValue)
-        {
-            ForceSplitData = (BreakIndexCounter, oldWordSizePixels);
         }
 
         // Oh hey we get to break a word that doesn't fit on a single line.
         if (WordSizePixels > _maxSizeX)
         {
-            var (breakIndex, splitWordSize) = ForceSplitData.Value;
-            if (splitWordSize == 0)
+            if (oldWordSizePixels == 0)
             {
                 // Happens if there's literally not enough space for a single character so uh...
                 // Yeah just don't.
@@ -132,10 +122,8 @@ internal struct WordWrap
                 return;
             }
 
-            // Reset forceSplitData so that we can split again if necessary.
-            ForceSplitData = null;
-            breakLine = breakIndex;
-            WordSizePixels -= splitWordSize;
+            breakLine = BreakIndexCounter;
+            WordSizePixels -= oldWordSizePixels;
             WordStartBreakIndex = null;
             MaxUsedWidth = Math.Max(MaxUsedWidth, _maxSizeX);
             PosX = WordSizePixels;
@@ -161,7 +149,6 @@ internal struct WordWrap
                 Logger.Error($"wordSizePixels: {WordSizePixels}");
                 Logger.Error($"posX: {PosX}");
                 Logger.Error($"lastChar: {LastRune}");
-                Logger.Error($"forceSplitData: {ForceSplitData}");
                 // Logger.Error($"LineBreaks: {string.Join(", ", LineBreaks)}");
 
                 throw new Exception(


### PR DESCRIPTION
When testing https://github.com/space-wizards/space-station-14/pull/45085, I hit an assert in WordWrap; it's caused by the same issue which causes the strange wrapping described in https://github.com/space-wizards/RobustToolbox/pull/6393#issuecomment-4960932950

Reproing the assert is fairly straightforward; build content in debug and spawn a "paper". Empty paper has placeholder text "This page intentionally left blank" - resize the paper window so it's around the width of the word "intentionally". Maybe wiggle the mouse around a little bit; you'll hit the assert eventually. I've added some new tests, and running them at revision c0568fda5967d79f8d80a1327645990c2c1222dd will also repro the assert.

Reproing the wrapping also straightforward. Write on the paper with:

> asdf asdf aVeryLongWordThatNeedsToBeSplitMultipleTimes asdf asdf
 
Then resize the paper window, note the weird line breaks at locations that don't really make sense:

https://github.com/user-attachments/assets/d5c3e4dc-95ba-420e-8957-4cbba30942c3

Both of these problems were coming from the same issue - the WordWrap had a field `ForceSplitData`, which stored the index of the first rune which causes the current line to overflow. As best I can tell (paging Mr. Chesterson), this was trying to handle the case where, if a word needed splitting on account of being longer than a single line, the start of that word could be placed on the current line, optimizing vertical space. i.e.

```
asdf asdf aVer
yLongWordThatN
eedsTo...
```

but this `ForceSplitData` conflicted with the "split at a word boundary" code that handles the rest of the splitting. The assert was being hit because we were seeing two conflicting split locations - one at the `ForceSplitData` and one at the location where the full word no longer fits on a single line.

That kind of split above is also different to how every other gui text tool wraps (at least, the ones I've tested.) - those tools would *not* try to optimize vertical space and would instead lay the text out like:

```
asdf asdf
aVeryLongWordT
hatNeedsTo...
```

This PR just removes that `ForceSplitData` entirely, which makes the wrapping behave a lot more sane (and not hit asserts):


https://github.com/user-attachments/assets/43170601-000c-4a28-b4d1-0aa93cf9cc5b

