### PR TITLE
Add and use CopyNoType to MappingDataNode, don't copy in ComponentRegistrySerializer.Read

### DIFF
--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -1200,8 +1200,7 @@ namespace Robust.Shared.Prototypes
                         continue;
                     }
 
-                    var copy = componentMapping.Copy();
-                    copy.Remove("type");
+                    var copy = componentMapping.CopyNoType();
                     _tempMappingData[type.Value] = copy;
                 }
             }

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -1032,7 +1032,7 @@ namespace Robust.Shared.Prototypes
             {
                 throw new InvalidImplementationException(kind,
                     typeof(IPrototype),
-                    $"Duplicate prototype type ID: {attribute.Type}. Current: {existing}");
+                    $"Duplicate prototype type ID: {name}. Current: {existing}");
             }
 
             var foundIdAttribute = false;

--- a/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
@@ -266,6 +266,25 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
             return newMapping;
         }
 
+        internal MappingDataNode CopyNoType()
+        {
+            var newMapping = new MappingDataNode(_children.Count)
+            {
+                Tag = Tag,
+                Start = Start,
+                End = End
+            };
+
+            foreach (var (key, val) in _list)
+            {
+                if (key != "type")
+                    newMapping.Add(key, val.Copy());
+            }
+
+            newMapping._keyNodes = _keyNodes;
+            return newMapping;
+        }
+
         /// <summary>
         /// Variant of <see cref="Copy"/> that doesn't clone the keys or values.
         /// </summary>

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
@@ -132,9 +132,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
 
                 referenceTypes[refIdx++] = compIdx;
 
-                var copy = componentMapping.Copy();
-                copy.Remove("type");
-
+                var copy = componentMapping.CopyNoType();
                 list.Add(serializationManager.ValidateNode(registration.Type, copy, context));
             }
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
@@ -69,10 +69,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
 
                 referenceTypes[refIdx++] = compIdx;
 
-                var copy = componentMapping.Copy()!;
-                copy.Remove("type");
-
-                var read = (IComponent)serializationManager.Read(registration.Type, copy, hookCtx, context)!;
+                var read = (IComponent)serializationManager.Read(registration.Type, componentMapping, hookCtx, context)!;
 
                 // The full YAML mapping is already retained by PrototypeManager.
                 components[compType] = new ComponentRegistryEntry(read);


### PR DESCRIPTION
No copy faster than copy, also removing "type" is way slower than just not copying it in the first place
Also fixes an exception message being incorrect in PrototypeManager
Needs https://github.com/space-wizards/space-station-14/pull/45150