### PR TITLE
Make ComponentRegistrySerializer.Read 3.7 times faster

### DIFF
--- a/Robust.Serialization.Generator/Generator.cs
+++ b/Robust.Serialization.Generator/Generator.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Robust.Roslyn.Shared;
 using static Robust.Roslyn.Shared.DataDefinitionHelper;
 using static Robust.Serialization.Generator.CustomSerializerType;
 using static Robust.Serialization.Generator.Types;
@@ -36,6 +37,7 @@ public class Generator : IIncrementalGenerator
     private const string SequenceDataNodeName = "Robust.Shared.Serialization.Markdown.Sequence.SequenceDataNode";
     private const string ValueDataNodeName = "Robust.Shared.Serialization.Markdown.Value.ValueDataNode";
     private const string EntityUidName = "Robust.Shared.GameObjects.EntityUid";
+    private const string ComponentName = "Robust.Shared.GameObjects.Component";
 
     public void Initialize(IncrementalGeneratorInitializationContext initContext)
     {
@@ -193,7 +195,7 @@ public class Generator : IIncrementalGenerator
 
                 {{GetCopiers(definition)}}
 
-                {{GetReader(definition)}}
+                {{GetReaders(definition)}}
 
                 {{GetWriter(definition)}}
 
@@ -612,6 +614,41 @@ public class Generator : IIncrementalGenerator
         return builder.ToString();
     }
 
+    private static string GetReadCompMethod(DataDefinition definition)
+    {
+        var inheritsComp = TypeSymbolHelper.Inherits(definition.Type, ComponentName);
+        if (!inheritsComp)
+        {
+            if (!TypeSymbolHelper.ShittyTypeMatch(definition.Type, ComponentName)) return string.Empty;
+
+            return """
+                public virtual void ReadComp(
+                    ref Component target,
+                    MappingDataNode mappingDataNode,
+                    ISerializationManager serialization,
+                    SerializationHookContext hookCtx,
+                    ISerializationContext? context)
+                {
+                    Component.Read(ref target, mappingDataNode, serialization, hookCtx, context);
+                }
+                """;
+        }
+
+        return $$"""
+            public override void ReadComp(
+                ref Component target,
+                MappingDataNode mappingDataNode,
+                ISerializationManager serialization,
+                SerializationHookContext hookCtx,
+                ISerializationContext? context)
+            {
+                var cast = ({{definition.GenericTypeName}}) target;
+                {{definition.GenericTypeName}}.Read(ref cast, mappingDataNode, serialization, hookCtx, context);
+                target = (Component) cast;
+            }
+            """;
+    }
+
     private static string GetInstantiators(DataDefinition definition)
     {
         var builder = new StringBuilder();
@@ -773,32 +810,8 @@ public class Generator : IIncrementalGenerator
         if (!definition.IsDataDefinition(type, out _))
             return;
 
-        var sameType = definition.Type.Equals(type, SymbolEqualityComparer.Default) &&
-                       targetType == definition.GenericTypeName &&
-                       targetType != "object";
-        var isSealedOrStruct = definition.Type.IsSealed || definition.Type.IsValueType;
         var isAbstract = definition.Type.IsAbstract;
-        var isInterface = definition.Type.TypeKind == TypeKind.Interface;
-        var modifier = (sameType, targetType == "object", isSealedOrStruct, isInterface) switch
-        {
-            (true, _, true, _) => string.Empty,
-            (true, _, false, _) => "virtual ",
-            (false, true, true, _) => string.Empty,
-            (false, true, false, _) => "virtual ",
-            (false, false, _, true) => string.Empty,
-            (false, false, _, false) => "override ",
-        };
-
-        if (!sameType && targetType == "object" && forceOverride)
-            modifier = "override ";
-
-        if (forceOverride && modifier is "" or "virtual ")
-        {
-            if (modifier is "")
-                modifier += "override ";
-            else if (modifier == "virtual ")
-                modifier = "override ";
-        }
+        var modifier = GetModifier(definition, type, targetType, forceOverride, out var sameType);
 
         builder.AppendLine($"""
             public {modifier}void Copy(
@@ -876,7 +889,43 @@ public class Generator : IIncrementalGenerator
         }
     }
 
-    private static string GetReader(DataDefinition definition)
+    private static object GetModifier(
+        DataDefinition definition,
+        ITypeSymbol type,
+        string targetType,
+        bool forceOverride,
+        out bool sameType)
+    {
+        sameType = definition.Type.Equals(type, SymbolEqualityComparer.Default) &&
+                       targetType == definition.GenericTypeName &&
+                       targetType != "object";
+        var isSealedOrStruct = definition.Type.IsSealed || definition.Type.IsValueType;
+        var isInterface = definition.Type.TypeKind == TypeKind.Interface;
+        var modifier = (sameType, targetType == "object", isSealedOrStruct, isInterface) switch
+        {
+            (true, _, true, _) => string.Empty,
+            (true, _, false, _) => "virtual ",
+            (false, true, true, _) => string.Empty,
+            (false, true, false, _) => "virtual ",
+            (false, false, _, true) => string.Empty,
+            (false, false, _, false) => "override ",
+        };
+
+        if (!sameType && targetType == "object" && forceOverride)
+            modifier = "override ";
+
+        if (forceOverride && modifier is "" or "virtual ")
+        {
+            if (modifier is "")
+                modifier += "override ";
+            else if (modifier == "virtual ")
+                modifier = "override ";
+        }
+
+        return modifier;
+    }
+
+    private static string GetReaders(DataDefinition definition)
     {
         string body;
         if (definition.Type.IsAbstract)
@@ -947,6 +996,8 @@ public class Generator : IIncrementalGenerator
             {
                 {{body}}
             }
+
+            {{GetReadCompMethod(definition)}}
             """;
     }
 

--- a/Robust.Shared/Serialization/ISerializationGenerated.cs
+++ b/Robust.Shared/Serialization/ISerializationGenerated.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Definition;
-using Robust.Shared.Serialization.Markdown;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using Robust.Shared.Serialization.Markdown.Validation;
 
@@ -11,6 +11,7 @@ using Robust.Shared.Serialization.Markdown.Validation;
 
 namespace Robust.Shared.Serialization;
 
+[NotContentImplementable]
 public interface ISerializationGenerated<T> : ISerializationGenerated
 {
     /// <seealso cref="ISerializationManager.CreateCopy"/>
@@ -43,6 +44,18 @@ public interface ISerializationGenerated<T> : ISerializationGenerated
     [Obsolete("Use ISerializationManager.Read instead")]
     static virtual void Read(
         ref T target,
+        MappingDataNode mappingDataNode,
+        ISerializationManager serialization,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <seealso cref="ISerializationManager.Read"/>
+    [Obsolete("Use ISerializationManager.Read instead")]
+    void ReadComp(
+        ref Component target,
         MappingDataNode mappingDataNode,
         ISerializationManager serialization,
         SerializationHookContext hookCtx,
@@ -92,6 +105,7 @@ public interface ISerializationGenerated<T> : ISerializationGenerated
     }
 }
 
+[NotContentImplementable]
 public interface ISerializationGenerated
 {
     /// <seealso cref="ISerializationManager.CopyTo"/>

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
@@ -18,9 +18,13 @@ using static Robust.Shared.Prototypes.EntityPrototype;
 namespace Robust.Shared.Serialization.TypeSerializers.Implementations
 {
     [TypeSerializer]
-    public sealed partial class ComponentRegistrySerializer : BaseTypeSerializer, ITypeSerializer<ComponentRegistry, SequenceDataNode>, ITypeInheritanceHandler<ComponentRegistry, SequenceDataNode>, ITypeCopier<ComponentRegistry>
+    public sealed partial class ComponentRegistrySerializer : BaseTypeSerializer, ITypeSerializer<ComponentRegistry, SequenceDataNode>, ITypeInheritanceHandler<ComponentRegistry, SequenceDataNode>, ITypeCopier<ComponentRegistry>,
+        IPostInjectInit
     {
+        [Dependency] private IDynamicTypeFactory _dynamicTypeFactory = default!;
         [Dependency] private IComponentFactory _factory = default!;
+
+        private IDynamicTypeFactoryInternal _dynamicTypeFactoryInternal = default!;
 
         public ComponentRegistry Read(ISerializationManager serializationManager,
             SequenceDataNode node,
@@ -36,7 +40,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             foreach (var sequenceEntry in node.Sequence)
             {
                 var componentMapping = (MappingDataNode)sequenceEntry;
-                string compType = ((ValueDataNode) componentMapping.Get("type")).Value;
+                var compType = ((ValueDataNode) componentMapping.Get("type")).Value;
                 // See if type exists to detect errors.
                 switch (_factory.GetComponentAvailability(compType))
                 {
@@ -51,16 +55,10 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                         continue;
                 }
 
-                // Has this type already been added?
-                if (components.ContainsKey(compType))
-                {
-                    Log.Error($"Component of type '{compType}' defined twice in prototype!");
-                    continue;
-                }
-
                 var registration = _factory.GetRegistration(compType);
                 var compIdx = registration.Idx;
 
+                // Has this type already been added?
                 if (referenceTypes[..refIdx].Contains(compIdx))
                 {
                     throw new InvalidOperationException(
@@ -69,13 +67,15 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
 
                 referenceTypes[refIdx++] = compIdx;
 
-                var copy = componentMapping.Copy()!;
-                copy.Remove("type");
-
-                var read = (IComponent)serializationManager.Read(registration.Type, copy, hookCtx, context)!;
+                var comp = (Component) _dynamicTypeFactoryInternal.CreateInstanceUnchecked(registration.Type, inject: false);
+#pragma warning disable CS0618 // Type or member is obsolete
+                comp = comp.Instantiate();
+#pragma warning restore CS0618 // Type or member is obsolete
+                comp.ReadComp(ref comp, componentMapping, serializationManager, hookCtx, context);
+                SerializationManager.TryRunAfterHook(comp, hookCtx);
 
                 // The full YAML mapping is already retained by PrototypeManager.
-                components[compType] = new ComponentRegistryEntry(read);
+                components[compType] = new ComponentRegistryEntry(comp);
             }
 
             return components;
@@ -227,6 +227,11 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
             }
 
             return dict;
+        }
+
+        void IPostInjectInit.PostInject()
+        {
+            _dynamicTypeFactoryInternal = (IDynamicTypeFactoryInternal) _dynamicTypeFactory;
         }
     }
 }


### PR DESCRIPTION
34 seconds > 9 seconds on my puter for test startup on debug (all threads)
Adds a source generated method for reading comps which is equivalent to the path before unless you are using a type serializer, which we are not and neither should we for comps
Also removes a redundant ContainsKey check