### PR TITLE
Replace some usages of object reads with generic type reads

### DIFF
--- a/Robust.Shared/Audio/SoundSpecifierTypeSerializer.cs
+++ b/Robust.Shared/Audio/SoundSpecifierTypeSerializer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.Manager;
@@ -27,6 +28,7 @@ public sealed class SoundSpecifierTypeSerializer :
         if (hasCollection)
             return typeof(SoundCollectionSpecifier);
 
+        // See Read below if you are adding new types
         return typeof(SoundPathSpecifier);
     }
 
@@ -35,7 +37,15 @@ public sealed class SoundSpecifierTypeSerializer :
         ISerializationManager.InstantiationDelegate<SoundSpecifier>? instanceProvider = null)
     {
         var type = GetType(node);
-        return (SoundSpecifier)serializationManager.Read(type, node, hookCtx, context)!;
+
+        if (type == typeof(SoundPathSpecifier))
+            return serializationManager.Read<SoundPathSpecifier>(node, hookCtx, context, notNullableOverride: true);
+
+        if (type == typeof(SoundCollectionSpecifier))
+            return serializationManager.Read<SoundCollectionSpecifier>(node, hookCtx, context, notNullableOverride: true);
+
+        // See GetType above if you are adding new types
+        throw new NotImplementedException();
     }
 
     public SoundSpecifier Read(ISerializationManager serializationManager, ValueDataNode node,

--- a/Robust.Shared/EntitySerialization/MapChunkSerializer.cs
+++ b/Robust.Shared/EntitySerialization/MapChunkSerializer.cs
@@ -35,7 +35,7 @@ internal sealed class MapChunkSerializer : ITypeSerializer<MapChunk, MappingData
         ISerializationContext? context = null,
         ISerializationManager.InstantiationDelegate<MapChunk>? instantiationDelegate = null)
     {
-        var ind = (Vector2i) serializationManager.Read(typeof(Vector2i), node["ind"], hookCtx, context)!;
+        var ind = serializationManager.Read<Vector2i>(node["ind"], hookCtx, context)!;
         var tileNode = (ValueDataNode)node["tiles"];
         var tileBytes = Convert.FromBase64String(tileNode.Value);
 
@@ -49,9 +49,7 @@ internal sealed class MapChunkSerializer : ITypeSerializer<MapChunk, MappingData
 
         // TODO: This should be on the context I think?
         if (node.TryGet("size", out ValueDataNode? sizeNode))
-        {
-            size = (ushort) serializationManager.Read(typeof(ushort), sizeNode, context)!;
-        }
+            size = serializationManager.Read<ushort>(sizeNode, context)!;
 
         var chunk = instantiationDelegate != null ? instantiationDelegate() : new MapChunk(ind.X, ind.Y, size);
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/AbstractDictionarySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/AbstractDictionarySerializer.cs
@@ -42,8 +42,9 @@ public sealed class AbstractDictionarySerializer<TValue> : ITypeSerializer<Dicti
         foreach (var (key, valueNode) in node.Children)
         {
             var type = serializationManager.ReflectionManager.YamlTypeTagLookup(typeof(TValue), key)!;
-            valueNode.Tag = key;
-            var value = serializationManager.Read<TValue>(valueNode, hookCtx, context, notNullableOverride: true);
+            var copy = valueNode.Copy();
+            copy.Tag = $"!type:{key}";
+            var value = serializationManager.Read<TValue>(copy, hookCtx, context, notNullableOverride: true);
             dict.Add(type, value);
         }
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/AbstractDictionarySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/AbstractDictionarySerializer.cs
@@ -42,7 +42,8 @@ public sealed class AbstractDictionarySerializer<TValue> : ITypeSerializer<Dicti
         foreach (var (key, valueNode) in node.Children)
         {
             var type = serializationManager.ReflectionManager.YamlTypeTagLookup(typeof(TValue), key)!;
-            var value = (TValue) serializationManager.Read(type, valueNode, hookCtx, context, notNullableOverride:true)!;
+            valueNode.Tag = key;
+            var value = serializationManager.Read<TValue>(valueNode, hookCtx, context, notNullableOverride: true);
             dict.Add(type, value);
         }
 


### PR DESCRIPTION
Saves you a visit to the _readBoxingDelegates dictionary
Content equivalent (not needed to merge this) https://github.com/space-wizards/space-station-14/pull/45149