### PR TITLE
Refactor PVS detach queue

### DIFF
--- a/Robust.Client.IntegrationTests/GameStates/GameStateProcessor_Tests.cs
+++ b/Robust.Client.IntegrationTests/GameStates/GameStateProcessor_Tests.cs
@@ -2,6 +2,7 @@ using Moq;
 using NUnit.Framework;
 using Robust.Client.GameStates;
 using Robust.Client.Timing;
+using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.Log;
 using Robust.Shared.Timing;
@@ -163,6 +164,55 @@ namespace Robust.UnitTesting.Client.GameStates
             Assert.That(curState, Is.Not.Null);
         }
 
+        [Test]
+        public void PvsDetachMergesMessagesWithSameTick()
+        {
+            var (_, processor) = SetupEmptyProcessor();
+            var tick = new GameTick(5);
+
+            processor.AddLeavePvsMessage(new() { Ent(1), Ent(2) }, tick);
+            processor.AddLeavePvsMessage(new() { Ent(3) }, tick);
+
+            var result = processor.GetEntitiesToDetach(tick, 10);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Tick, Is.EqualTo(tick));
+            Assert.That(result[0].Entities, Is.EqualTo(new[] { Ent(1), Ent(2), Ent(3) }));
+        }
+
+        [Test]
+        public void PvsDetachProcessesOldestTickFirst()
+        {
+            var (_, processor) = SetupEmptyProcessor();
+
+            processor.AddLeavePvsMessage(new() { Ent(10) }, new GameTick(10));
+            processor.AddLeavePvsMessage(new() { Ent(5) }, new GameTick(5));
+
+            var result = processor.GetEntitiesToDetach(new GameTick(10), 10);
+
+            Assert.That(result, Has.Count.EqualTo(2));
+            Assert.That(result[0].Tick, Is.EqualTo(new GameTick(5)));
+            Assert.That(result[1].Tick, Is.EqualTo(new GameTick(10)));
+        }
+
+        [Test]
+        public void PvsDetachPartialBudgetKeepsRemainingEntities()
+        {
+            var (_, processor) = SetupEmptyProcessor();
+            var tick = new GameTick(1);
+            processor.AddLeavePvsMessage(new() { Ent(1), Ent(2), Ent(3) }, tick);
+
+            var result = processor.GetEntitiesToDetach(tick, 2);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Entities, Is.EqualTo(new[] { Ent(2), Ent(3) }));
+
+            result = processor.GetEntitiesToDetach(tick, 10);
+            Assert.That(result, Has.Count.EqualTo(1));
+            Assert.That(result[0].Entities, Is.EqualTo(new[] { Ent(1) }));
+        }
+
+
         /// <summary>
         ///     Creates a new empty GameState with the given to and from properties.
         /// </summary>
@@ -170,6 +220,25 @@ namespace Robust.UnitTesting.Client.GameStates
         {
             return new(new GameTick(@from), new GameTick(to), 0, default, default, default);
         }
+
+        private static NetEntity Ent(int id) => new(id);
+
+        private static (IClientGameTiming timing, GameStateProcessor processor) SetupEmptyProcessor()
+        {
+            var timingMock = new Mock<IClientGameTiming>();
+            timingMock.SetupProperty(p => p.CurTick);
+            timingMock.SetupProperty(p => p.LastProcessedTick);
+            timingMock.SetupProperty(p => p.LastRealTick);
+            timingMock.SetupProperty(p => p.TickTimingAdjustment);
+
+            var timing = timingMock.Object;
+            var managerMock = new Mock<IClientGameStateManager>();
+            var logMock = new Mock<ISawmill>();
+            var processor = new GameStateProcessor(managerMock.Object, timing, logMock.Object);
+
+            return (timing, processor);
+        }
+
 
         /// <summary>
         ///     Creates a new GameTiming and GameStateProcessor, fills the processor with enough states, and calculate the first tick.

--- a/Robust.Client/GameStates/GameStateProcessor.cs
+++ b/Robust.Client/GameStates/GameStateProcessor.cs
@@ -20,7 +20,7 @@ namespace Robust.Client.GameStates
 
         private readonly List<GameState> _stateBuffer = new();
 
-        private readonly Dictionary<GameTick, List<NetEntity>> _pvsDetachMessages = new();
+        private readonly List<(GameTick Tick, List<NetEntity> Entities)> _pvsDetachMessages = new();
         public GameState? LastFullState { get; private set; }
         public bool WaitingForFull => LastFullStateRequested.HasValue;
         public (GameTick Tick, DateTime Time)? LastFullStateRequested { get; private set; } = (GameTick.Zero, DateTime.MaxValue);
@@ -312,7 +312,38 @@ Had full state: {LastFullState != null}"
         {
             // Late message may still need to be processed,
             DebugTools.Assert(entities.Count > 0);
-            _pvsDetachMessages.TryAdd(tick, entities);
+
+            // Typically detaches are sorted by tick.
+            var count = _pvsDetachMessages.Count;
+            if (count == 0)
+            {
+                _pvsDetachMessages.Add((tick, entities));
+                return;
+            }
+
+            var lastTick = _pvsDetachMessages[count - 1].Tick;
+            if (tick == lastTick)
+            {
+                _pvsDetachMessages[count - 1].Entities.AddRange(entities);
+                return;
+            }
+
+            // Normal path of new tick so just add to the end.
+            if (tick > lastTick)
+            {
+                _pvsDetachMessages.Add((tick, entities));
+                return;
+            }
+
+            // This is the slow path if the message is out of order
+            var index = FindDetachMessageIndex(tick);
+            if (index >= 0)
+            {
+                _pvsDetachMessages[index].Entities.AddRange(entities);
+                return;
+            }
+
+            _pvsDetachMessages.Insert(~index, (tick, entities));
         }
 
         public void ClearDetachQueue() => _pvsDetachMessages.Clear();
@@ -320,15 +351,24 @@ Had full state: {LastFullState != null}"
         public List<(GameTick Tick, List<NetEntity> Entities)> GetEntitiesToDetach(GameTick toTick, int budget)
         {
             var result = new List<(GameTick Tick, List<NetEntity> Entities)>();
-            foreach (var (tick, entities) in _pvsDetachMessages)
+
+            if (budget <= 0)
+                return result;
+
+            var removeCount = 0;
+            for (var i = 0; i < _pvsDetachMessages.Count; i++)
             {
+                if (budget <= 0)
+                    break;
+
+                var (tick, entities) = _pvsDetachMessages[i];
                 if (tick > toTick)
-                    continue;
+                    break;
 
                 if (budget >= entities.Count)
                 {
                     budget -= entities.Count;
-                    _pvsDetachMessages.Remove(tick);
+                    removeCount++;
                     result.Add((tick, entities));
                     continue;
                 }
@@ -338,9 +378,38 @@ Had full state: {LastFullState != null}"
                 entities.RemoveRange(index, budget);
                 break;
             }
+
+            if (removeCount > 0)
+                _pvsDetachMessages.RemoveRange(0, removeCount);
+
             return result;
         }
 
+        private int FindDetachMessageIndex(GameTick tick)
+        {
+            // Bad binary search if we need to scrape ticks.
+            var low = 0;
+            var high = _pvsDetachMessages.Count - 1;
+            while (low <= high)
+            {
+                var mid = low + ((high - low) / 2);
+                var midTick = _pvsDetachMessages[mid].Tick;
+                if (midTick < tick)
+                {
+                    low = mid + 1;
+                }
+                else if (midTick > tick)
+                {
+                    high = mid - 1;
+                }
+                else
+                {
+                    return mid;
+                }
+            }
+
+            return ~low;
+        }
         private bool TryGetDeltaState(out GameState? curState, out GameState? nextState)
         {
             curState = null;
@@ -454,9 +523,9 @@ Had full state: {LastFullState != null}"
         public bool IsQueuedForDetach(NetEntity entity)
         {
             // This isn't fast, but its just meant for use in tests & debug asserts.
-            foreach (var msg in _pvsDetachMessages.Values)
+            foreach (var (_, entities) in _pvsDetachMessages)
             {
-                if (msg.Contains(entity))
+                if (entities.Contains(entity))
                     return true;
             }
 


### PR DESCRIPTION
Use a list over dictionary as it's faster than scanning every tick + adding is faster.

The only path where this will be slower is if the tick is old / out of order.