### PR TITLE
Add support for Sun Microsystems Help through Cut keys

### DIFF
--- a/Resources/Locale/en-US/input.ftl
+++ b/Resources/Locale/en-US/input.ftl
@@ -78,4 +78,15 @@ input-key-RSystem-mac = Right ⌘
 input-key-LSystem-linux = Left Meta
 input-key-RSystem-linux = Right Meta
 
+input-key-Help = Help
+input-key-Stop = Stop
+input-key-Again = Again
+input-key-Prop = Props
+input-key-Undo = Undo
+input-key-Cut = Cut
+input-key-Copy = Copy
+input-key-Open = Open
+input-key-Paste = Paste
+input-key-Find = Find
+
 input-key-unknown = <unknown key>

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Key.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Key.cs
@@ -205,6 +205,16 @@ internal partial class Clyde
             MapKey(SC.SDL_SCANCODE_PAUSE, Key.Pause);
             MapKey(SC.SDL_SCANCODE_CAPSLOCK, Key.CapsLock);
             MapKey(SC.SDL_SCANCODE_SCROLLLOCK, Key.ScrollLock);
+            MapKey(SC.SDL_SCANCODE_HELP, Key.Help);
+            MapKey(SC.SDL_SCANCODE_CANCEL, Key.Stop);
+            MapKey(SC.SDL_SCANCODE_AGAIN, Key.Again);
+            MapKey(SC.SDL_SCANCODE_AC_PROPERTIES, Key.Props);
+            MapKey(SC.SDL_SCANCODE_UNDO, Key.Undo);
+            MapKey(SC.SDL_SCANCODE_CUT, Key.Cut);
+            MapKey(SC.SDL_SCANCODE_COPY, Key.Copy);
+            MapKey(SC.SDL_SCANCODE_AC_OPEN, Key.Open);
+            MapKey(SC.SDL_SCANCODE_PASTE, Key.Paste);
+            MapKey(SC.SDL_SCANCODE_FIND, Key.Find);
 
             var keyMapReverse = new Dictionary<Key, SC>();
 

--- a/Robust.Client/Input/InputDevices.cs
+++ b/Robust.Client/Input/InputDevices.cs
@@ -174,7 +174,17 @@ namespace Robust.Client.Input
             Pause,
             World1,
             CapsLock,
-            ScrollLock
+            ScrollLock,
+            Help,
+            Stop,
+            Again,
+            Props,
+            Undo,
+            Cut,
+            Copy,
+            Open,
+            Paste,
+            Find,
         }
 
         public static bool IsMouseKey(this Key key)


### PR DESCRIPTION
As far as I can tell we lose nothing by supporting these. Tested on a physical Sun Microsystems Type 7.
Front isn't in here because SDL literally does not have a scancode for that. Our only option is to pound sand, I guess.

While writing this PR I also found that `Key.World1` has no associated MapKey call. In theory, we could map it to `SDL_SCANCODE_INTERNATIONAL1` - however, at that point, I would personally honestly say we should just map through World9/`SDL_SCANCODE_INTERNATIONAL9` as well.

Additionally, LShift/RShift, LAlt/RAlt, and LControl/RControl are not distinguished between L/R positions on the keyboard unlike LSystem/RSystem. Is there a reason for this? On many keyboards they're distinct scancodes - the Type 7 in particular has Right Shift and Right Alt (labeled as Alt Graph).

On the subject of Alt, for some reason `Key.Alt` is specialcased with `#if MACOS` in InputDevices. This should really be an `OperatingSystem#IsMacOS` call, which in fact is used directly above for LSystem/RSystem. Why it is _not_ done this way for Alt? At the very least, both checks should use the same logic.