### PR TITLE
Make CVars allow EntProtoId and EntProtoId<T> and automatically validate them

### DIFF
--- a/Robust.Shared/Configuration/ConfigurationCommands.cs
+++ b/Robust.Shared/Configuration/ConfigurationCommands.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Robust.Shared.Console;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.Configuration
@@ -55,6 +56,16 @@ namespace Robust.Shared.Configuration
             if (type == typeof(ushort))
             {
                 return ushort.Parse(input);
+            }
+
+            if (type == typeof(EntProtoId))
+            {
+                return (EntProtoId) input;
+            }
+
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(EntProtoId<>))
+            {
+                return (EntProtoId) input;
             }
 
             throw new NotSupportedException();

--- a/Robust.Shared/Configuration/ConfigurationManager.cs
+++ b/Robust.Shared/Configuration/ConfigurationManager.cs
@@ -10,6 +10,7 @@ using Nett;
 using Robust.Shared.Collections;
 using Robust.Shared.IoC;
 using Robust.Shared.Log;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -330,6 +331,12 @@ namespace Robust.Shared.Configuration
                             table.Add(keyName, val);
                             break;
                         case double val:
+                            table.Add(keyName, val);
+                            break;
+                        case EntProtoId val:
+                            table.Add(keyName, val);
+                            break;
+                        case IComparable<EntProtoId> val: // EntProtoId<T>
                             table.Add(keyName, val);
                             break;
                         default:
@@ -959,7 +966,15 @@ namespace Robust.Shared.Configuration
                 set
                 {
                     if (value != null && Registered)
-                        DebugTools.AssertEqual(value.GetType(), Type);
+                    {
+#if DEBUG
+                        if (Type != null && Type.IsGenericType && Type.GetGenericTypeDefinition() == typeof(EntProtoId<>))
+                            DebugTools.AssertEqual(value.GetType(), typeof(EntProtoId));
+                        else
+                            DebugTools.AssertEqual(value.GetType(), Type);
+#endif
+                    }
+
                     _value = value;
                 }
             }

--- a/Robust.Shared/Network/Messages/MsgConVars.cs
+++ b/Robust.Shared/Network/Messages/MsgConVars.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Lidgren.Network;
 using Robust.Shared.Log;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 
@@ -53,6 +54,7 @@ namespace Robust.Shared.Network.Messages
                         value = buffer.ReadBoolean();
                         break;
                     case CvarType.String:
+                    case CvarType.EntProtoId:
 
                         // give the string a smaller bounds than int.MaxValue
                         var strSize = buffer.PeekStringSize();
@@ -60,6 +62,10 @@ namespace Robust.Shared.Network.Messages
                             throw new InvalidOperationException($"Cvar string value size '{nameSize}' for cvar '{name}' is out of bounds (0-{MaxStringValSize} bytes).");
 
                         value = buffer.ReadString();
+
+                        if (valType == CvarType.EntProtoId)
+                            value = (EntProtoId) (string) value;
+
                         break;
                     case CvarType.Float:
                         value = buffer.ReadFloat();
@@ -117,6 +123,14 @@ namespace Robust.Shared.Network.Messages
                         buffer.Write((byte)CvarType.Double);
                         buffer.Write(val);
                         break;
+                    case EntProtoId val:
+                        buffer.Write((byte)CvarType.EntProtoId);
+                        buffer.Write(val.Id);
+                        break;
+                    case IComparable<EntProtoId> val: // EntProtoId<T>
+                        buffer.Write((byte)CvarType.EntProtoId);
+                        buffer.Write(val.ToString());
+                        break;
                     default:
                         throw new ArgumentOutOfRangeException(nameof(value), value.GetType(), $"CVar {name} is not of a valid CVar type!");
                 }
@@ -133,7 +147,8 @@ namespace Robust.Shared.Network.Messages
             Bool,
             String,
             Float,
-            Double
+            Double,
+            EntProtoId,
         }
     }
 }

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -434,18 +434,27 @@ public interface IPrototypeManager
     /// This will validate all known to <see cref="IReflectionManager"/>
     /// </summary>
     /// <remarks>
-    /// This will validate any field that uses <see cref="ProtoId"/> or <see cref="EntProtoId"/>.
+    /// This will validate any field that uses <see cref="ProtoId"/> or <see cref="EntProtoId"/>,
+    /// including the values and default values of CVars typed <see cref="EntProtoId"/> or <see cref="EntProtoId{T}"/>.
     /// It also looks for these obsolete attributes: either a <see cref="ValidatePrototypeIdAttribute{T}"/> attribute, or a
     /// <see cref="DataFieldAttribute"/> with a <see cref="PrototypeIdSerializer{TPrototype}"/> serializer.
     /// </remarks>
     /// <param name="prototypes">A collection prototypes to use for validation. Any prototype not in this collection
     /// will be considered invalid.</param>
+    /// <seealso cref="ValidateCVars"/>
     List<string> ValidateStaticFields(Dictionary<Type, HashSet<string>> prototypes);
 
     /// <summary>
     /// This is a variant of <see cref="ValidateStaticFields(System.Collections.Generic.Dictionary{System.Type,System.Collections.Generic.HashSet{string}})"/> that only validates a single type.
     /// </summary>
     List<string> ValidateStaticFields(Type type, Dictionary<Type, HashSet<string>> prototypes);
+
+    /// <summary>
+    /// Validates the current values and default values of all registered CVars
+    /// typed <see cref="EntProtoId"/> or <see cref="EntProtoId{T}"/>
+    /// </summary>
+    /// <returns>A list containing errors for each file that failed validation.</returns>
+    List<string> ValidateCVars();
 
     /// <summary>
     /// This method will serialize all loaded prototypes into yaml and then validate them. This can be used to ensure

--- a/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.Categories.cs
@@ -11,7 +11,7 @@ using System.Reflection;
 namespace Robust.Shared.Prototypes;
 
 // This partial class handles entity prototype categories
-public abstract partial class PrototypeManager : IPrototypeManagerInternal
+public abstract partial class PrototypeManager
 {
     /// <summary>
     /// Cached array of components with the <see cref="EntityCategoryAttribute"/>

--- a/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.ValidateFields.cs
@@ -24,6 +24,13 @@ public partial class PrototypeManager
                 ValidateStaticFieldsInternal(type, errors, prototypes);
         }
 
+        ValidateCVars(
+            errors,
+            id =>
+                prototypes.TryGetValue(typeof(EntityPrototype), out var ids) &&
+                ids.Contains(id)
+        );
+
         return errors;
     }
 
@@ -32,6 +39,14 @@ public partial class PrototypeManager
     {
         var errors = new List<string>();
         ValidateStaticFieldsInternal(type, errors, prototypes);
+        return errors;
+    }
+
+    /// <inheritdoc/>
+    public List<string> ValidateCVars()
+    {
+        var errors = new List<string>();
+        ValidateCVars(errors, id => HasIndex(id));
         return errors;
     }
 
@@ -235,5 +250,39 @@ public partial class PrototypeManager
 
         proto = null;
         return false;
+    }
+
+    private void ValidateCVars(List<string> errors, Predicate<string> hasEntityPrototype)
+    {
+        foreach (var cVarName in _config.GetRegisteredCVars())
+        {
+            var cVarType = _config.GetCVarType(cVarName);
+            if (cVarType == typeof(EntProtoId))
+            {
+                var cVar = (EntProtoId) _config.GetCVar(cVarName);
+                if (!hasEntityPrototype(cVar))
+                {
+                    errors.Add($"{nameof(EntProtoId)} CVar failed validation. No entity prototype found with id {cVar}.");
+                }
+            }
+            else if (cVarType.IsGenericType &&
+                     cVarType.GetGenericTypeDefinition() == typeof(EntProtoId<>))
+            {
+                var cVar = (EntProtoId) _config.GetCVar(cVarName).ToString()!;
+                var compType = cVarType.GetGenericArguments()[0];
+                if (!hasEntityPrototype(cVar))
+                {
+                    errors.Add($"{nameof(EntProtoId<>)} CVar failed validation. No entity prototype found with id {cVar}.");
+                    continue;
+                }
+
+                if (!TryIndex(cVar, out var proto) ||
+                    !proto.HasComp(compType, _factory))
+                {
+                    var name = _factory.GetComponentName(compType);
+                    errors.Add($"{nameof(EntProtoId<>)} CVar failed validation. Entity prototype '{cVar}' does not have a component of type '{name}'.");
+                }
+            }
+        }
     }
 }

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -7,8 +7,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using Robust.Shared.Asynchronous;
-using Robust.Shared.Collections;
+using Robust.Shared.Configuration;
 using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -37,6 +36,7 @@ namespace Robust.Shared.Prototypes
         [Dependency] private IComponentFactory _factory = default!;
         [Dependency] private IEntityManager _entMan = default!;
         [Dependency] private IRobustRandom _random = default!;
+        [Dependency] private IConfigurationManager _config = default!;
 
         private readonly Dictionary<string, FrozenDictionary<string, MappingDataNode>> _prototypeDataCache = new();
 


### PR DESCRIPTION
Spicy meatball PR 
Tired of typing them as strings and then having to validate them in Content manually
This PR does not add support for other prototype types, because I live a happy life downstream with the only prototype kind that matters being EntityPrototype

Content PR (not needed to merge this) https://github.com/space-wizards/space-station-14/pull/45169

Example output:
```
EntProtoId CVar failed validation. No entity prototype found with id abcd1234.
EntProtoId CVar failed validation. Entity prototype 'ActionFireStarter' does not have a component of type 'Buckle'.
```