### PR TITLE
Pre-allocate serializer sizes

### DIFF
--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/DictionarySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/DictionarySerializer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
-using System.Linq;
 using Robust.Shared.IoC;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Manager.Attributes;
@@ -78,7 +77,7 @@ public sealed class DictionarySerializer<TKey, TValue> :
         bool alwaysWrite = false,
         ISerializationContext? context = null)
     {
-        var mappingNode = new MappingDataNode();
+        var mappingNode = new MappingDataNode(value.Count);
         foreach (var (key, val) in value)
         {
             // TODO SERIALIZATION
@@ -123,7 +122,7 @@ public sealed class DictionarySerializer<TKey, TValue> :
         bool alwaysWrite = false,
         ISerializationContext? context = null)
     {
-        return InterfaceWrite(serializationManager, value.ToDictionary(k => k.Key, v => v.Value), alwaysWrite, context);
+        return InterfaceWrite(serializationManager, value, alwaysWrite, context);
     }
 
     #endregion
@@ -134,7 +133,7 @@ public sealed class DictionarySerializer<TKey, TValue> :
         MappingDataNode node, IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context,
         ISerializationManager.InstantiationDelegate<Dictionary<TKey, TValue>>? instanceProvider)
     {
-        var dict = instanceProvider != null ? instanceProvider() : new Dictionary<TKey, TValue>();
+        var dict = instanceProvider != null ? instanceProvider() : new Dictionary<TKey, TValue>(node.Children.Count);
 
         var keyNode = new ValueDataNode();
         foreach (var (key, value) in node.Children)
@@ -184,7 +183,7 @@ public sealed class DictionarySerializer<TKey, TValue> :
                 $"Provided value to a Read-call for a {nameof(IReadOnlyDictionary<TKey, TValue>)}. Ignoring...");
         }
 
-        var dict = new Dictionary<TKey, TValue>();
+        var dict = new Dictionary<TKey, TValue>(node.Children.Count);
 
         var keyNode = new ValueDataNode();
         foreach (var (key, value) in node.Children)

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/HashSetSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/HashSetSerializer.cs
@@ -31,7 +31,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             ISerializationContext? context,
             ISerializationManager.InstantiationDelegate<HashSet<T>>? instanceProvider)
         {
-            var set = instanceProvider != null ? instanceProvider() : new HashSet<T>();
+            var set = instanceProvider != null ? instanceProvider() : new HashSet<T>(node.Sequence.Count);
 
             foreach (var dataNode in node.Sequence)
             {
@@ -124,20 +124,30 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
-            return Write(serializationManager, value.ToHashSet(), dependencies, alwaysWrite, context);
+            return WriteInternal(serializationManager, value, value.Count, alwaysWrite, context);
         }
 
         public DataNode Write(ISerializationManager serializationManager, FrozenSet<T> value, IDependencyCollection dependencies,
             bool alwaysWrite = false, ISerializationContext? context = null)
         {
-            return Write(serializationManager, value.ToHashSet(), dependencies, alwaysWrite, context);
+            return WriteInternal(serializationManager, value, value.Count, alwaysWrite, context);
         }
 
         public DataNode Write(ISerializationManager serializationManager, HashSet<T> value,
             IDependencyCollection dependencies, bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
-            var sequence = new SequenceDataNode();
+            return WriteInternal(serializationManager, value, value.Count, alwaysWrite, context);
+        }
+
+        private static DataNode WriteInternal(
+            ISerializationManager serializationManager,
+            IEnumerable<T> value,
+            int count,
+            bool alwaysWrite = false,
+            ISerializationContext? context = null)
+        {
+            var sequence = new SequenceDataNode(count);
 
             foreach (var elem in value)
             {

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ListSerializers.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Generic/ListSerializers.cs
@@ -23,10 +23,10 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
         ITypeCopyCreator<IReadOnlyCollection<T>>,
         ITypeCopyCreator<ImmutableList<T>>
     {
-        private DataNode WriteInternal(ISerializationManager serializationManager, IEnumerable<T> value, bool alwaysWrite = false,
+        private DataNode WriteInternal(ISerializationManager serializationManager, IEnumerable<T> value, int? count = null, bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
-            var sequence = new SequenceDataNode();
+            var sequence = count is { } capacity ? new SequenceDataNode(capacity) : new SequenceDataNode();
 
             foreach (var elem in value)
             {
@@ -41,14 +41,14 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
-            return WriteInternal(serializationManager, value, alwaysWrite, context);
+            return WriteInternal(serializationManager, value, value.Count, alwaysWrite, context);
         }
 
         public DataNode Write(ISerializationManager serializationManager, List<T> value,
             IDependencyCollection dependencies, bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
-            return WriteInternal(serializationManager, value, alwaysWrite, context);
+            return WriteInternal(serializationManager, value, value.Count, alwaysWrite, context);
         }
 
         public DataNode Write(ISerializationManager serializationManager, IReadOnlyCollection<T> value,
@@ -56,7 +56,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
-            return WriteInternal(serializationManager, value, alwaysWrite, context);
+            return WriteInternal(serializationManager, value, value.Count, alwaysWrite, context);
         }
 
         public DataNode Write(ISerializationManager serializationManager, IReadOnlyList<T> value,
@@ -64,7 +64,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             bool alwaysWrite = false,
             ISerializationContext? context = null)
         {
-            return WriteInternal(serializationManager, value, alwaysWrite, context);
+            return WriteInternal(serializationManager, value, value.Count, alwaysWrite, context);
         }
 
         List<T> ITypeReader<List<T>, SequenceDataNode>.Read(ISerializationManager serializationManager,
@@ -73,7 +73,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
             SerializationHookContext hookCtx,
             ISerializationContext? context, ISerializationManager.InstantiationDelegate<List<T>>? instanceProvider)
         {
-            var list = instanceProvider != null ? instanceProvider() : new List<T>();
+            var list = instanceProvider != null ? instanceProvider() : new List<T>(node.Sequence.Count);
 
             foreach (var dataNode in node.Sequence)
             {
@@ -132,7 +132,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
                 Log.Warning($"Provided value to a Read-call for a {nameof(IReadOnlySet<T>)}. Ignoring...");
             }
 
-            var list = new List<T>();
+            var list = new List<T>(node.Sequence.Count);
 
             foreach (var dataNode in node.Sequence)
             {
@@ -153,7 +153,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Generic
                 Log.Warning($"Provided value to a Read-call for a {nameof(IReadOnlyCollection<T>)}. Ignoring...");
             }
 
-            var list = new List<T>();
+            var list = new List<T>(node.Sequence.Count);
 
             foreach (var dataNode in node.Sequence)
             {


### PR DESCRIPTION
Re-sizing takes time also avoid dummy LINQ collections.