### PR TITLE
Fix "spawn tiles" window UIBox2 errors

### DIFF
--- a/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
+++ b/Robust.Client/UserInterface/Controllers/Implementations/TileSpawningUIController.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using Robust.Client.Graphics;
 using Robust.Client.Placement;
@@ -9,7 +8,7 @@ using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Enums;
-using Robust.Shared.Graphics;
+using Robust.Shared.Maths;
 using Robust.Shared.IoC;
 using Robust.Shared.Localization;
 using Robust.Shared.Map;
@@ -239,7 +238,13 @@ public sealed partial class TileSpawningUIController : UIController
             {
                 texture = _resources.GetResource<TextureResource>(path);
             }
-            _window.TileList.AddItem(Loc.GetString(entry.Name), texture);
+
+            var item = _window.TileList.AddItem(Loc.GetString(entry.Name), texture);
+
+            if (texture != null)
+            {
+                item.IconRegion = new UIBox2(0, 0, texture.Width / entry.Variants, texture.Height);
+            }
         }
     }
 }

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -508,8 +508,8 @@ namespace Robust.Client.UserInterface.Controls
 
                     if (item.Text != null)
                     {
-                        var textBox = new UIBox2(contentBox.Left + item.IconSize.X * item.IconScale, contentBox.Top, contentBox.Right,
-                            contentBox.Bottom);
+                        var textStart = Math.Min(contentBox.Left + item.IconSize.X * item.IconScale, contentBox.Right);
+                        var textBox = new UIBox2(textStart, contentBox.Top, contentBox.Right, contentBox.Bottom);
                         DrawTextInternal(handle, item.Text, textBox);
                     }
                 }

--- a/Robust.Client/UserInterface/Controls/ItemList.cs
+++ b/Robust.Client/UserInterface/Controls/ItemList.cs
@@ -501,7 +501,7 @@ namespace Robust.Client.UserInterface.Controls
                         }
                         else
                         {
-                            handle.DrawTextureRectRegion(item.Icon, UIBox2.FromDimensions(drawOffset, item.Icon.Size * item.IconScale),
+                            handle.DrawTextureRectRegion(item.Icon, UIBox2.FromDimensions(drawOffset, item.IconRegion.Size * item.IconScale),
                                 item.IconRegion, item.IconModulate);
                         }
                     }


### PR DESCRIPTION
Like https://github.com/space-wizards/space-station-14/pull/45085, but now for engine!

If you open the sandbox menu and hit the "spawn tiles" button, you'll see UIBox2 failing validation. Some of the tile textures had multiple variants, and the ItemList had not enough room for displaying text. 8969a8f17d7591b365326ae0c88229c2219b82dd just added a sanity Math.Min to make that piece robust.

The tile menu displays all the variants of the tile, which, IMO looks bad:

<img width="681" height="736" alt="TilesBefore" src="https://github.com/user-attachments/assets/e456b740-4955-4bda-b752-2db512e3330a" />

The ItemList supports showing only a subset of a texture, but this feature was unused and didn't work. afea191f8121b756236df0d493389321800b4120 fixes that and displays only the first tile variant in that UI:

<img width="360" height="606" alt="TilesAfter" src="https://github.com/user-attachments/assets/a071ec6a-42a4-4ffe-8d07-650a992ed553" />

A few tile types have the same name and same variant0 (see the "asteroid sand" in that screenshot), so probably need to do something there? Animate switching between the variants? Just give them different names? An explicit icon in the tile prototype? Open to suggestions.
