### PR TITLE
Fix animations on DefaultWindow

### DIFF
--- a/Robust.Client/UserInterface/CustomControls/DefaultWindow.xaml.cs
+++ b/Robust.Client/UserInterface/CustomControls/DefaultWindow.xaml.cs
@@ -145,6 +145,8 @@ namespace Robust.Client.UserInterface.CustomControls
 
         protected override void FrameUpdate(FrameEventArgs args)
         {
+            base.FrameUpdate(args);
+
             // This is to avoid unnecessarily setting a position where our size isn't yet fully updated.
             // This most commonly happens with saved window positions if your window position is <= 0.
             if (!IsMeasureValid)


### PR DESCRIPTION
DefaultWindow overrides FrameUpdate, but didn't call the base FrameUpdate.

Control.FrameUpdate() handles stepping animations, so if you tried to Control.PlayAnimation() on a DefaultWindow, the animations wouldn't work.