### PR TITLE
Update engine workflow

### DIFF
--- a/.github/workflows/update-engine-version.yml
+++ b/.github/workflows/update-engine-version.yml
@@ -14,16 +14,12 @@ env:
 jobs:
   version:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout engine
         uses: actions/checkout@v7.0.1
-        with:
-          submodules: recursive
 
-      - name: Configure Git
+      - name: Configure git
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -38,9 +34,6 @@ jobs:
     name: Update ${{ matrix.repo }}
     runs-on: ubuntu-latest
     needs: version
-    permissions:
-      contents: write
-      pull-requests: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/update-engine-version.yml
+++ b/.github/workflows/update-engine-version.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   VERSION: ${{ inputs.version }}
-  GH_TOKEN: ${{ secrets.UPDATE_ENGINE_TOKEN }}
 
 jobs:
   version:
@@ -44,6 +43,9 @@ jobs:
           - space-wizards/space-station-14
           - space-wizards/RobustToolboxTemplateSingleplayer
           - space-wizards/RobustToolboxTemplate
+
+    env:
+      GH_TOKEN: ${{ secrets.UPDATE_ENGINE_TOKEN }} # Use token that allows to manage PRs and contents in target repositories
 
     steps:
       - name: Checkout target

--- a/.github/workflows/update-engine-version.yml
+++ b/.github/workflows/update-engine-version.yml
@@ -1,0 +1,90 @@
+name: Update Engine Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version Number (example: 0.1.0)'
+        required: true
+
+env:
+  VERSION: ${{ inputs.version }}
+  GH_TOKEN: ${{ secrets.UPDATE_ENGINE_TOKEN }}
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout engine
+        uses: actions/checkout@v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Configure Git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Create new version
+        run: |
+          python ./Tools/version.py $VERSION
+          git push
+          git push ${{ github.server_url }}/${{ github.repository }}.git v$VERSION
+
+  update-repos:
+    name: Update ${{ matrix.repo }}
+    runs-on: ubuntu-latest
+    needs: version
+    permissions:
+      contents: write
+      pull-requests: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - space-wizards/space-station-14
+          - space-wizards/RobustToolboxTemplateSingleplayer
+          - space-wizards/RobustToolboxTemplate
+
+    steps:
+      - name: Checkout target
+        uses: actions/checkout@v7.0.1
+        with:
+          repository: ${{ matrix.repo }}
+          submodules: recursive
+          token: ${{ env.GH_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Update engine submodule
+        run: |
+          git checkout -B update/robust-$VERSION
+          cd RobustToolbox
+          git fetch origin tag v$VERSION --no-tags
+          git checkout v$VERSION
+          cd ..
+          git add RobustToolbox
+          git commit -m "Update RobustToolbox to $VERSION"
+          git push --set-upstream origin update/robust-$VERSION
+
+      - name: Open PR
+        id: pr
+        run: |
+          echo "url=$(gh pr create \
+            --repo ${{ matrix.repo }} \
+            --base master \
+            --head update/robust-$VERSION \
+            --title "Update RobustToolbox to $VERSION" \
+            --body "Created by GitHub Action." \
+          )" >> $GITHUB_OUTPUT
+
+      - name: Merge PR
+        run: |
+          gh pr merge ${{ steps.pr.url }} --auto --squash --delete-branch

--- a/.github/workflows/update-engine-version.yml
+++ b/.github/workflows/update-engine-version.yml
@@ -14,6 +14,8 @@ env:
 jobs:
   version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout engine

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,4 +1,4 @@
-name: Update Engine Version
+name: Update Version
 
 on:
   workflow_dispatch:
@@ -17,10 +17,10 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout engine
+      - name: Checkout RobustToolbox
         uses: actions/checkout@v7.0.1
 
-      - name: Configure git
+      - name: Configure Git
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -60,7 +60,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-      - name: Update engine submodule
+      - name: Update RobustToolbox submodule
         run: |
           git checkout -B update/robust-$VERSION
           cd RobustToolbox


### PR DESCRIPTION
Fixes #6931.

Allows to easily create a new engine version and update submodule in SS14 and template repositories.

Requires an organization fine-grained token with access to needed **target** repositories (read and write for content and PRs) which is then needs to be added to RobustToolbox actions secrets with name ``UPDATE_ENGINE_TOKEN``. Also, requires auto-merge to be enabled in target repositories.
