### PR TITLE
Move RA0056 check to the EntitySystemSubscriptionGeneratorErrorAnalyzer

### DIFF
--- a/Robust.Roslyn.Shared/PartialTypeHelper.cs
+++ b/Robust.Roslyn.Shared/PartialTypeHelper.cs
@@ -16,7 +16,6 @@ public sealed record PartialTypeInfo(
     string? Namespace,
     EquatableArray<PartialTypeInfo.NestedPart> Parts,
     bool IsValid,
-    Location SyntaxLocation,
     bool IsSealed)
 {
     public string Name => Parts[^1].Name;
@@ -50,7 +49,6 @@ public sealed record PartialTypeInfo(
             symbol.ContainingNamespace.IsGlobalNamespace ? null : symbol.ContainingNamespace.ToDisplayString(),
             parts.ToImmutable().AsEquatableArray(),
             isValid,
-            syntax.Keyword.GetLocation(),
             symbol.IsSealed);
     }
 

--- a/Robust.Roslyn.Shared/PartialTypeHelper.cs
+++ b/Robust.Roslyn.Shared/PartialTypeHelper.cs
@@ -65,18 +65,6 @@ public sealed record PartialTypeInfo(
         return false;
     }
 
-    [Obsolete("Diagnostics from source generators are recommended against, apparently: https://github.com/dotnet/roslyn/issues/71709")]
-    public bool CheckPartialDiagnostic(SourceProductionContext context, DiagnosticDescriptor diagnostic)
-    {
-        if (!IsValid)
-        {
-            context.ReportDiagnostic(Diagnostic.Create(diagnostic, SyntaxLocation, Parts[^1].DisplayName));
-            return true;
-        }
-
-        return false;
-    }
-
     public string GetQualifiedName()
     {
         return Namespace == null ? Name : $"{Namespace}.{Name}";

--- a/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
+++ b/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
@@ -59,6 +59,8 @@ public class EntitySystemSubscriptionGenerator : IIncrementalGenerator
             (productionContext, info) =>
             {
                 var (partialTypeInfo, subscriptions) = info;
+                if (!partialTypeInfo.IsValid)
+                    return;
 
                 var subscriptionsSyntax = new StringBuilder();
                 foreach (var method in subscriptions)

--- a/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
+++ b/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
@@ -19,15 +19,6 @@ namespace Robust.Shared.EntitySystemSubscriptionsGenerator;
 [Generator(LanguageNames.CSharp)]
 public class EntitySystemSubscriptionGenerator : IIncrementalGenerator
 {
-    private static readonly DiagnosticDescriptor NotPartial = new(
-        Diagnostics.IdNonPartialContainingTypeForGeneratedSubscription,
-        "Containing class must be declared as Partial",
-        "Method is declared in type \"{0}\" which is not Partial",
-        "Usage",
-        DiagnosticSeverity.Error,
-        true
-    );
-
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var annotatedEntitySystems = Aggregate(
@@ -68,8 +59,6 @@ public class EntitySystemSubscriptionGenerator : IIncrementalGenerator
             (productionContext, info) =>
             {
                 var (partialTypeInfo, subscriptions) = info;
-                if (partialTypeInfo.CheckPartialDiagnostic(productionContext, NotPartial))
-                    return;
 
                 var subscriptionsSyntax = new StringBuilder();
                 foreach (var method in subscriptions)

--- a/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGeneratorErrorAnalyzer.cs
+++ b/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGeneratorErrorAnalyzer.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Robust.Roslyn.Shared;
 
@@ -7,7 +9,7 @@ namespace Robust.Shared.EntitySystemSubscriptionsGenerator;
 
 /// <summary>
 /// This analyzer ensures that all methods annotated with the relevant subscription attributes are:<ul>
-///   <li>In an EntitySystem</li>
+///   <li>In a partial EntitySystem</li>
 ///   <li>Have the correct signature for their subscription type</li>
 /// </ul></summary>
 /// <seealso cref="EntitySystemSubscriptionGenerator"/>
@@ -32,8 +34,17 @@ public class EntitySystemSubscriptionGeneratorErrorAnalyzer : DiagnosticAnalyzer
         true
     );
 
+    private static readonly DiagnosticDescriptor NotPartial = new(
+        Diagnostics.IdNonPartialContainingTypeForGeneratedSubscription,
+        "Containing class must be declared as Partial",
+        "Method is declared in type \"{0}\" which is not Partial",
+        "Usage",
+        DiagnosticSeverity.Error,
+        true
+    );
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
-        [BadMethodSignature, NotEntitySystem];
+        [BadMethodSignature, NotEntitySystem, NotPartial];
 
     public override void Initialize(AnalysisContext context)
     {
@@ -42,11 +53,11 @@ public class EntitySystemSubscriptionGeneratorErrorAnalyzer : DiagnosticAnalyzer
             GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics
         );
 
-        EnsureAnnotatedSubscriptionMethodsAreInAnEntitySystem(context);
+        EnsureAnnotatedSubscriptionMethodsAreInAPartialEntitySystem(context);
         EnsureAnnotatedSubscriptionMethodsHaveCorrectSignatures(context);
     }
 
-    private static void EnsureAnnotatedSubscriptionMethodsAreInAnEntitySystem(AnalysisContext context)
+    private static void EnsureAnnotatedSubscriptionMethodsAreInAPartialEntitySystem(AnalysisContext context)
     {
         List<string> attributeNames =
         [
@@ -71,8 +82,24 @@ public class EntitySystemSubscriptionGeneratorErrorAnalyzer : DiagnosticAnalyzer
                     if (!c.Symbol.GetAttributes()
                             .Select(it => it.AttributeClass)
                             .Intersect(attributeSymbols, SymbolEqualityComparer.IncludeNullability)
-                            .Any() ||
-                        IsSubtypeOf(c.Symbol.ContainingType, entitySystemType))
+                            .Any())
+                        return;
+
+                    var references = c.Symbol.ContainingType.DeclaringSyntaxReferences;
+                    if (references.Length != 0)
+                    {
+                        var containingTypeDeclaration = (TypeDeclarationSyntax)references[0].GetSyntax();
+                        if (!containingTypeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+                        {
+                            c.RegisterSymbolEndAction(c => c.ReportDiagnostic(Diagnostic.Create(
+                                NotPartial,
+                                c.Symbol.Locations[0],
+                                c.Symbol.ContainingType?.Name ?? "<unknown>"
+                            )));
+                        }
+                    }
+
+                    if (IsSubtypeOf(c.Symbol.ContainingType, entitySystemType))
                         return;
 
                     c.RegisterSymbolEndAction(c => c.ReportDiagnostic(Diagnostic.Create(


### PR DESCRIPTION
Fixes #6771.

<img width="1184" height="220" alt="Screenshot_20260807_171617" src="https://github.com/user-attachments/assets/c6f81b6e-92e5-4339-a111-037462c5d8a1" />

Breaking changes:
Removed PartialTypeInfo.CheckPartialDiagnostic since it was obsolete and unused.
Removed PartialTypeInfo.SyntaxLocation since it became unused.