### PR TITLE
Use \n instead of os.linesep in Tools/version.py

### DIFF
--- a/Tools/version.py
+++ b/Tools/version.py
@@ -53,10 +53,11 @@ def write_version(version: str, file_only: bool):
 
     # Update
     with open("MSBuild/Robust.Engine.Version.props", "w") as file:
-        file.write("<Project>" + os.linesep)
-        file.write("    <!-- This file automatically reset by Tools/version.py -->"  + os.linesep)
-        file.write("    <PropertyGroup><Version>" + version + "</Version></PropertyGroup>" + os.linesep)
-        file.write("</Project>" + os.linesep)
+        file.write(
+            "<Project>\n"
+            "    <!-- This file automatically reset by Tools/version.py -->\n"
+            f"    <PropertyGroup><Version>{version}</Version></PropertyGroup>\n"
+            "</Project>\n")
 
     if not file_only:
         # Commit


### PR DESCRIPTION
Fixes #6888.

\n is universal for all platforms, while os.linesep is platform-dependent. Output:
<img width="1293" height="156" alt="выява" src="https://github.com/user-attachments/assets/19b92bf2-508d-4cbf-957c-0307b86c9e79" />
