### PR TITLE
Fix duplicate chents in state handler

### DIFF
--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -615,16 +615,8 @@ namespace Robust.Client.GameStates
             // This is terrible, and I hate it. This also needs to run even when prediction is disabled.
             _entitySystemManager.GetEntitySystem<TransformSystem>().Reset();
 
-            if (!PredictionNeedsResetting)
-                return;
-
-            PredictionNeedsResetting = false;
-            var countReset = 0;
-            var system = _entitySystemManager.GetEntitySystem<ClientDirtySystem>();
-            var metaQuery = _entities.GetEntityQuery<MetaDataComponent>();
-            RemQueue<IComponent> toRemove = new();
-
-            // Handle predicted entity spawns.
+            // Handle predicted entity spawns before applying state-created entities. This
+            // keeps predicted chunk entities from colliding with authoritative chunk entities.
             var predicted = new ValueList<EntityUid>();
             var predictedQuery = _entities.AllEntityQueryEnumerator<PredictedSpawnComponent>();
 
@@ -638,6 +630,15 @@ namespace Robust.Client.GameStates
             {
                 _entities.DeleteEntity(ent);
             }
+
+            if (!PredictionNeedsResetting)
+                return;
+
+            PredictionNeedsResetting = false;
+            var countReset = 0;
+            var system = _entitySystemManager.GetEntitySystem<ClientDirtySystem>();
+            var metaQuery = _entities.GetEntityQuery<MetaDataComponent>();
+            RemQueue<IComponent> toRemove = new();
 
             foreach (var entity in system.DirtyEntities)
             {

--- a/Robust.Client/UserInterface/CustomControls/DefaultWindow.xaml.cs
+++ b/Robust.Client/UserInterface/CustomControls/DefaultWindow.xaml.cs
@@ -62,7 +62,6 @@ namespace Robust.Client.UserInterface.CustomControls
 
             Contents = ContentsContainer;
 
-            CloseButton.OnPressed += CloseButtonPressed;
             XamlChildren = new SS14ContentCollection(this);
         }
 
@@ -126,11 +125,18 @@ namespace Robust.Client.UserInterface.CustomControls
 
         // Drag resizing and moving code is mostly taken from Godot's WindowDialog.
 
+        protected override void EnteredTree()
+        {
+            base.EnteredTree();
+
+            CloseButton.OnPressed += CloseButtonPressed;
+        }
+
         protected override void ExitedTree()
         {
-            base.ExitedTree();
-
             CloseButton.OnPressed -= CloseButtonPressed;
+
+            base.ExitedTree();
         }
 
         private void CloseButtonPressed(BaseButton.ButtonEventArgs args)

--- a/Robust.Shared/GameStates/ChunkEntitySystem.cs
+++ b/Robust.Shared/GameStates/ChunkEntitySystem.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Map.Enumerators;
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Robust.Shared.GameStates;
@@ -33,6 +34,7 @@ public abstract partial class ChunkEntitySystem : EntitySystem
     [Dependency] private EntityQuery<MapGridComponent> _gridQuery;
     [Dependency] private EntityQuery<TransformComponent> _xformQuery;
     [Dependency] private EntityQuery<ChunkContainerComponent> _containerQuery;
+    [Dependency] private IGameTiming _timing = default!;
     [Dependency] private MetaDataSystem _metaData = default!;
 
     /// <summary>
@@ -146,6 +148,28 @@ public abstract partial class ChunkEntitySystem : EntitySystem
 
         Del(chunk.Owner, meta);
         return true;
+    }
+
+    /// <summary>
+    /// Removes a data component from a chunk entity and removes the chunk entity if it no longer contains any data.
+    /// During prediction, the component is dirtied instead of removed so rollback can restore it before prediction reruns.
+    /// </summary>
+    public bool TryRemoveChunkData<T>(Entity<ChunkEntityComponent, T, MetaDataComponent?> chunk)
+        where T : IComponent
+    {
+        var meta = chunk.Comp3;
+
+        if (!_metaQuery.Resolve(chunk.Owner, ref meta))
+            return false;
+
+        if (_timing.InPrediction)
+        {
+            EntityManager.Dirty(chunk.Owner, chunk.Comp2, meta);
+            return true;
+        }
+
+        EntityManager.RemoveComponent(chunk.Owner, chunk.Comp2, meta);
+        return TryRemoveChunk((chunk.Owner, chunk.Comp1, meta));
     }
 
     // Returns chunk entities in range of the position, assumes non-normalized inputs.
@@ -378,7 +402,17 @@ public abstract partial class ChunkEntitySystem : EntitySystem
                 return;
             }
 
-            DebugTools.Assert($"Duplicate chunk entity for root {ToPrettyString(comp.Root)} and chunk {comp.Chunk}.");
+            if (_timing.ApplyingState)
+            {
+                // State application can receive a replacement chunk before the old
+                // chunk's deletion has been processed. Clear the stale slot so the
+                // incoming authoritative chunk state can own it.
+                RemoveChunk(oldChunk);
+            }
+            else
+            {
+                DebugTools.Assert($"Duplicate chunk entity for root {ToPrettyString(comp.Root)} and chunk {comp.Chunk}.");
+            }
         }
 
         meta.Flags |= MetaDataFlags.ChunkEntity;

--- a/Robust.Shared/GameStates/ChunkEntitySystem.cs
+++ b/Robust.Shared/GameStates/ChunkEntitySystem.cs
@@ -150,28 +150,6 @@ public abstract partial class ChunkEntitySystem : EntitySystem
         return true;
     }
 
-    /// <summary>
-    /// Removes a data component from a chunk entity and removes the chunk entity if it no longer contains any data.
-    /// During prediction, the component is dirtied instead of removed so rollback can restore it before prediction reruns.
-    /// </summary>
-    public bool TryRemoveChunkData<T>(Entity<ChunkEntityComponent, T, MetaDataComponent?> chunk)
-        where T : IComponent
-    {
-        var meta = chunk.Comp3;
-
-        if (!_metaQuery.Resolve(chunk.Owner, ref meta))
-            return false;
-
-        if (_timing.InPrediction)
-        {
-            EntityManager.Dirty(chunk.Owner, chunk.Comp2, meta);
-            return true;
-        }
-
-        EntityManager.RemoveComponent(chunk.Owner, chunk.Comp2, meta);
-        return TryRemoveChunk((chunk.Owner, chunk.Comp1, meta));
-    }
-
     // Returns chunk entities in range of the position, assumes non-normalized inputs.
     public ChunkEntityEnumerator GetChunksInRange(EntityUid root, Vector2 localPosition, float range)
     {


### PR DESCRIPTION
This can happen because deletions run after so if the server deletes and adds a chent in the same tick (i.e. 2 separate chents occupy the same index) it causes this.

Ignore window PR xd.