### PR TITLE
Fix AlwaysPushInheritance read writes resulting in inconsistent ordering for sequences

### DIFF
--- a/Robust.Shared.IntegrationTests/Serialization/AlwaysPushInheritanceTest.cs
+++ b/Robust.Shared.IntegrationTests/Serialization/AlwaysPushInheritanceTest.cs
@@ -28,17 +28,19 @@ public sealed partial class AlwaysPushInheritanceTest : OurSerializationTest
             [listTag] = new SequenceDataNode("3", "4", "5")
         };
 
-        var combined = Serialization.PushComposition<AlwaysPushInheritanceTestDefinition, MappingDataNode>(parent, child);
+        var composed = Serialization.PushComposition<AlwaysPushInheritanceTestDefinition, MappingDataNode>(parent, child);
 
-        Assert.That(combined, Does.ContainKey(ParentDataFieldAttribute.Name));
-        Assert.That(combined, Does.ContainKey(IdDataFieldAttribute.Name));
-        Assert.That(combined, Does.ContainKey(listTag));
-        Assert.That(combined, Has.Count.EqualTo(3));
+        // The composed node has the same nodes as the child, plus the list elements of the parent
+        Assert.That(composed, Does.ContainKey(ParentDataFieldAttribute.Name));
+        Assert.That(composed, Does.ContainKey(IdDataFieldAttribute.Name));
+        Assert.That(composed, Does.ContainKey(listTag));
+        Assert.That(composed, Has.Count.EqualTo(3));
 
-        var sequence = combined[listTag] as SequenceDataNode;
+        var sequence = composed[listTag] as SequenceDataNode;
         Assert.That(sequence, Is.Not.Null);
         Assert.That(sequence, Has.Count.EqualTo(6));
 
+        // The composed list has all the elements from the parent plus the child
         for (var i = 0; i < 6; i++)
         {
             Assert.That(sequence.Sequence[i], Is.TypeOf<ValueDataNode>());
@@ -47,19 +49,24 @@ public sealed partial class AlwaysPushInheritanceTest : OurSerializationTest
             Assert.That(value.Value, Is.EqualTo($"{i}"));
         }
 
-        var read = Serialization.Read<AlwaysPushInheritanceTestDefinition>(combined, notNullableOverride: true);
-        Assert.That(read.List, Has.Count.EqualTo(6));
+        var read = Serialization.Read<AlwaysPushInheritanceTestDefinition>(composed, notNullableOverride: true);
 
+        // The read definition has the same list elements as the composed node
+        Assert.That(read.List, Has.Count.EqualTo(6));
         for (var i = 0; i < 6; i++)
         {
             Assert.That(read.List[i], Is.EqualTo(i));
         }
 
         var write = (MappingDataNode) Serialization.WriteValue(read, notNullableOverride: true);
+
+        // The re-written mapping has a list equivalent to the one from the original composed mapping
         Assert.That(write, Does.ContainKey(listTag));
-        Assert.That(write[listTag], Is.EquivalentTo((SequenceDataNode) combined[listTag]));
+        Assert.That(write[listTag], Is.EquivalentTo((SequenceDataNode) composed[listTag]));
 
         var read2 = Serialization.Read<AlwaysPushInheritanceTestDefinition>(write, notNullableOverride: true);
+
+        // The re-read definition has a list equivalent to the one from the original definition used to re-write the mapping node
         Assert.That(read.List, Is.EquivalentTo(read2.List));
     }
 

--- a/Robust.Shared.IntegrationTests/Serialization/AlwaysPushInheritanceTest.cs
+++ b/Robust.Shared.IntegrationTests/Serialization/AlwaysPushInheritanceTest.cs
@@ -1,0 +1,73 @@
+﻿using NUnit.Framework;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.Manager.Attributes;
+using Robust.Shared.Serialization.Manager.Definition;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Sequence;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.UnitTesting.Shared.Serialization;
+
+namespace Robust.Shared.IntegrationTests.Serialization;
+
+public sealed partial class AlwaysPushInheritanceTest : OurSerializationTest
+{
+    [Test]
+    public void ReadWriteOrderPreservedTest()
+    {
+        var listTag = DataDefinitionUtility.AutoGenerateTag(nameof(AlwaysPushInheritanceTestDefinition.List));
+        var parent = new MappingDataNode
+        {
+            [IdDataFieldAttribute.Name] = new ValueDataNode("parent"),
+            [listTag] = new SequenceDataNode("0", "1", "2")
+        };
+
+        var child = new MappingDataNode
+        {
+            [ParentDataFieldAttribute.Name] = new ValueDataNode("parent"),
+            [IdDataFieldAttribute.Name] = new ValueDataNode("child"),
+            [listTag] = new SequenceDataNode("3", "4", "5")
+        };
+
+        var combined = Serialization.PushComposition<AlwaysPushInheritanceTestDefinition, MappingDataNode>(parent, child);
+
+        Assert.That(combined, Does.ContainKey(ParentDataFieldAttribute.Name));
+        Assert.That(combined, Does.ContainKey(IdDataFieldAttribute.Name));
+        Assert.That(combined, Does.ContainKey(listTag));
+        Assert.That(combined, Has.Count.EqualTo(3));
+
+        var sequence = combined[listTag] as SequenceDataNode;
+        Assert.That(sequence, Is.Not.Null);
+        Assert.That(sequence, Has.Count.EqualTo(6));
+
+        for (var i = 0; i < 6; i++)
+        {
+            Assert.That(sequence.Sequence[i], Is.TypeOf<ValueDataNode>());
+
+            var value = (ValueDataNode)sequence.Sequence[i];
+            Assert.That(value.Value, Is.EqualTo($"{i}"));
+        }
+
+        var read = Serialization.Read<AlwaysPushInheritanceTestDefinition>(combined, notNullableOverride: true);
+        Assert.That(read.List, Has.Count.EqualTo(6));
+
+        for (var i = 0; i < 6; i++)
+        {
+            Assert.That(read.List[i], Is.EqualTo(i));
+        }
+
+        var write = (MappingDataNode) Serialization.WriteValue(read, notNullableOverride: true);
+        Assert.That(write, Does.ContainKey(listTag));
+        Assert.That(write[listTag], Is.EquivalentTo((SequenceDataNode) combined[listTag]));
+
+        var read2 = Serialization.Read<AlwaysPushInheritanceTestDefinition>(write, notNullableOverride: true);
+        Assert.That(read.List, Is.EquivalentTo(read2.List));
+    }
+
+    [DataDefinition]
+    private sealed partial class AlwaysPushInheritanceTestDefinition
+    {
+        [DataField]
+        [AlwaysPushInheritance]
+        public List<int> List = new();
+    }
+}

--- a/Robust.Shared/Serialization/Manager/SerializationManager.Composition.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Composition.cs
@@ -152,9 +152,10 @@ public partial class SerializationManager
         // I have NFI what this comment means.
 
         var result = child.Copy();
+        var i = 0;
         foreach (var entry in parent)
         {
-            result.Add(entry.Copy());
+            result.Insert(i++, entry.Copy());
         }
 
         return result;


### PR DESCRIPTION
Might cause large diffs on maps would have to test
Previously it would do
parent: 1, 2, 3
child: 4, 5, 6
result: 4, 5, 6, 1, 2, 3

Now it always does
result: 1, 2, 3, 4, 5, 6

This is consistent with the documentation we already have, but changes the behaviour
AlwaysPushInheritanceAttribute states:
```
    /// <summary>
    ///     When inheriting a field from a parent, always <b>merge</b> the two fields when such behavior exists.
    ///     This is unlike the normal behavior where the child's field will always <b>overwrite</b> the parent's.
    ///     <br/>
    ///     Merging is done at a YAML level by merging mappings and sequences recursively.
    /// </summary>
    /// <example>
    ///     <code>
    ///     - id: Parent
    ///       myField: [Foo, Bar]
    ///     <br/>
    ///     - id: Child
    ///       parents: [Parent]
    ///       myField: [Baz, Qux]
    ///     </code>
    ///     Which, when deserialized and assuming myField is marked with AlwaysPushInheritance, will result in data that
    ///     looks like this:
    ///     <code>
    ///     - id: Child
    ///       myField: [Foo, Bar, Baz, Qux]
    ///     </code>
    ///     compared to the default behavior:
    ///     <code>
    ///     - id: Child
    ///       myField: [Baz, Qux]
    ///     </code>
    /// </example>
```

Mind you that wasn't written by Paul, so maybe he intended for it to end up the other way around, either way a test has been added to ensure consistency

The actual fix is 2 lines, the test is the rest of the diff