### PR TITLE
Slap to clean netpeers in a concurrentqueue

### DIFF
--- a/Robust.Shared/Network/NetManager.ClientConnect.cs
+++ b/Robust.Shared/Network/NetManager.ClientConnect.cs
@@ -99,7 +99,7 @@ namespace Robust.Shared.Network
             catch (OperationCanceledException)
             {
                 winningPeer.Peer.Shutdown("Cancelled");
-                _toCleanNetPeers.Add(winningPeer.Peer);
+                _toCleanNetPeers.Enqueue(winningPeer.Peer);
                 ClientConnectState = ClientConnectionState.NotConnecting;
                 return;
             }
@@ -108,7 +108,7 @@ namespace Robust.Shared.Network
                 OnConnectFailed(e.Message);
                 _logger.Error("Exception during handshake: {0}", e);
                 winningPeer.Peer.Shutdown("Something happened.");
-                _toCleanNetPeers.Add(winningPeer.Peer);
+                _toCleanNetPeers.Enqueue(winningPeer.Peer);
                 ClientConnectState = ClientConnectionState.NotConnecting;
                 return;
             }
@@ -322,7 +322,7 @@ namespace Robust.Shared.Network
                     {
                         // Connection failed, clean up and yeet an exception
                         peer.Shutdown(reason);
-                        _toCleanNetPeers.Add(peer);
+                        _toCleanNetPeers.Enqueue(peer);
                         throw new ConnectionFailedException(reason);
                     }
 
@@ -332,7 +332,7 @@ namespace Robust.Shared.Network
                 {
                     // Something went wrong!
                     peer.Shutdown("Connection attempt failed");
-                    _toCleanNetPeers.Add(peer);
+                    _toCleanNetPeers.Enqueue(peer);
                     throw;
                 }
             }
@@ -493,7 +493,7 @@ namespace Robust.Shared.Network
             public void Dispose()
             {
                 Peer.Peer.Shutdown("Disposing unused connection attempt");
-                netManager._toCleanNetPeers.Add(Peer.Peer);
+                netManager._toCleanNetPeers.Enqueue(Peer.Peer);
             }
         }
     }

--- a/Robust.Shared/Network/NetManager.cs
+++ b/Robust.Shared/Network/NetManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -136,7 +137,7 @@ namespace Robust.Shared.Network
         private readonly List<NetPeerData> _netPeers = new();
 
         // Client connect happens during status changed and such callbacks, so we need to defer deletion of these.
-        private readonly List<NetPeer> _toCleanNetPeers = new();
+        private readonly ConcurrentQueue<NetPeer> _toCleanNetPeers = new();
 
         private readonly Dictionary<NetConnection, TaskCompletionSource<object?>> _awaitingDisconnect
             = new();
@@ -715,14 +716,9 @@ namespace Robust.Shared.Network
                 */
             }
 
-            if (_toCleanNetPeers.Count != 0)
+            while (_toCleanNetPeers.TryDequeue(out var peer))
             {
-                foreach (var peer in _toCleanNetPeers)
-                {
-                    _netPeers.RemoveAll(p => p.Peer == peer);
-                }
-
-                _toCleanNetPeers.Clear();
+                _netPeers.RemoveAll(p => p.Peer == peer);
             }
 
             SentMessagesMetrics.IncTo(sentMessages);


### PR DESCRIPTION
ClientConnect is async and this can run concurrently with processpackets.