### PR TITLE
Make DataDefinition constructor 2 times faster and allocate less

### DIFF
--- a/Robust.Serialization.Generator/Generator.cs
+++ b/Robust.Serialization.Generator/Generator.cs
@@ -796,6 +796,18 @@ public class Generator : IIncrementalGenerator
 
         GetCopierMethod(definition, definition.Type, "object", baseDefinition, builder, requiredFields);
         GetCopierMethod(definition, definition.Type, GetGenericTypeName(type), false, builder, requiredFields);
+        builder.AppendLine($$"""
+            public static void CopyObj(
+                {{definition.GenericTypeName}} source,
+                ref {{definition.GenericTypeName}} target,
+                ISerializationManager serialization,
+                SerializationHookContext hookCtx,
+                ISerializationContext? context)
+            {
+                source.Copy(ref target, serialization, hookCtx, context);
+            }
+            """);
+
         return builder.ToString();
     }
 
@@ -997,6 +1009,18 @@ public class Generator : IIncrementalGenerator
                 {{body}}
             }
 
+            public static void ReadObj(
+                ref object target,
+                MappingDataNode mappingDataNode,
+                ISerializationManager serialization,
+                SerializationHookContext hookCtx,
+                ISerializationContext? context)
+            {
+                var obj = ({{definition.GenericTypeName}}) target;
+                {{definition.GenericTypeName}}.Read(ref obj, mappingDataNode, serialization, hookCtx, context);
+                target = obj;
+            }
+
             {{GetReadCompMethod(definition)}}
             """;
     }
@@ -1046,7 +1070,7 @@ public class Generator : IIncrementalGenerator
             if (!field.Attribute.IsDataFieldAttribute || !field.Attribute.Required)
             {
                 builder.AppendLine($$"""
-                    if (alwaysWrite || !EqualityComparer<{{fieldType}}>.Default.Equals(obj.{{field.Symbol.Name}}, ({{fieldType}}) defaultValues["{{field.Attribute.Tag}}"]!))
+                    if (alwaysWrite || !EqualityComparer<{{fieldType}}>.Default.Equals(obj.{{field.Symbol.Name}}, ({{fieldType}}) defaultValues[{{i}}].DefaultValue!))
                     {
                     """);
             }
@@ -1137,7 +1161,7 @@ public class Generator : IIncrementalGenerator
                 ISerializationManager serialization,
                 ISerializationContext? context,
                 bool alwaysWrite,
-                ImmutableDictionary<string, object?> defaultValues)
+                ImmutableArray<DataFieldDefinition> defaultValues)
             {
                 {{builder}}
             }
@@ -1237,11 +1261,35 @@ public class Generator : IIncrementalGenerator
     {
         var builder = new StringBuilder();
         var nullConditional = definition.Type.IsValueType ? string.Empty : "?";
-        var fieldTags = new List<string>(definition.Fields.Count);
-        foreach (var field in definition.Fields)
+        var fields = new StringBuilder();
+        var duplicates = new StringBuilder();
+        var inherited = new Dictionary<INamedTypeSymbol, int>();
+        for (var i = 0; i < definition.Fields.Count; i++)
         {
-            if (!definition.Type.Equals(field.Symbol.ContainingType, SymbolEqualityComparer.Default))
-                continue;
+            var field = definition.Fields[i];
+            for (var j = 0; j < definition.Fields.Count; j++)
+            {
+                if (i == j)
+                    continue;
+
+                var other = definition.Fields[j];
+                if (field.Attribute.Tag != other.Attribute.Tag)
+                    continue;
+
+                if (field.Symbol is not IPropertySymbol fieldProperty ||
+                    !Equals(fieldProperty.OverriddenProperty, other.Symbol))
+                {
+                    continue;
+                }
+
+                if (other.Symbol is not IPropertySymbol otherProperty ||
+                    !Equals(field.Symbol, otherProperty.OverriddenProperty))
+                {
+                    continue;
+                }
+
+                duplicates.Append($"\"{field.Attribute.Tag.Replace("\"", "\\\"")}\", ");
+            }
 
             var (fieldType, _) = GetCleanNameForGenericType(field.Type, out var isNullableValueType);
             var nullable = field.Type.NullableAnnotation == NullableAnnotation.Annotated ||
@@ -1250,41 +1298,67 @@ public class Generator : IIncrementalGenerator
             if (!isNullableValueType && fieldType.EndsWith("?"))
                 fieldType = fieldType.Substring(0, fieldType.Length - 1);
 
-            builder.AppendLine($$"""
-                if (fieldsParsed == null || !fieldsParsed.Contains("{{field.Attribute.Tag}}"))
-                {
-                    fields.Add(new DataFieldDefinition(
-                        "{{field.Attribute.Tag}}",
-                        {{field.Attribute.Priority}},
-                        {{field.Attribute.IsDataFieldAttribute.ToString().ToLowerInvariant()}},
-                        {{field.Attribute.Include.ToString().ToLowerInvariant()}},
-                        instance{{nullConditional}}.{{field.Symbol.Name}},
-                        (InheritanceBehavior) {{field.Attribute.InheritanceBehavior}},
-                        "{{field.Symbol.Name}}",
-                        typeof({{fieldType}}),
-                        {{nullable.ToString().ToLowerInvariant()}},
-                        "{{field.Attribute.CamelCasedName}}",
-                        {{(field.CustomSerializer == null ? "null" : $"typeof({field.CustomSerializer.Value.Serializer.ToDisplayString()})")}}
-                    ));
-                }
-                """);
+            var fieldDefinition = $"""
+                new DataFieldDefinition(
+                    "{field.Attribute.Tag}",
+                    {field.Attribute.Priority},
+                    {field.Attribute.IsDataFieldAttribute.ToString().ToLowerInvariant()},
+                    {field.Attribute.Include.ToString().ToLowerInvariant()},
+                    instance{nullConditional}.{field.Symbol.Name},
+                    (InheritanceBehavior) {field.Attribute.InheritanceBehavior},
+                    "{field.Symbol.Name}",
+                    typeof({fieldType}),
+                    {nullable.ToString().ToLowerInvariant()},
+                    "{field.Attribute.CamelCasedName}",
+                    {(field.CustomSerializer == null ? "null" : $"typeof({field.CustomSerializer.Value.Serializer.ToDisplayString()})")}
+                )
+                """;
 
-            fieldTags.Add($"\"{field.Attribute.Tag}\"");
+            var containing = field.Symbol.ContainingType;
+            if (definition.Type.Equals(containing, SymbolEqualityComparer.Default))
+            {
+                builder.AppendLine($"builder.Add({fieldDefinition});");
+                fields.AppendLine($"{i} => {fieldDefinition},");
+            }
+            else
+            {
+                inherited.TryGetValue(containing, out var inheritedIndex);
+
+                builder.AppendLine($"builder.Add(global::{containing.ToDisplayString()}.GetFieldDefinition(instance, {inheritedIndex}));");
+                fields.AppendLine($"{i} => global::{containing.ToDisplayString()}.GetFieldDefinition(instance, {inheritedIndex}),");
+
+                inheritedIndex++;
+                inherited[containing] = inheritedIndex;
+            }
         }
-
-        if (definition.GetFirstDataDefinitionBaseType() is { } baseType)
-            builder.AppendLine(
-                $"{baseType.ToDisplayString()}.GetFieldDefinitions(instance, fields, [{string.Join(", ", fieldTags)}]);");
 
         var instance = definition.Type.IsAbstract
             ? string.Empty
             : $"instance = global::{definition.Type.ToDisplayString()}.StaticInstantiate();";
 
         return $$"""
-            public static void GetFieldDefinitions({{definition.GenericTypeName}}{{nullConditional}} instance, List<DataFieldDefinition> fields, string[]? fieldsParsed = null)
+            public static global::System.Collections.Immutable.ImmutableArray<DataFieldDefinition> GetFieldDefinitions({{definition.GenericTypeName}}{{nullConditional}} instance)
             {
                 {{instance}}
+
+                var builder = global::System.Collections.Immutable.ImmutableArray.CreateBuilder<DataFieldDefinition>({{definition.Fields.Count}});
                 {{builder}}
+                return builder.MoveToImmutable();
+            }
+
+            public static DataFieldDefinition GetFieldDefinition({{definition.GenericTypeName}}{{nullConditional}} instance, int field)
+            {
+                return field switch
+                {
+                    {{fields}}
+                    _ => throw new global::System.ArgumentOutOfRangeException(nameof(field)),
+                };
+            }
+
+            [Obsolete("Used only in serialization source generation internally")]
+            public static string[] GetDuplicates()
+            {
+                return {{(duplicates.Length == 0 ? "global::System.Array.Empty<string>()" : $"new[] {{{duplicates}}}")}};
             }
             """;
     }

--- a/Robust.Shared/Serialization/ISerializationGenerated.cs
+++ b/Robust.Shared/Serialization/ISerializationGenerated.cs
@@ -40,6 +40,18 @@ public interface ISerializationGenerated<T> : ISerializationGenerated
         SerializationHookContext hookCtx,
         ISerializationContext? context = null);
 
+    /// <seealso cref="ISerializationManager.CopyTo"/>
+    [Obsolete("Use ISerializationManager.CopyTo instead")]
+    static virtual void CopyObj(
+        T source,
+        ref T target,
+        ISerializationManager serialization,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context)
+    {
+        throw new NotImplementedException();
+    }
+
     /// <seealso cref="ISerializationManager.Read"/>
     [Obsolete("Use ISerializationManager.Read instead")]
     static virtual void Read(
@@ -48,6 +60,19 @@ public interface ISerializationGenerated<T> : ISerializationGenerated
         ISerializationManager serialization,
         SerializationHookContext hookCtx,
         ISerializationContext? context)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <seealso cref="ISerializationManager.Read"/>
+    [Obsolete("Use ISerializationManager.Read instead")]
+    static virtual void ReadObj(
+        ref object target,
+        MappingDataNode mappingDataNode,
+        ISerializationManager serialization,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context
+    )
     {
         throw new NotImplementedException();
     }
@@ -72,7 +97,7 @@ public interface ISerializationGenerated<T> : ISerializationGenerated
         ISerializationManager serialization,
         ISerializationContext? context,
         bool alwaysWrite,
-        ImmutableDictionary<string, object?> defaultValues)
+        ImmutableArray<DataFieldDefinition> defaultValues)
     {
         throw new NotImplementedException();
     }
@@ -99,7 +124,19 @@ public interface ISerializationGenerated<T> : ISerializationGenerated
     }
 
     [Obsolete("Used only in serialization source generation internally")]
-    static virtual void GetFieldDefinitions(T? instance, List<DataFieldDefinition> fields, string[]? fieldsParsed = null)
+    static virtual ImmutableArray<DataFieldDefinition> GetFieldDefinitions(T? instance)
+    {
+        throw new NotImplementedException();
+    }
+
+    [Obsolete("Used only in serialization source generation internally")]
+    static virtual DataFieldDefinition GetFieldDefinition(T? instance, int field)
+    {
+        throw new NotImplementedException();
+    }
+
+    [Obsolete("Used only in serialization source generation internally")]
+    static virtual string[] GetDuplicates()
     {
         throw new NotImplementedException();
     }

--- a/Robust.Shared/Serialization/Manager/Definition/DataDefinition.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/DataDefinition.cs
@@ -32,10 +32,12 @@ namespace Robust.Shared.Serialization.Manager.Definition
         internal readonly SerializeDelegateSignature<T> Serialize;
         internal readonly CopyDelegateSignature<T> CopyTo;
         internal readonly EqualDelegateSignature<T> AreEqual;
-
         internal override PopulateDelegateSignature<object> PopulateObj { get; init; }
-#pragma warning restore CS0618
         internal override ISerializationManager.InstantiationDelegate<object> InstantiateObj { get; init; }
+        private ValidateAllFieldsDelegate FieldValidators { get; }
+#pragma warning restore CS0618
+
+        private string[] Duplicates { get; }
 
         [UsedImplicitly]
         internal DataDefinition(SerializationManager manager, bool isRecord)
@@ -43,72 +45,17 @@ namespace Robust.Shared.Serialization.Manager.Definition
             IsRecord = isRecord;
 
 #pragma warning disable CS0618
-            var fieldDefs = new List<DataFieldDefinition>();
-            T.GetFieldDefinitions(default, fieldDefs);
-#pragma warning restore CS0618
-            for (var i = 0; i < fieldDefs.Count; i++)
-            {
-                var field = fieldDefs[i];
-                if (field is { IsDataField: true, Tag: null })
-                    field.Tag = DataDefinitionUtility.AutoGenerateTag(field.FieldInfoName);
-            }
-
-            fieldDefs.Sort((a, b) =>
-            {
-                var priority = b.Priority.CompareTo(a.Priority);
-                if (priority != 0)
-                    return priority;
-
-                return b.FieldInfoName.CompareTo(a.FieldInfoName, StringComparison.OrdinalIgnoreCase);
-            });
-
-            var dataFields = fieldDefs
-                .Where(f => f.IsDataField)
-                .Select(f => f.Tag ?? f.CamelCasedName)
-                .ToArray();
-
-            Duplicates = dataFields
-                .Where(f =>
-                    dataFields.Count(df => df == f) > 1)
-                .Distinct()
-                .ToArray();
-
-            BaseFieldDefinitions = fieldDefs.ToImmutableArray();
-
-            DefaultValues = fieldDefs.Select(f => f.DefaultValue).ToImmutableArray();
-            DefaultValuesDict = fieldDefs.ToImmutableDictionary(
-                f => f.IsDataField
-                    ? f.Tag ?? f.CamelCasedName
-                    : f.CamelCasedName,
-                f => f.DefaultValue
-            );
-
-            //has to be done after fieldinterfaceinfos are done
-#pragma warning disable CS0618
-            // TODO source gen this one too!
-            PopulateObj = (ref target, node, serialization, ctx, context) =>
-            {
-                var obj = (T) target;
-                T.Read(ref obj, node, serialization, ctx, context);
-                target = obj;
-            };
-
+            BaseFieldDefinitions = T.GetFieldDefinitions(default);
+            Duplicates = T.GetDuplicates();
+            PopulateObj = T.ReadObj;
             Populate = T.Read;
             Serialize = T.Write;
-            CopyTo = (source, ref target, ctx, context) => source.Copy(ref target, manager, ctx, context); // TODO source gen this one too!
+            CopyTo = T.CopyObj;
             AreEqual = T.AreEqual;
             FieldValidators = T.Validate;
             InstantiateObj = T.StaticInstantiateObject;
 #pragma warning restore CS0618
         }
-
-        private string[] Duplicates { get; }
-        internal ImmutableArray<object?> DefaultValues { get; }
-        internal ImmutableDictionary<string, object?> DefaultValuesDict { get; }
-
-#pragma warning disable CS0618
-        private ValidateAllFieldsDelegate FieldValidators { get; }
-#pragma warning restore CS0618
 
         private bool TryGetIndex(string tag, out int index)
         {

--- a/Robust.Shared/Serialization/Manager/Definition/DataDefinitionDelegates.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/DataDefinitionDelegates.cs
@@ -12,6 +12,7 @@ namespace Robust.Shared.Serialization.Manager.Definition;
 internal delegate void CopyDelegateSignature<T>(
     T source,
     ref T target,
+    ISerializationManager serialization,
     SerializationHookContext hookCtx,
     ISerializationContext? context);
 
@@ -31,7 +32,7 @@ internal delegate void SerializeDelegateSignature<T>(
     ISerializationManager serialization,
     ISerializationContext? context,
     bool alwaysWrite,
-    ImmutableDictionary<string, object?> defaultValues
+    ImmutableArray<DataFieldDefinition> defaultValues
 );
 
 [Obsolete("Used only in source generation")]

--- a/Robust.Shared/Serialization/Manager/Definition/DataFieldDefinition.cs
+++ b/Robust.Shared/Serialization/Manager/Definition/DataFieldDefinition.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using Robust.Shared.Serialization.Manager.Attributes;
-using Robust.Shared.Utility;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Robust.Shared.Serialization.Manager.Definition;
 
 [Obsolete("Only used in serialization source generators")]
-public record struct DataFieldDefinition(
+public readonly record struct DataFieldDefinition(
     string? Tag,
     int Priority,
     bool IsDataField,

--- a/Robust.Shared/Serialization/Manager/SerializationManager.Copying.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Copying.cs
@@ -341,7 +341,7 @@ public sealed partial class SerializationManager
             return false;
         }
 
-        definition.CopyTo(source, ref target, hookCtx, context);
+        definition.CopyTo(source, ref target, this, hookCtx, context);
         return true;
     }
 

--- a/Robust.Shared/Serialization/Manager/SerializationManager.Writing.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.Writing.cs
@@ -260,7 +260,7 @@ public sealed partial class SerializationManager
             throw new InvalidOperationException($"No data definition found for type {typeof(T)} when writing");
 
         var mapping = new MappingDataNode();
-        definition.Serialize(value, mapping, this, context, alwaysWrite, definition.DefaultValuesDict);
+        definition.Serialize(value, mapping, this, context, alwaysWrite, definition.BaseFieldDefinitions);
 
         return mapping;
     }


### PR DESCRIPTION
On debug
7097 ms > 3323 ms total thread time
230 ms > 148 ms client thread time
111 ms > 82 ms server thread time

Also less allocations
All it does now is assign the properties directly, no more lambdas, no more garbage