### PR TITLE
Add physics queries to entitylookup

### DIFF
--- a/Robust.Shared.IntegrationTests/EntityLookup_Test.cs
+++ b/Robust.Shared.IntegrationTests/EntityLookup_Test.cs
@@ -6,8 +6,10 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Maths;
+using Robust.Shared.Physics;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Physics.Systems;
 using Robust.UnitTesting.Server;
 
@@ -17,6 +19,9 @@ namespace Robust.UnitTesting.Shared
     internal sealed class EntityLookupTest
     {
         private static readonly MapId MapId = new MapId(1);
+        private const string FixtureId = "fix1";
+        private const int FixtureLayer = 1;
+        private const int FixtureMask = 2;
 
         private static readonly TestCaseData[] IntersectingCases = new[]
         {
@@ -56,13 +61,38 @@ namespace Robust.UnitTesting.Shared
             new TestCaseData(true, new MapCoordinates(new Vector2(11f + 0.35f, 10f), MapId), Vector2i.Zero, false),
         };
 
-        private EntityUid GetPhysicsEntity(IEntityManager entManager, MapCoordinates spawnPos)
+        private EntityUid GetPhysicsEntity(
+            IEntityManager entManager,
+            MapCoordinates spawnPos,
+            int collisionLayer = 0,
+            int collisionMask = 0,
+            float radius = 0.35f,
+            bool hard = true)
         {
             var ent = entManager.SpawnEntity(null, spawnPos);
             var physics = entManager.AddComponent<PhysicsComponent>(ent);
-            entManager.System<FixtureSystem>().TryCreateFixture(ent, new PhysShapeCircle(0.35f, Vector2.Zero), "fix1");
+            entManager.System<FixtureSystem>().TryCreateFixture(
+                ent,
+                new PhysShapeCircle(radius, Vector2.Zero),
+                FixtureId,
+                hard: hard,
+                collisionLayer: collisionLayer,
+                collisionMask: collisionMask);
             entManager.System<SharedPhysicsSystem>().SetCanCollide(ent, true, body: physics);
             return ent;
+        }
+
+        private static FixtureQueryArgs FixtureQuery(bool approximate = false, bool ignoreShapeSkin = false)
+        {
+            return new FixtureQueryArgs(
+                new QueryFilter
+                {
+                    LayerBits = FixtureMask,
+                    MaskBits = FixtureLayer,
+                    Flags = QueryFlags.Dynamic | QueryFlags.Static,
+                },
+                approximate,
+                ignoreShapeSkin);
         }
 
         private Entity<MapGridComponent> SetupGrid(MapId mapId, SharedMapSystem mapSystem, IEntityManager entManager)
@@ -335,6 +365,145 @@ namespace Robust.UnitTesting.Shared
 
         #endregion
 
+        #region Fixtures
+
+        [Test]
+        public void TestGetFixturesIntersectingReturnsFixtureProxies()
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+            mapSystem.CreateMap(MapId);
+
+            var matching = GetPhysicsEntity(entManager, new MapCoordinates(Vector2.Zero, MapId), FixtureLayer, FixtureMask);
+            _ = GetPhysicsEntity(entManager, new MapCoordinates(Vector2.Zero, MapId), collisionLayer: 4, collisionMask: 8);
+            _ = GetPhysicsEntity(entManager, new MapCoordinates(new Vector2(5f, 0f), MapId), FixtureLayer, FixtureMask);
+
+            var fixtures = new HashSet<FixtureProxy>();
+            lookup.GetFixturesIntersecting(
+                MapId,
+                Box2.CenteredAround(Vector2.Zero, Vector2.One),
+                fixtures,
+                FixtureQuery());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fixtures.Select(fixture => fixture.Entity), Is.EquivalentTo(new[] { matching }));
+                Assert.That(fixtures.Single().FixtureId, Is.EqualTo(FixtureId));
+            });
+
+            mapSystem.DeleteMap(MapId);
+        }
+
+        [Test]
+        public void TestForEachFixtureIntersectingCanStopQuery()
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+            mapSystem.CreateMap(MapId);
+
+            _ = GetPhysicsEntity(entManager, new MapCoordinates(Vector2.Zero, MapId), FixtureLayer, FixtureMask);
+            _ = GetPhysicsEntity(entManager, new MapCoordinates(new Vector2(0.1f, 0f), MapId), FixtureLayer, FixtureMask);
+
+            var state = new FixtureCallbackState { StopAfter = 1 };
+            var completed = lookup.ForEachFixtureIntersecting(
+                MapId,
+                Box2.CenteredAround(Vector2.Zero, Vector2.One),
+                ref state,
+                new CountFixtureCallback(),
+                FixtureQuery());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(completed, Is.False);
+                Assert.That(state.Count, Is.EqualTo(1));
+            });
+
+            mapSystem.DeleteMap(MapId);
+        }
+
+        [Test]
+        public void TestFixtureShapeQueryUsesNarrowphaseWhenExact()
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+            mapSystem.CreateMap(MapId);
+
+            var target = GetPhysicsEntity(entManager, new MapCoordinates(Vector2.Zero, MapId), FixtureLayer, FixtureMask);
+            var queryShape = new PhysShapeCircle(0.05f);
+            var queryTransform = new Transform(new Vector2(0.39f, 0.39f), 0f);
+
+            var approximate = new HashSet<FixtureProxy>();
+            lookup.GetFixturesIntersecting(
+                MapId,
+                queryShape,
+                queryTransform,
+                approximate,
+                FixtureQuery(approximate: true));
+
+            var exact = new HashSet<FixtureProxy>();
+            lookup.GetFixturesIntersecting(
+                MapId,
+                queryShape,
+                queryTransform,
+                exact,
+                FixtureQuery());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(approximate.Select(fixture => fixture.Entity), Does.Contain(target));
+                Assert.That(exact.Select(fixture => fixture.Entity), Does.Not.Contain(target));
+            });
+
+            mapSystem.DeleteMap(MapId);
+        }
+
+        [Test]
+        public void TestForEachLocalFixtureIntersectingQueriesBroadphaseEntity()
+        {
+            var sim = RobustServerSimulation.NewSimulation();
+            var server = sim.InitializeInstance();
+
+            var lookup = server.Resolve<IEntitySystemManager>().GetEntitySystem<EntityLookupSystem>();
+            var entManager = server.Resolve<IEntityManager>();
+            var mapSystem = entManager.System<SharedMapSystem>();
+
+            mapSystem.CreateMap(MapId);
+            var grid = SetupGrid(MapId, mapSystem, entManager);
+            var matching = GetPhysicsEntity(entManager, new MapCoordinates(new Vector2(10.5f, 10.5f), MapId), FixtureLayer, FixtureMask);
+
+            var state = new FixtureCallbackState();
+            var completed = lookup.ForEachLocalFixtureIntersecting(
+                grid.Owner,
+                new PhysShapeCircle(0.5f),
+                new Transform(new Vector2(0.5f, 0.5f), 0f),
+                ref state,
+                new CountFixtureCallback(),
+                FixtureQuery());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(completed, Is.True);
+                Assert.That(state.Count, Is.EqualTo(1));
+                Assert.That(state.LastEntity, Is.EqualTo(matching));
+            });
+
+            mapSystem.DeleteMap(MapId);
+        }
+
+        #endregion
+
         /// <summary>
         /// Is the entity correctly removed / added to EntityLookup when anchored
         /// </summary>
@@ -375,6 +544,23 @@ namespace Robust.UnitTesting.Shared
             entManager.DeleteEntity(dummy);
             entManager.DeleteEntity(grid);
             mapSystem.DeleteMap(mapId);
+        }
+
+        private struct FixtureCallbackState
+        {
+            public int Count;
+            public int StopAfter;
+            public EntityUid LastEntity;
+        }
+
+        private readonly struct CountFixtureCallback : IFixtureQueryCallback<FixtureCallbackState>
+        {
+            public bool Invoke(ref FixtureCallbackState state, in FixtureProxy fixture)
+            {
+                state.Count++;
+                state.LastEntity = fixture.Entity;
+                return state.StopAfter <= 0 || state.Count < state.StopAfter;
+            }
         }
     }
 }

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.LocalQueries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.LocalQueries.cs
@@ -71,7 +71,7 @@ public sealed partial class EntityLookupSystem
     /// <summary>
     /// Gets entities intersecting to the relative broadphase entity. Does NOT turn the transform into local terms.
     /// </summary>
-    public void GetLocalEntitiesIntersecting(EntityUid gridUid, IPhysShape shape, Transform localTransform, HashSet<EntityUid> intersecting, LookupFlags flags = DefaultFlags, BroadphaseComponent? lookup = null)
+    public void GetLocalEntitiesIntersecting<T>(EntityUid gridUid, T shape, Transform localTransform, HashSet<EntityUid> intersecting, LookupFlags flags = DefaultFlags, BroadphaseComponent? lookup = null) where T : IPhysShape
     {
         var localAABB = shape.ComputeAABB(localTransform, 0);
         AddEntitiesIntersecting(gridUid, intersecting, shape, localAABB, localTransform, flags: flags, lookup: lookup);

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.Physics.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.Physics.cs
@@ -1,0 +1,406 @@
+using System.Collections.Generic;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Collision;
+using Robust.Shared.Physics.Collision.Shapes;
+using Robust.Shared.Physics.Dynamics;
+using Robust.Shared.Physics.Shapes;
+using Robust.Shared.Physics.Systems;
+
+namespace Robust.Shared.GameObjects;
+
+public interface IFixtureQueryCallback<TState>
+{
+    /// <summary>
+    /// Invoked for each matching fixture. Return false to stop the query.
+    /// </summary>
+    bool Invoke(ref TState state, in FixtureProxy fixture);
+}
+
+public record struct FixtureQueryArgs
+{
+    public QueryFilter Filter { get; init; }
+    public bool Approximate { get; init; }
+    public bool IgnoreShapeSkin { get; init; }
+
+    public FixtureQueryArgs(QueryFilter filter, bool approximate = false, bool ignoreShapeSkin = false)
+    {
+        Filter = filter;
+        Approximate = approximate;
+        IgnoreShapeSkin = ignoreShapeSkin;
+    }
+}
+
+public sealed partial class EntityLookupSystem
+{
+    /// <summary>
+    /// Gets fixtures intersecting the specified world AABB.
+    /// </summary>
+    public void GetFixturesIntersecting(
+        MapId mapId,
+        Box2 worldAABB,
+        HashSet<FixtureProxy> fixtures,
+        FixtureQueryArgs query)
+    {
+        ForEachFixtureIntersecting(mapId, worldAABB, ref fixtures, new AddFixtureToHashSetCallback(), query);
+    }
+
+    /// <summary>
+    /// Invokes <paramref name="callback"/> for each fixture intersecting the specified world AABB.
+    /// Returns false if the callback stopped the query.
+    /// </summary>
+    public bool ForEachFixtureIntersecting<TState, TCallback>(
+        MapId mapId,
+        Box2 worldAABB,
+        ref TState state,
+        TCallback callback,
+        FixtureQueryArgs query)
+        where TCallback : struct, IFixtureQueryCallback<TState>
+    {
+        var polygon = new SlimPolygon(worldAABB);
+        return ForEachFixtureIntersecting(mapId, polygon, Physics.Transform.Empty, ref state, callback, query);
+    }
+
+    /// <summary>
+    /// Gets fixtures intersecting the specified rotated world bounds.
+    /// </summary>
+    public void GetFixturesIntersecting(
+        MapId mapId,
+        Box2Rotated worldBounds,
+        HashSet<FixtureProxy> fixtures,
+        FixtureQueryArgs query)
+    {
+        ForEachFixtureIntersecting(mapId, worldBounds, ref fixtures, new AddFixtureToHashSetCallback(), query);
+    }
+
+    /// <summary>
+    /// Invokes <paramref name="callback"/> for each fixture intersecting the specified rotated world bounds.
+    /// Returns false if the callback stopped the query.
+    /// </summary>
+    public bool ForEachFixtureIntersecting<TState, TCallback>(
+        MapId mapId,
+        Box2Rotated worldBounds,
+        ref TState state,
+        TCallback callback,
+        FixtureQueryArgs query)
+        where TCallback : struct, IFixtureQueryCallback<TState>
+    {
+        var polygon = new SlimPolygon(worldBounds);
+        return ForEachFixtureIntersecting(mapId, polygon, Physics.Transform.Empty, ref state, callback, query);
+    }
+
+    /// <summary>
+    /// Gets fixtures intersecting a shape in world-space.
+    /// </summary>
+    public void GetFixturesIntersecting<TShape>(
+        MapId mapId,
+        TShape shape,
+        Transform shapeTransform,
+        HashSet<FixtureProxy> fixtures,
+        FixtureQueryArgs query)
+        where TShape : IPhysShape
+    {
+        GetFixturesIntersecting(mapId, shape, 0, shapeTransform, fixtures, query);
+    }
+
+    /// <summary>
+    /// Gets fixtures intersecting a child shape in world-space.
+    /// </summary>
+    public void GetFixturesIntersecting<TShape>(
+        MapId mapId,
+        TShape shape,
+        int childIndex,
+        Transform shapeTransform,
+        HashSet<FixtureProxy> fixtures,
+        FixtureQueryArgs query)
+        where TShape : IPhysShape
+    {
+        ForEachFixtureIntersecting(
+            mapId,
+            shape,
+            childIndex,
+            shapeTransform,
+            ref fixtures,
+            new AddFixtureToHashSetCallback(),
+            query);
+    }
+
+    /// <summary>
+    /// Invokes <paramref name="callback"/> for each fixture intersecting a shape in world-space.
+    /// Returns false if the callback stopped the query.
+    /// </summary>
+    public bool ForEachFixtureIntersecting<TState, TShape, TCallback>(
+        MapId mapId,
+        TShape shape,
+        Transform shapeTransform,
+        ref TState state,
+        TCallback callback,
+        FixtureQueryArgs query)
+        where TShape : IPhysShape
+        where TCallback : struct, IFixtureQueryCallback<TState>
+    {
+        return ForEachFixtureIntersecting(mapId, shape, 0, shapeTransform, ref state, callback, query);
+    }
+
+    /// <summary>
+    /// Invokes <paramref name="callback"/> for each fixture intersecting a child shape in world-space.
+    /// Returns false if the callback stopped the query.
+    /// </summary>
+    public bool ForEachFixtureIntersecting<TState, TShape, TCallback>(
+        MapId mapId,
+        TShape shape,
+        int childIndex,
+        Transform shapeTransform,
+        ref TState state,
+        TCallback callback,
+        FixtureQueryArgs query)
+        where TShape : IPhysShape
+        where TCallback : struct, IFixtureQueryCallback<TState>
+    {
+        if (mapId == MapId.Nullspace)
+            return true;
+
+        var worldAABB = shape.ComputeAABB(shapeTransform, childIndex);
+        var queryState = new GridFixtureQueryState<TState, TShape, TCallback>(
+            state,
+            callback,
+            shape,
+            childIndex,
+            shapeTransform,
+            query,
+            this,
+            _physics);
+
+        _map.FindGridsIntersecting(mapId, worldAABB, ref queryState,
+            static (EntityUid uid, MapGridComponent grid, ref GridFixtureQueryState<TState, TShape, TCallback> state) =>
+            {
+                var localTransform = state.Physics.GetRelativePhysicsTransform(state.Transform, uid);
+                var result = state.Lookup.ForEachLocalFixtureIntersecting(
+                    uid,
+                    state.Shape,
+                    state.ChildIndex,
+                    localTransform,
+                    ref state.State,
+                    state.Callback,
+                    state.Query);
+
+                if (!result)
+                    state.Continue = false;
+
+                return result;
+            }, approx: true, includeMap: false);
+
+        state = queryState.State;
+
+        if (!queryState.Continue)
+            return false;
+
+        var mapUid = _map.GetMapOrInvalid(mapId);
+        var mapTransform = _physics.GetRelativePhysicsTransform(shapeTransform, mapUid);
+        return ForEachLocalFixtureIntersecting(
+            mapUid,
+            shape,
+            childIndex,
+            mapTransform,
+            ref state,
+            callback,
+            query);
+    }
+
+    /// <summary>
+    /// Invokes <paramref name="callback"/> for each fixture intersecting a shape in the local coordinates of a broadphase entity.
+    /// Returns false if the callback stopped the query.
+    /// </summary>
+    public bool ForEachLocalFixtureIntersecting<TState, TShape, TCallback>(
+        EntityUid lookupUid,
+        TShape shape,
+        Transform localTransform,
+        ref TState state,
+        TCallback callback,
+        FixtureQueryArgs query,
+        BroadphaseComponent? lookup = null)
+        where TShape : IPhysShape
+        where TCallback : struct, IFixtureQueryCallback<TState>
+    {
+        return ForEachLocalFixtureIntersecting(lookupUid, shape, 0, localTransform, ref state, callback, query, lookup);
+    }
+
+    /// <summary>
+    /// Invokes <paramref name="callback"/> for each fixture intersecting a child shape in the local coordinates of a broadphase entity.
+    /// Returns false if the callback stopped the query.
+    /// </summary>
+    public bool ForEachLocalFixtureIntersecting<TState, TShape, TCallback>(
+        EntityUid lookupUid,
+        TShape shape,
+        int childIndex,
+        Transform localTransform,
+        ref TState state,
+        TCallback callback,
+        FixtureQueryArgs query,
+        BroadphaseComponent? lookup = null)
+        where TShape : IPhysShape
+        where TCallback : struct, IFixtureQueryCallback<TState>
+    {
+        if (!_broadQuery.Resolve(lookupUid, ref lookup))
+            return true;
+
+        var localAABB = shape.ComputeAABB(localTransform, childIndex);
+        var queryState = new FixtureQueryState<TState, TShape, TCallback>(
+            state,
+            callback,
+            shape,
+            childIndex,
+            localTransform,
+            query,
+            _physics,
+            _manifoldManager);
+
+        if ((query.Filter.Flags & QueryFlags.Dynamic) == QueryFlags.Dynamic)
+        {
+            lookup.DynamicTree.QueryAabb(ref queryState, FixtureQuery, localAABB, false);
+            if (!queryState.Continue)
+            {
+                state = queryState.State;
+                return false;
+            }
+        }
+
+        if ((query.Filter.Flags & QueryFlags.Static) == QueryFlags.Static)
+            lookup.StaticTree.QueryAabb(ref queryState, FixtureQuery, localAABB, false);
+
+        state = queryState.State;
+        return queryState.Continue;
+    }
+
+    private static bool FixtureQuery<TState, TShape, TCallback>(
+        ref FixtureQueryState<TState, TShape, TCallback> state,
+        in FixtureProxy proxy)
+        where TShape : IPhysShape
+        where TCallback : struct, IFixtureQueryCallback<TState>
+    {
+        if (!FixtureMatchesFilter(proxy, state.Query.Filter))
+            return true;
+
+        if (!state.Query.Approximate)
+        {
+            var transform = state.Physics.GetLocalPhysicsTransform(proxy.Entity, proxy.Xform);
+            if (!state.Manifolds.TestOverlap(
+                    state.Shape,
+                    state.ChildIndex,
+                    proxy.Fixture.Shape,
+                    proxy.ChildIndex,
+                    state.Transform,
+                    transform,
+                    ignoreShapeSkin: state.Query.IgnoreShapeSkin))
+            {
+                return true;
+            }
+        }
+
+        if (state.Callback.Invoke(ref state.State, proxy))
+            return true;
+
+        state.Continue = false;
+        return false;
+    }
+
+    private static bool FixtureMatchesFilter(in FixtureProxy proxy, QueryFilter filter)
+    {
+        if ((filter.Flags & QueryFlags.Sensors) == 0 && !proxy.Fixture.Hard)
+            return false;
+
+        if ((proxy.Fixture.CollisionLayer & filter.MaskBits) == 0 &&
+            (proxy.Fixture.CollisionMask & filter.LayerBits) == 0)
+        {
+            return false;
+        }
+
+        if (filter.IsIgnored?.Invoke(proxy.Entity) == true)
+            return false;
+
+        return true;
+    }
+
+    private readonly struct AddFixtureToHashSetCallback : IFixtureQueryCallback<HashSet<FixtureProxy>>
+    {
+        public bool Invoke(ref HashSet<FixtureProxy> state, in FixtureProxy fixture)
+        {
+            state.Add(fixture);
+            return true;
+        }
+    }
+
+    private struct GridFixtureQueryState<TState, TShape, TCallback>
+        where TShape : IPhysShape
+        where TCallback : struct, IFixtureQueryCallback<TState>
+    {
+        public TState State;
+        public TCallback Callback;
+        public TShape Shape;
+        public int ChildIndex;
+        public Transform Transform;
+        public FixtureQueryArgs Query;
+        public EntityLookupSystem Lookup;
+        public SharedPhysicsSystem Physics;
+        public bool Continue;
+
+        public GridFixtureQueryState(
+            TState state,
+            TCallback callback,
+            TShape shape,
+            int childIndex,
+            Transform transform,
+            FixtureQueryArgs query,
+            EntityLookupSystem lookup,
+            SharedPhysicsSystem physics)
+        {
+            State = state;
+            Callback = callback;
+            Shape = shape;
+            ChildIndex = childIndex;
+            Transform = transform;
+            Query = query;
+            Lookup = lookup;
+            Physics = physics;
+            Continue = true;
+        }
+    }
+
+    private struct FixtureQueryState<TState, TShape, TCallback>
+        where TShape : IPhysShape
+        where TCallback : struct, IFixtureQueryCallback<TState>
+    {
+        public TState State;
+        public TCallback Callback;
+        public TShape Shape;
+        public int ChildIndex;
+        public Transform Transform;
+        public FixtureQueryArgs Query;
+        public SharedPhysicsSystem Physics;
+        public IManifoldManager Manifolds;
+        public bool Continue;
+
+        public FixtureQueryState(
+            TState state,
+            TCallback callback,
+            TShape shape,
+            int childIndex,
+            Transform transform,
+            FixtureQueryArgs query,
+            SharedPhysicsSystem physics,
+            IManifoldManager manifolds)
+        {
+            State = state;
+            Callback = callback;
+            Shape = shape;
+            ChildIndex = childIndex;
+            Transform = transform;
+            Query = query;
+            Physics = physics;
+            Manifolds = manifolds;
+            Continue = true;
+        }
+    }
+}

--- a/Robust.Shared/GameObjects/Systems/EntityLookupSystem.Physics.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookupSystem.Physics.cs
@@ -19,18 +19,14 @@ public interface IFixtureQueryCallback<TState>
     bool Invoke(ref TState state, in FixtureProxy fixture);
 }
 
-public record struct FixtureQueryArgs
+public readonly record struct FixtureQueryArgs(
+    QueryFilter Filter,
+    bool Approximate = false,
+    bool IgnoreShapeSkin = false)
 {
-    public QueryFilter Filter { get; init; }
-    public bool Approximate { get; init; }
-    public bool IgnoreShapeSkin { get; init; }
-
-    public FixtureQueryArgs(QueryFilter filter, bool approximate = false, bool ignoreShapeSkin = false)
-    {
-        Filter = filter;
-        Approximate = approximate;
-        IgnoreShapeSkin = ignoreShapeSkin;
-    }
+    public readonly QueryFilter Filter = Filter;
+    public readonly bool Approximate = Approximate;
+    public readonly bool IgnoreShapeSkin = IgnoreShapeSkin;
 }
 
 public sealed partial class EntityLookupSystem

--- a/Robust.Shared/Physics/Collision/CollisionManager.Overlap.cs
+++ b/Robust.Shared/Physics/Collision/CollisionManager.Overlap.cs
@@ -12,7 +12,14 @@ internal sealed partial class CollisionManager
     /// <param name="xfA">The transform for the first shape.</param>
     /// <param name="xfB">The transform for the seconds shape.</param>
     /// <returns></returns>
-    public bool TestOverlap<T, U>(T shapeA, int indexA, U shapeB, int indexB, in Transform xfA, in Transform xfB)
+    public bool TestOverlap<T, U>(
+        T shapeA,
+        int indexA,
+        U shapeB,
+        int indexB,
+        in Transform xfA,
+        in Transform xfB,
+        bool ignoreShapeSkin = false)
         where T : IPhysShape
         where U : IPhysShape
     {
@@ -20,6 +27,16 @@ internal sealed partial class CollisionManager
 
         input.ProxyA.Set(in shapeA, indexA);
         input.ProxyB.Set(in shapeB, indexB);
+
+        if (ignoreShapeSkin)
+        {
+            if (shapeA.ShapeType != ShapeType.Circle)
+                input.ProxyA.Radius = 0f;
+
+            if (shapeB.ShapeType != ShapeType.Circle)
+                input.ProxyB.Radius = 0f;
+        }
+
         input.TransformA = xfA;
         input.TransformB = xfB;
         input.UseRadii = true;

--- a/Robust.Shared/Physics/Collision/IManifoldManager.cs
+++ b/Robust.Shared/Physics/Collision/IManifoldManager.cs
@@ -12,7 +12,14 @@ internal interface IManifoldManager
 
     void ReturnEdge(EdgeShape edge);
 
-    bool TestOverlap<T, U>(T shapeA, int indexA, U shapeB, int indexB, in Transform xfA, in Transform xfB)
+    bool TestOverlap<T, U>(
+        T shapeA,
+        int indexA,
+        U shapeB,
+        int indexB,
+        in Transform xfA,
+        in Transform xfB,
+        bool ignoreShapeSkin = false)
         where T : IPhysShape
         where U : IPhysShape;
 

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
@@ -185,7 +185,7 @@ namespace Robust.Shared.Physics.Systems
                     MaskBits = -1L,
                     Flags = QueryFlags.Dynamic | QueryFlags.Static | QueryFlags.Sensors,
                 },
-                approximate: true);
+                Approximate: true);
         }
 
         private readonly struct AddPhysicsBodyCallback : IFixtureQueryCallback<HashSet<PhysicsComponent>>

--- a/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
+++ b/Robust.Shared/Physics/Systems/SharedPhysicsSystem.Queries.cs
@@ -139,32 +139,19 @@ namespace Robust.Shared.Physics.Systems
         /// <summary>
         /// Get all entities colliding with a certain body.
         /// </summary>
-        [Obsolete("Use EntityLookupSystem")]
+        [Obsolete("Use EntityLookupSystem.ForEachFixtureIntersecting or EntityLookupSystem.GetFixturesIntersecting")]
         public IEnumerable<PhysicsComponent> GetCollidingEntities(MapId mapId, in Box2 worldAABB)
         {
-            if (mapId == MapId.Nullspace) return Array.Empty<PhysicsComponent>();
+            if (mapId == MapId.Nullspace)
+                return Array.Empty<PhysicsComponent>();
 
-            var aabb = worldAABB;
             var bodies = new HashSet<PhysicsComponent>();
-            var state = (_transform, bodies, aabb);
-
-            _broadphase.GetBroadphases(mapId, worldAABB, ref state, static
-                (
-                    Entity<BroadphaseComponent> entity,
-                    ref (SharedTransformSystem _transform, HashSet<PhysicsComponent> bodies, Box2 aabb) tuple) =>
-                {
-                    var gridAABB = tuple._transform.GetInvWorldMatrix(entity.Owner).TransformBox(tuple.aabb);
-
-                    foreach (var proxy in entity.Comp.StaticTree.QueryAabb(gridAABB, false))
-                    {
-                        tuple.bodies.Add(proxy.Body);
-                    }
-
-                    foreach (var proxy in entity.Comp.DynamicTree.QueryAabb(gridAABB, false))
-                    {
-                        tuple.bodies.Add(proxy.Body);
-                    }
-                });
+            _lookup.ForEachFixtureIntersecting(
+                mapId,
+                worldAABB,
+                ref bodies,
+                new AddPhysicsBodyCallback(),
+                GetAllFixtureQueryArgs());
 
             return bodies;
         }
@@ -172,37 +159,51 @@ namespace Robust.Shared.Physics.Systems
         /// <summary>
         /// Get all entities colliding with a certain body.
         /// </summary>
-        [Obsolete("Use EntityLookupSystem")]
+        [Obsolete("Use EntityLookupSystem.ForEachFixtureIntersecting or EntityLookupSystem.GetFixturesIntersecting")]
         public IEnumerable<Entity<PhysicsComponent>> GetCollidingEntities(MapId mapId, in Box2Rotated worldBounds)
         {
             if (mapId == MapId.Nullspace)
                 return Array.Empty<Entity<PhysicsComponent>>();
 
             var bodies = new HashSet<Entity<PhysicsComponent>>();
-
-            var state = (_transform, bodies, worldBounds);
-
-            _broadphase.GetBroadphases(mapId, worldBounds.CalcBoundingBox(), ref state,
-                static (
-                    Entity<BroadphaseComponent> entity,
-                    ref (SharedTransformSystem _transform, HashSet<Entity<PhysicsComponent>> bodies, Box2Rotated
-                        worldBounds
-                        ) tuple) =>
-                {
-                    var gridAABB = tuple._transform.GetInvWorldMatrix(entity.Owner).TransformBox(tuple.worldBounds);
-
-                    foreach (var proxy in entity.Comp.StaticTree.QueryAabb(gridAABB, false))
-                    {
-                        tuple.bodies.Add((proxy.Entity, proxy.Body));
-                    }
-
-                    foreach (var proxy in entity.Comp.DynamicTree.QueryAabb(gridAABB, false))
-                    {
-                        tuple.bodies.Add((proxy.Entity, proxy.Body));
-                    }
-                });
+            _lookup.ForEachFixtureIntersecting(
+                mapId,
+                worldBounds,
+                ref bodies,
+                new AddEntityPhysicsBodyCallback(),
+                GetAllFixtureQueryArgs());
 
             return bodies;
+        }
+
+        private static FixtureQueryArgs GetAllFixtureQueryArgs()
+        {
+            return new FixtureQueryArgs(
+                new QueryFilter
+                {
+                    LayerBits = -1L,
+                    MaskBits = -1L,
+                    Flags = QueryFlags.Dynamic | QueryFlags.Static | QueryFlags.Sensors,
+                },
+                approximate: true);
+        }
+
+        private readonly struct AddPhysicsBodyCallback : IFixtureQueryCallback<HashSet<PhysicsComponent>>
+        {
+            public bool Invoke(ref HashSet<PhysicsComponent> state, in FixtureProxy fixture)
+            {
+                state.Add(fixture.Body);
+                return true;
+            }
+        }
+
+        private readonly struct AddEntityPhysicsBodyCallback : IFixtureQueryCallback<HashSet<Entity<PhysicsComponent>>>
+        {
+            public bool Invoke(ref HashSet<Entity<PhysicsComponent>> state, in FixtureProxy fixture)
+            {
+                state.Add((fixture.Entity, fixture.Body));
+                return true;
+            }
         }
 
         public void GetContactingEntities(Entity<PhysicsComponent?> ent, HashSet<EntityUid> contacting, bool approximate = false)


### PR DESCRIPTION
Sanity. Right now they're on sharedphysicssystem but a lot of content just uses entitylookup and then immediately wants fixture data. This just makes it actually sane and not bleed performance like crazy.

Added callback versions because the existing lookup should get it + used struct args because they are based and I should've used them in the first place to minimise API breakage.