### PR TITLE
Make Toolshed's PrototypeTypeParser return its results sorted

### DIFF
--- a/Robust.Shared/Toolshed/TypeParsers/PrototypeTypeParser.cs
+++ b/Robust.Shared/Toolshed/TypeParsers/PrototypeTypeParser.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Text;
+﻿using System.Text;
 using Robust.Shared.Configuration;
 using Robust.Shared.Console;
 using Robust.Shared.IoC;
@@ -53,7 +50,7 @@ public sealed partial class ProtoIdTypeParser<T> : TypeParser<ProtoId<T>>
     {
         var hint = ToolshedCommand.GetArgHint(arg, typeof(ProtoId<T>));
         var maxCount = _config.GetCVar(CVars.ToolshedPrototypesAutocompleteLimit);
-        var options = CompletionHelper.PrototypeIdsLimited<T>(ctx.Input[ctx.Index..], proto: _proto, maxCount: maxCount);
+        var options = CompletionHelper.PrototypeIdsLimited<T>(ctx.Input[ctx.Index..], _proto, true, maxCount);
         return CompletionResult.FromHintOptions(options, hint);
     }
 }


### PR DESCRIPTION
The sort happens after the max count limit
Makes it slightly easier to find anything (and also notice when it's cut-off)
This changes it for both ProtoId<T> and EntProtoId