### PR TITLE
Fix LayerSetShader to accept null shader input

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* `LayerSetShader` now supports setting shaders to `null` when using an `object` layer key.
 
 ### Bugfixes
 

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -980,14 +980,8 @@ namespace Robust.Client.GameObjects
             LayerSetShader(layer, shader, prototype);
         }
 
-        public void LayerSetShader(int layer, string? shaderName)
+        public void LayerSetShader(int layer, string shaderName)
         {
-            if (shaderName == null)
-            {
-                LayerSetShader(layer, null, null);
-                return;
-            }
-
             if (!prototypes.TryIndex<ShaderPrototype>(shaderName, out var prototype))
             {
                 Logger.ErrorS(LogCategory,
@@ -1002,7 +996,7 @@ namespace Robust.Client.GameObjects
             LayerSetShader(layer, prototype.Instance(), shaderName);
         }
 
-        public void LayerSetShader(object layerKey, string? shaderName)
+        public void LayerSetShader(object layerKey, string shaderName)
         {
             if (!LayerMapTryGet(layerKey, out var layer, true))
                 return;

--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -972,7 +972,7 @@ namespace Robust.Client.GameObjects
             theLayer.ShaderPrototype = prototype;
         }
 
-        public void LayerSetShader(object layerKey, ShaderInstance shader, string? prototype = null)
+        public void LayerSetShader(object layerKey, ShaderInstance? shader, string? prototype = null)
         {
             if (!LayerMapTryGet(layerKey, out var layer, true))
                 return;
@@ -980,8 +980,14 @@ namespace Robust.Client.GameObjects
             LayerSetShader(layer, shader, prototype);
         }
 
-        public void LayerSetShader(int layer, string shaderName)
+        public void LayerSetShader(int layer, string? shaderName)
         {
+            if (shaderName == null)
+            {
+                LayerSetShader(layer, null, null);
+                return;
+            }
+
             if (!prototypes.TryIndex<ShaderPrototype>(shaderName, out var prototype))
             {
                 Logger.ErrorS(LogCategory,
@@ -996,7 +1002,7 @@ namespace Robust.Client.GameObjects
             LayerSetShader(layer, prototype.Instance(), shaderName);
         }
 
-        public void LayerSetShader(object layerKey, string shaderName)
+        public void LayerSetShader(object layerKey, string? shaderName)
         {
             if (!LayerMapTryGet(layerKey, out var layer, true))
                 return;


### PR DESCRIPTION
When rendering, all "regular" sprites are rendered with the layer's shader property set to `null`. 

If a sprite gets a shader set, you can revert it to `null` via the method:
`LayerSetShader(int layer, ShaderInstance? shader, string? prototype = null)`.

For some reason the `object layerKey` version of this method did not allow `null`, so this PR fixes that.

---

I left
`LayerSetShader(int layer, string shaderName)`
`LayerSetShader(object layerKey, string shaderName)`
the same since making the string nullable would have them effectively identical to the other two.