### PR TITLE
Fix Clyde deadlock on nvidia/wayland

### DIFF
--- a/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
+++ b/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs
@@ -167,6 +167,11 @@ namespace Robust.Client.Graphics.Clyde
                 {
                     GL.Finish();
                 }
+                else if (Clyde._hasGLFenceSync)
+                {
+                    // Submit the fences before the secondary contexts wait on them.
+                    GL.Flush();
+                }
 
                 if (Clyde.EffectiveThreadWindowBlit)
                 {


### PR DESCRIPTION
I am *not* well-versed in OpenGL but I *think* this is correct.
According to [the docs](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_sync.txt) here:

> If a sync object is associated with a fence command issued previously, but not yet flushed, ClientWaitSync may hang forever.

We use WaitSync instead of ClientWaitSync, so I'm not sure how relevant that is, however the docs also say:
> Applications which block on a fence sync object must take additional steps to assure that the context from which the corresponding fence command was issued has flushed that command.

In our case, we do FenceSync here: https://github.com/space-wizards/RobustToolbox/blob/1d0b581982dac2840943586282d03d633585e28b/Robust.Client/Graphics/Clyde/Clyde.Rendering.cs#L1171

and then we WaitSync on it here: https://github.com/space-wizards/RobustToolbox/blob/1d0b581982dac2840943586282d03d633585e28b/Robust.Client/Graphics/Clyde/GLContext/GLContextWindow.cs#L206

And we don't Flush() at any point.

Additionally, Issue 20 in the docs also indicates a Flush() after FenceSync() is needed in this situation, which is what my change adds. It does still mention ClientWaitSync instead of WaitSync, and I'm not sure if that matters.

This change does fix the issue on my end so it closes #6958