### PR TITLE
Reject nullable component parameters in generated event subscriptions

### DIFF
--- a/Robust.Analyzers.Tests/EntitySystemSubscriptionGeneratorErrorAnalyzerTest.cs
+++ b/Robust.Analyzers.Tests/EntitySystemSubscriptionGeneratorErrorAnalyzerTest.cs
@@ -1,0 +1,116 @@
+extern alias EntitySystemSubscriptionsGenerator;
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Analyzer = EntitySystemSubscriptionsGenerator::Robust.Shared.EntitySystemSubscriptionsGenerator.EntitySystemSubscriptionGeneratorErrorAnalyzer;
+using Diagnostics = EntitySystemSubscriptionsGenerator::Robust.Roslyn.Shared.Diagnostics;
+
+namespace Robust.Analyzers.Tests;
+
+[TestFixture]
+[TestOf(typeof(Analyzer))]
+[Parallelizable(ParallelScope.All)]
+public sealed class EntitySystemSubscriptionGeneratorErrorAnalyzerTest
+{
+    private const string TestTypeDefs = """
+        #nullable enable
+        global using System;
+        global using Robust.Shared.Analyzers;
+        global using Robust.Shared.GameObjects;
+
+        namespace Robust.Shared.Analyzers
+        {
+            [AttributeUsage(AttributeTargets.Method)]
+            public sealed class SubscribeLocalEventAttribute : Attribute;
+        }
+
+        namespace Robust.Shared.GameObjects
+        {
+            public readonly struct EntityUid;
+            public interface IComponent;
+            public readonly struct Entity<T> where T : IComponent?;
+            public abstract class EntitySystem;
+        }
+
+        public sealed class TestComponent : IComponent;
+        public sealed class TestEvent;
+        """;
+
+    [Test]
+    public async Task NonNullableComponentParameter()
+    {
+        await Verify("""
+            public sealed class TestSystem : EntitySystem
+            {
+                [SubscribeLocalEvent]
+                private void OnEvent(EntityUid uid, TestComponent component, ref TestEvent args)
+                {
+                }
+            }
+            """);
+    }
+
+    [Test]
+    public async Task NonNullableEntityComponent()
+    {
+        await Verify("""
+            public sealed class TestSystem : EntitySystem
+            {
+                [SubscribeLocalEvent]
+                private void OnEvent(Entity<TestComponent> entity, ref TestEvent args)
+                {
+                }
+            }
+            """);
+    }
+
+    [Test]
+    public async Task NullableComponentParameter()
+    {
+        await Verify("""
+            public sealed class TestSystem : EntitySystem
+            {
+                [SubscribeLocalEvent]
+                private void {|#0:OnEvent|}(EntityUid uid, TestComponent? component, ref TestEvent args)
+                {
+                }
+            }
+            """, new DiagnosticResult(
+                Diagnostics.IdInvalidAMethodSignatureForGeneratedSubscription,
+                DiagnosticSeverity.Error).WithLocation(0));
+    }
+
+    [Test]
+    public async Task NullableEntityComponent()
+    {
+        await Verify("""
+            public sealed class TestSystem : EntitySystem
+            {
+                [SubscribeLocalEvent]
+                private void {|#0:OnEvent|}(Entity<TestComponent?> entity, ref TestEvent args)
+                {
+                }
+            }
+            """, new DiagnosticResult(
+                Diagnostics.IdInvalidAMethodSignatureForGeneratedSubscription,
+                DiagnosticSeverity.Error).WithLocation(0));
+    }
+
+    private static Task Verify(string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<Analyzer, DefaultVerifier>
+        {
+            TestState =
+            {
+                Sources = { source },
+            },
+        };
+
+        test.TestState.Sources.Add(("TestTypeDefs.cs", TestTypeDefs));
+        test.TestState.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+}

--- a/Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj
+++ b/Robust.Analyzers.Tests/Robust.Analyzers.Tests.csproj
@@ -54,6 +54,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Robust.Analyzers\Robust.Analyzers.csproj"/>
+    <ProjectReference Include="..\Robust.Shared.EntitySystemSubscriptionsGenerator\Robust.Shared.EntitySystemSubscriptionsGenerator.csproj" Aliases="EntitySystemSubscriptionsGenerator" />
     <ProjectReference Include="..\Robust.Serialization.Generator\Robust.Serialization.Generator.csproj" Aliases="SerializationGenerator" />
   </ItemGroup>
 </Project>

--- a/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
+++ b/Robust.Shared.EntitySystemSubscriptionsGenerator/EntitySystemSubscriptionGenerator.cs
@@ -196,6 +196,7 @@ using JetBrains.Annotations;
 
         if (entityType.OriginalDefinition.ToDisplayString() != EntityTypeName ||
             entityType.TypeArguments is not [INamedTypeSymbol componentType] ||
+            componentType.NullableAnnotation == NullableAnnotation.Annotated ||
             !TypeSymbolHelper.ImplementsInterface(componentType, IComponentTypeName))
             return null;
 
@@ -211,6 +212,7 @@ using JetBrains.Annotations;
             method.Parameters[1].Type is not INamedTypeSymbol componentType ||
             method.Parameters[2].Type is not INamedTypeSymbol eventType ||
             !TypeSymbolHelper.ShittyTypeMatch(entityUidType, EntityUidTypeName) ||
+            componentType.NullableAnnotation == NullableAnnotation.Annotated ||
             !TypeSymbolHelper.ImplementsInterface(componentType, IComponentTypeName))
             return null;
 


### PR DESCRIPTION
Fixes #6873.

Nullable component parameters are not valid for component-filtered event subscriptions, since the event bus never supplies null components. The subscription generator currently carries the nullable annotation into generated type arguments, which produces invalid generated code.

This follows the direction discussed in #6882: report the invalid handler instead of silently removing its nullable annotation.