### PR TITLE
Add horizontal alignment support to RichTextLabel

### DIFF
--- a/Robust.Client/UserInterface/Controls/RichTextLabel.cs
+++ b/Robust.Client/UserInterface/Controls/RichTextLabel.cs
@@ -28,6 +28,12 @@ namespace Robust.Client.UserInterface.Controls
         private TextOutline? _actualFontOutline;
         private bool _fontOutlineCacheValid;
 
+        /// <summary>
+        /// Horizontal alignment of the text
+        /// </summary>
+        [ViewVariables]
+        public AlignMode Align { get; set; } = AlignMode.Left;
+
         [ViewVariables(VVAccess.ReadWrite)]
         public float LineHeightScale
         {
@@ -204,7 +210,7 @@ namespace Robust.Client.UserInterface.Controls
         protected internal override void Draw(DrawingHandleScreen handle)
         {
             base.Draw(handle);
-            _entry?.Draw(_tagManager, handle, _getFont(), SizeBox, 0, _drawingContext, UIScale, LineHeightScale, ActualFontOutline);
+            _entry?.Draw(_tagManager, handle, _getFont(), SizeBox, 0, _drawingContext, UIScale, LineHeightScale, ActualFontOutline, Align);
         }
 
         protected override void StylePropertiesChanged()
@@ -231,6 +237,14 @@ namespace Robust.Client.UserInterface.Controls
             _actualFont = UserInterfaceManager.ThemeDefaults.DefaultFont;
             _fontCacheValid = true;
             return _actualFont;
+        }
+
+        public enum AlignMode : byte
+        {
+            Left = 0,
+            Center = 1,
+            Right = 2,
+            Fill = 3
         }
     }
 }

--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -348,7 +348,7 @@ namespace Robust.Client.UserInterface
             var globalBreakCounter = 0;
             var lineBreakIndex = 0;
             var currentLine = 0;
-            var baseLine = drawBox.TopLeft + new Vector2(0, defaultFont.GetAscent(uiScale) + verticalOffset);
+            var baseLine = drawBox.TopLeft + new Vector2(GetAlignedOffset(currentLine), defaultFont.GetAscent(uiScale) + verticalOffset);
             var controlYAdvance = 0f;
             var hasOutline = outline.HasValue;
             var outlineSettings = outline.GetValueOrDefault();

--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -189,7 +189,7 @@ namespace Robust.Client.UserInterface
             Width = wordWrap.FinalizeText(out breakLine);
             CheckLineBreak(ref this, breakLine);
 
-            CalculateLineWidths(ref this, tagManager, defaultFont, uiScale);
+            CalculateLineWidths(ref this, tagManager, context, defaultFont, uiScale);
 
             return this;
 
@@ -237,14 +237,12 @@ namespace Robust.Client.UserInterface
         private void CalculateLineWidths(
             ref RichTextEntry entry,
             MarkupTagManager tagManager,
+            MarkupDrawingContext context,
             Font defaultFont,
             float uiScale)
         {
             entry.LineWidths.Clear();
             entry.LineWidths.Add(0);
-            var context = new MarkupDrawingContext();
-            context.Color.Push(entry._defaultColor);
-            context.Font.Push(defaultFont);
 
             var globalBreakCounter = 0;
             var lineBreakIndex = 0;

--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -118,6 +118,7 @@ namespace Robust.Client.UserInterface
         /// <summary>
         ///     Recalculate line dimensions and where it has line breaks for word wrapping.
         /// </summary>
+        /// <param name="tagManager">MarkupTagManager</param>
         /// <param name="defaultFont">The font being used for display.</param>
         /// <param name="maxSizeX">The maximum horizontal size of the container of this entry.</param>
         /// <param name="uiScale"></param>
@@ -144,7 +145,7 @@ namespace Robust.Client.UserInterface
             foreach (var node in Message)
             {
                 nodeIndex++;
-                var text = ProcessNode(tagManager, node, context);
+                var text = ProcessNode(tagManager, node, context, _tagsAllowed);
 
                 if (!context.Font.TryPeek(out var font))
                     font = defaultFont;
@@ -170,7 +171,8 @@ namespace Robust.Client.UserInterface
 
                 var desiredSize = control.DesiredPixelSize;
                 var controlMetrics = new CharMetrics(
-                    0, 0,
+                    0,
+                    0,
                     desiredSize.X,
                     desiredSize.X,
                     desiredSize.Y);
@@ -225,6 +227,63 @@ namespace Robust.Client.UserInterface
             }
         }
 
+        private static List<int> CalculateLineWidths(
+            in RichTextEntry entry,
+            MarkupTagManager tagManager,
+            Font defaultFont,
+            float uiScale)
+        {
+            var widths = new List<int> { 0 };
+            var context = new MarkupDrawingContext();
+            context.Color.Push(entry._defaultColor);
+            context.Font.Push(defaultFont);
+
+            var globalBreakCounter = 0;
+            var lineBreakIndex = 0;
+            var currentLine = 0;
+            var nodeIndex = -1;
+
+            foreach (var node in entry.Message)
+            {
+                nodeIndex++;
+                var text = ProcessNode(tagManager, node, context, entry._tagsAllowed);
+                if (!context.Font.TryPeek(out var font))
+                    font = defaultFont;
+
+                foreach (var rune in text.EnumerateRunes())
+                {
+                    if (lineBreakIndex < entry.LineBreaks.Count &&
+                        entry.LineBreaks[lineBreakIndex] == globalBreakCounter)
+                    {
+                        currentLine += 1;
+                        widths.Add(0);
+                        lineBreakIndex += 1;
+                    }
+
+                    if (font.TryGetCharMetrics(rune, uiScale, out var metrics))
+                        widths[currentLine] += metrics.Advance;
+
+                    globalBreakCounter += 1;
+                }
+
+                if (entry.Controls == null || !entry.Controls.TryGetValue(nodeIndex, out var control))
+                    continue;
+
+                if (lineBreakIndex < entry.LineBreaks.Count &&
+                    entry.LineBreaks[lineBreakIndex] == globalBreakCounter)
+                {
+                    currentLine += 1;
+                    widths.Add(0);
+                    lineBreakIndex += 1;
+                }
+
+                control.Measure(new Vector2(entry.Width, entry.Height));
+                widths[currentLine] += control.DesiredPixelSize.X;
+            }
+
+            return widths;
+        }
+
         public readonly void Draw(
             MarkupTagManager tagManager,
             DrawingHandleBase handle,
@@ -234,7 +293,8 @@ namespace Robust.Client.UserInterface
             MarkupDrawingContext context,
             float uiScale,
             float lineHeightScale = 1,
-            TextOutline? outline = null)
+            TextOutline? outline = null,
+            RichTextLabel.AlignMode align = RichTextLabel.AlignMode.Left)
         {
             if (outline is { } outlineSettings)
             {
@@ -248,7 +308,8 @@ namespace Robust.Client.UserInterface
                     uiScale,
                     lineHeightScale,
                     outlineSettings,
-                    arrangeControls: false);
+                    arrangeControls: false,
+                    align);
             }
 
             DrawPass(
@@ -261,7 +322,8 @@ namespace Robust.Client.UserInterface
                 uiScale,
                 lineHeightScale,
                 outline: null,
-                arrangeControls: true);
+                arrangeControls: true,
+                align);
         }
 
         private readonly void DrawPass(
@@ -274,14 +336,18 @@ namespace Robust.Client.UserInterface
             float uiScale,
             float lineHeightScale,
             TextOutline? outline,
-            bool arrangeControls)
+            bool arrangeControls,
+            RichTextLabel.AlignMode align)
         {
             context.Clear();
             context.Color.Push(_defaultColor);
             context.Font.Push(defaultFont);
 
+            var lineWidths = CalculateLineWidths(in this, tagManager, defaultFont, uiScale);
+
             var globalBreakCounter = 0;
             var lineBreakIndex = 0;
+            var currentLine = 0;
             var baseLine = drawBox.TopLeft + new Vector2(0, defaultFont.GetAscent(uiScale) + verticalOffset);
             var controlYAdvance = 0f;
             var hasOutline = outline.HasValue;
@@ -293,7 +359,7 @@ namespace Robust.Client.UserInterface
             foreach (var node in Message)
             {
                 nodeIndex++;
-                var text = ProcessNode(tagManager, node, context);
+                var text = ProcessNode(tagManager, node, context, _tagsAllowed);
                 if (!context.Color.TryPeek(out var color) || !context.Font.TryPeek(out var font))
                 {
                     color = _defaultColor;
@@ -307,7 +373,9 @@ namespace Robust.Client.UserInterface
                     if (lineBreakIndex < LineBreaks.Count &&
                         LineBreaks[lineBreakIndex] == globalBreakCounter)
                     {
-                        baseLine = new Vector2(drawBox.Left, baseLine.Y + GetLineHeight(font, uiScale, lineHeightScale) + controlYAdvance);
+
+                        currentLine += 1;
+                        baseLine = new Vector2(drawBox.Left + GetAlignedOffset(currentLine), baseLine.Y + GetLineHeight(font, uiScale, lineHeightScale) + controlYAdvance);
                         controlYAdvance = 0;
                         lineBreakIndex += 1;
 
@@ -354,16 +422,33 @@ namespace Robust.Client.UserInterface
                 controlYAdvance = Math.Max(0f, (control.DesiredPixelSize.Y - GetLineHeight(font, uiScale, lineHeightScale)) * invertedScale);
                 baseLine += new Vector2(advanceX, 0);
             }
+
+            float GetAlignedOffset(int lineIndex)
+            {
+                if (lineIndex < 0 || lineIndex >= lineWidths.Count)
+                    return 0f;
+
+                var remainingWidth = drawBox.Width - lineWidths[lineIndex];
+                if (remainingWidth <= 0)
+                    return 0f;
+
+                return align switch
+                {
+                    RichTextLabel.AlignMode.Right => remainingWidth,
+                    RichTextLabel.AlignMode.Center or RichTextLabel.AlignMode.Fill => remainingWidth / 2f,
+                    _ => 0f,
+                };
+            }
         }
 
-        private readonly string ProcessNode(MarkupTagManager tagManager, MarkupNode node, MarkupDrawingContext context)
+        private static string ProcessNode(MarkupTagManager tagManager, MarkupNode node, MarkupDrawingContext context, Type[]? tagsAllowed)
         {
             // If a nodes name is null it's a text node.
             if (node.Name == null)
                 return node.Value.StringValue ?? "";
 
             //Skip the node if there is no markup tag for it.
-            if (!tagManager.TryGetMarkupTagHandler(node.Name, _tagsAllowed, out var tag))
+            if (!tagManager.TryGetMarkupTagHandler(node.Name, tagsAllowed, out var tag))
                 return "";
 
             if (!node.Closing)

--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -49,8 +49,12 @@ namespace Robust.Client.UserInterface
         /// </summary>
         public ValueList<int> LineBreaks;
 
-        public readonly Dictionary<int, Control>? Controls;
+        /// <summary>
+        ///     The width of each line in the entry text.
+        /// </summary>
+        public ValueList<int> LineWidths;
 
+        public readonly Dictionary<int, Control>? Controls;
 
         public RichTextEntry(
             FormattedMessage message,
@@ -67,6 +71,7 @@ namespace Robust.Client.UserInterface
             Height = 0;
             Width = 0;
             LineBreaks = default;
+            LineWidths = default;
             _defaultColor = defaultColor ?? new(200, 200, 200);
             _tagsAllowed = tagsAllowed;
             Controls = GetControls(parent, tagManager);
@@ -184,6 +189,8 @@ namespace Robust.Client.UserInterface
             Width = wordWrap.FinalizeText(out breakLine);
             CheckLineBreak(ref this, breakLine);
 
+            CalculateLineWidths(ref this, tagManager, defaultFont, uiScale);
+
             return this;
 
             bool ProcessRune(ref RichTextEntry src, Rune rune, out int? outBreakLine)
@@ -227,13 +234,14 @@ namespace Robust.Client.UserInterface
             }
         }
 
-        private static List<int> CalculateLineWidths(
-            in RichTextEntry entry,
+        private void CalculateLineWidths(
+            ref RichTextEntry entry,
             MarkupTagManager tagManager,
             Font defaultFont,
             float uiScale)
         {
-            var widths = new List<int> { 0 };
+            entry.LineWidths.Clear();
+            entry.LineWidths.Add(0);
             var context = new MarkupDrawingContext();
             context.Color.Push(entry._defaultColor);
             context.Font.Push(defaultFont);
@@ -256,12 +264,12 @@ namespace Robust.Client.UserInterface
                         entry.LineBreaks[lineBreakIndex] == globalBreakCounter)
                     {
                         currentLine += 1;
-                        widths.Add(0);
+                        entry.LineWidths.Add(0);
                         lineBreakIndex += 1;
                     }
 
                     if (font.TryGetCharMetrics(rune, uiScale, out var metrics))
-                        widths[currentLine] += metrics.Advance;
+                        entry.LineWidths[currentLine] += metrics.Advance;
 
                     globalBreakCounter += 1;
                 }
@@ -273,15 +281,13 @@ namespace Robust.Client.UserInterface
                     entry.LineBreaks[lineBreakIndex] == globalBreakCounter)
                 {
                     currentLine += 1;
-                    widths.Add(0);
+                    entry.LineWidths.Add(0);
                     lineBreakIndex += 1;
                 }
 
                 control.Measure(new Vector2(entry.Width, entry.Height));
-                widths[currentLine] += control.DesiredPixelSize.X;
+                entry.LineWidths[currentLine] += control.DesiredPixelSize.X;
             }
-
-            return widths;
         }
 
         public readonly void Draw(
@@ -343,11 +349,10 @@ namespace Robust.Client.UserInterface
             context.Color.Push(_defaultColor);
             context.Font.Push(defaultFont);
 
-            var lineWidths = CalculateLineWidths(in this, tagManager, defaultFont, uiScale);
-
             var globalBreakCounter = 0;
             var lineBreakIndex = 0;
             var currentLine = 0;
+            var widths = LineWidths;
             var baseLine = drawBox.TopLeft + new Vector2(GetAlignedOffset(currentLine), defaultFont.GetAscent(uiScale) + verticalOffset);
             var controlYAdvance = 0f;
             var hasOutline = outline.HasValue;
@@ -425,10 +430,10 @@ namespace Robust.Client.UserInterface
 
             float GetAlignedOffset(int lineIndex)
             {
-                if (lineIndex < 0 || lineIndex >= lineWidths.Count)
+                if (lineIndex < 0 || lineIndex >= widths.Count)
                     return 0f;
 
-                var remainingWidth = drawBox.Width - lineWidths[lineIndex];
+                var remainingWidth = drawBox.Width - widths[lineIndex];
                 if (remainingWidth <= 0)
                     return 0f;
 

--- a/Robust.Client/UserInterface/RichTextEntry.cs
+++ b/Robust.Client/UserInterface/RichTextEntry.cs
@@ -432,12 +432,14 @@ namespace Robust.Client.UserInterface
                 if (remainingWidth <= 0)
                     return 0f;
 
-                return align switch
+                var offset = align switch
                 {
                     RichTextLabel.AlignMode.Right => remainingWidth,
                     RichTextLabel.AlignMode.Center or RichTextLabel.AlignMode.Fill => remainingWidth / 2f,
                     _ => 0f,
                 };
+
+                return MathF.Floor(offset);
             }
         }
 


### PR DESCRIPTION
Revives #6472
Changes are basically the same

need this to add ss13 style chat to upstream


example:
https://github.com/jessicamaybe/space-station-14/tree/2026-08-12-richtextalignexample

setting the speech bubble alignment to Right
<img width="824" height="644" alt="image" src="https://github.com/user-attachments/assets/556639ed-626e-44aa-9b11-28113f59a16b" />

changed paper alignment to center with varying markups
<img width="704" height="683" alt="image" src="https://github.com/user-attachments/assets/f4e76e2d-d6d1-4fff-828e-8a7d59a4b8fb" />

markup in paper
```
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod [head=1]tempor incididunt[/head] ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation [bold][head=3]ullamco laboris nisi ut aliquip ex[/bold][/head] ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
```
