### PR TITLE
Disable analysis of generated code

### DIFF
--- a/Robust.Analyzers/DataDefinitionAnalyzer.cs
+++ b/Robust.Analyzers/DataDefinitionAnalyzer.cs
@@ -104,7 +104,7 @@ public sealed class DataDefinitionAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
 
         context.RegisterSymbolStartAction(symbolContext =>

--- a/Robust.Analyzers/ExplicitInterfaceAnalyzer.cs
+++ b/Robust.Analyzers/ExplicitInterfaceAnalyzer.cs
@@ -41,7 +41,7 @@ namespace Robust.Analyzers
 
         public override void Initialize(AnalysisContext context)
         {
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.None);
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
             context.RegisterCompilationStartAction(compilationContext =>
             {

--- a/Robust.Analyzers/ForbidLiteralAnalyzer.cs
+++ b/Robust.Analyzers/ForbidLiteralAnalyzer.cs
@@ -27,7 +27,7 @@ public sealed class ForbidLiteralAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterOperationAction(AnalyzeOperation, OperationKind.Invocation);
     }

--- a/Robust.Analyzers/NotNullableFlagAnalyzer.cs
+++ b/Robust.Analyzers/NotNullableFlagAnalyzer.cs
@@ -67,7 +67,7 @@ public sealed class NotNullableFlagAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterCompilationStartAction(compilationContext =>
         {

--- a/Robust.Analyzers/PreferGenericVariantAnalyzer.cs
+++ b/Robust.Analyzers/PreferGenericVariantAnalyzer.cs
@@ -55,7 +55,7 @@ public sealed class PreferGenericVariantAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.ReportDiagnostics | GeneratedCodeAnalysisFlags.Analyze);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterCompilationStartAction(compilationContext =>
         {

--- a/Robust.Analyzers/PreferNonGenericVariantForAnalyzer.cs
+++ b/Robust.Analyzers/PreferNonGenericVariantForAnalyzer.cs
@@ -26,7 +26,7 @@ public sealed class PreferNonGenericVariantForAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.ReportDiagnostics | GeneratedCodeAnalysisFlags.Analyze);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterCompilationStartAction(compilationContext =>
         {

--- a/Robust.Analyzers/PreferOtherTypeAnalyzer.cs
+++ b/Robust.Analyzers/PreferOtherTypeAnalyzer.cs
@@ -28,7 +28,7 @@ public sealed class PreferOtherTypeAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.ReportDiagnostics | GeneratedCodeAnalysisFlags.Analyze);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterSyntaxNodeAction(AnalyzeField, SyntaxKind.VariableDeclaration);
     }

--- a/Robust.Analyzers/PrototypeAnalyzer.cs
+++ b/Robust.Analyzers/PrototypeAnalyzer.cs
@@ -37,8 +37,7 @@ public sealed class PrototypeAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze |
-                                               GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
 
         context.RegisterCompilationStartAction(static ctx =>

--- a/Robust.Analyzers/ProxyForAnalyzer.cs
+++ b/Robust.Analyzers/ProxyForAnalyzer.cs
@@ -55,7 +55,7 @@ public sealed class ProxyForAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.ReportDiagnostics | GeneratedCodeAnalysisFlags.Analyze);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterCompilationStartAction(static ctx =>
         {

--- a/Robust.Analyzers/ValidateMemberAnalyzer.cs
+++ b/Robust.Analyzers/ValidateMemberAnalyzer.cs
@@ -26,7 +26,7 @@ public sealed class ValidateMemberAnalyzer : DiagnosticAnalyzer
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.RegisterOperationAction(AnalyzeOperation, OperationKind.Invocation);
     }
 


### PR DESCRIPTION
Disabled the analysis of code generator output on a bunch of analyzers. The generators should be outputting code that complies with our standards, so we shouldn't need to analyze it.

This saves about 6 seconds on a clean build on my machine.