### PR TITLE
Fix zero-sized render target thumbnails

### DIFF
--- a/Robust.Client.IntegrationTests/UserInterface/DevWindowTabRenderTargetsTest.cs
+++ b/Robust.Client.IntegrationTests/UserInterface/DevWindowTabRenderTargetsTest.cs
@@ -1,0 +1,23 @@
+#if TOOLS
+using NUnit.Framework;
+using Robust.Client.UserInterface;
+using Robust.Shared.Maths;
+
+namespace Robust.UnitTesting.Client.UserInterface;
+
+[TestFixture]
+[TestOf(typeof(DevWindowTabRenderTargets))]
+public sealed class DevWindowTabRenderTargetsTest
+{
+    [TestCase(50, 25, 50, 25)]
+    [TestCase(200, 100, 100, 50)]
+    [TestCase(2048, 2, 100, 1)]
+    [TestCase(2, 2048, 1, 50)]
+    public void TestThumbnailSize(int width, int height, int expectedWidth, int expectedHeight)
+    {
+        var size = DevWindowTabRenderTargets.GetThumbnailSize(new Vector2i(width, height));
+
+        Assert.That(size, Is.EqualTo(new Vector2i(expectedWidth, expectedHeight)));
+    }
+}
+#endif

--- a/Robust.Client.IntegrationTests/UserInterface/DevWindowTabRenderTargetsTest.cs
+++ b/Robust.Client.IntegrationTests/UserInterface/DevWindowTabRenderTargetsTest.cs
@@ -11,13 +11,21 @@ public sealed class DevWindowTabRenderTargetsTest
 {
     [TestCase(50, 25, 50, 25)]
     [TestCase(200, 100, 100, 50)]
-    [TestCase(2048, 2, 100, 1)]
-    [TestCase(2, 2048, 1, 50)]
     public void TestThumbnailSize(int width, int height, int expectedWidth, int expectedHeight)
     {
-        var size = DevWindowTabRenderTargets.GetThumbnailSize(new Vector2i(width, height));
+        var result = DevWindowTabRenderTargets.TryGetThumbnailSize(new Vector2i(width, height), out var size);
 
+        Assert.That(result, Is.True);
         Assert.That(size, Is.EqualTo(new Vector2i(expectedWidth, expectedHeight)));
+    }
+
+    [TestCase(2048, 2)]
+    [TestCase(2, 2048)]
+    public void TestEmptyThumbnailSize(int width, int height)
+    {
+        var result = DevWindowTabRenderTargets.TryGetThumbnailSize(new Vector2i(width, height), out _);
+
+        Assert.That(result, Is.False);
     }
 }
 #endif

--- a/Robust.Client/UserInterface/DevWindow/DevWindowTabRenderTargets.xaml.cs
+++ b/Robust.Client/UserInterface/DevWindow/DevWindowTabRenderTargets.xaml.cs
@@ -217,7 +217,7 @@ internal sealed partial class DevWindowTabRenderTargets : Control
         return rt;
     }
 
-    private static Vector2i GetThumbnailSize(Vector2i textureSize)
+    internal static Vector2i GetThumbnailSize(Vector2i textureSize)
     {
         const int maxHeight = 50;
         const int maxWidth = 100;
@@ -236,7 +236,7 @@ internal sealed partial class DevWindowTabRenderTargets : Control
             w = maxWidth;
         }
 
-        return new Vector2i((int)w, (int)h);
+        return new Vector2i(Math.Max(1, (int)w), Math.Max(1, (int)h));
     }
 #endif // TOOLS
 }

--- a/Robust.Client/UserInterface/DevWindow/DevWindowTabRenderTargets.xaml.cs
+++ b/Robust.Client/UserInterface/DevWindow/DevWindowTabRenderTargets.xaml.cs
@@ -127,10 +127,9 @@ internal sealed partial class DevWindowTabRenderTargets : Control
             // Disable texture thumbnails outside TOOLS.
             // Avoid people cheating by using devwindow to see through walls. Barely.
 #if TOOLS
-            if (instance is IRenderTexture renderTexture)
+            if (instance is IRenderTexture renderTexture &&
+                CloneTexture(renderTexture.Texture, loaded.ColorFormat) is { } clone)
             {
-                var clone = CloneTexture(renderTexture.Texture, loaded.ColorFormat);
-
                 _copyTextures.Add(clone);
 
                 AddColumn(new TextureRect
@@ -191,9 +190,10 @@ internal sealed partial class DevWindowTabRenderTargets : Control
     }
 
 #if TOOLS
-    private IRenderTexture CloneTexture(Texture texture, RTCF colorFormat)
+    private IRenderTexture? CloneTexture(Texture texture, RTCF colorFormat)
     {
-        var thumbnailSize = GetThumbnailSize(texture.Size);
+        if (!TryGetThumbnailSize(texture.Size, out var thumbnailSize))
+            return null;
 
         var rt = _clyde.CreateRenderTarget(
             thumbnailSize,
@@ -217,7 +217,7 @@ internal sealed partial class DevWindowTabRenderTargets : Control
         return rt;
     }
 
-    internal static Vector2i GetThumbnailSize(Vector2i textureSize)
+    internal static bool TryGetThumbnailSize(Vector2i textureSize, out Vector2i thumbnailSize)
     {
         const int maxHeight = 50;
         const int maxWidth = 100;
@@ -236,7 +236,8 @@ internal sealed partial class DevWindowTabRenderTargets : Control
             w = maxWidth;
         }
 
-        return new Vector2i(Math.Max(1, (int)w), Math.Max(1, (int)h));
+        thumbnailSize = new Vector2i((int)w, (int)h);
+        return thumbnailSize.X > 0 && thumbnailSize.Y > 0;
     }
 #endif // TOOLS
 }


### PR DESCRIPTION
Fixes #6856.

The 2048x2 FOV render target was scaled to a 100x0 thumbnail, triggering the non-zero size assert in Clyde. Skip creating the thumbnail when the scaled size has an empty dimension.