### PR TITLE
Change access of WordWrap to public

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,7 +14,7 @@ Don't change the format without looking at the script!
 
 ### New features
 
-*None yet*
+* Made `WordWrap` public.
 
 ### Bugfixes
 

--- a/Robust.Client/UserInterface/WordWrap.cs
+++ b/Robust.Client/UserInterface/WordWrap.cs
@@ -10,7 +10,7 @@ namespace Robust.Client.UserInterface;
 /// <summary>
 /// Helper utility struct for word-wrapping calculations.
 /// </summary>
-internal struct WordWrap
+public struct WordWrap
 {
     private readonly float _maxSizeX;
 


### PR DESCRIPTION
I needed wordwrap for some stuff I'm working on downstream and why not use the one that comes with engine