### PR TITLE
AppearanceChangeEvent: add TryGetData convenience function

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,7 +39,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* `AppearanceChangeEvent` now has a `TryGetData` function that checks the type of the data at a given key.
 
 ### Bugfixes
 

--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -158,8 +158,9 @@ namespace Robust.Client.GameObjects
         public SpriteComponent? Sprite;
 
         /// <summary>
-        /// Looks up an enum in the dictionary if it can.
-        /// If it finds it, it outputs the value in <paramref name="data"/> and returns true.
+        /// Looks up <paramref name="key"> in the appearance data if it can.
+        /// If it finds data of type <typeparamref name="T"/>,
+        /// it outputs the value in <paramref name="data"/> and returns true.
         /// Otherwise, it outputs default into data, returning false.
         /// </summary>
         public bool TryGetData<T>(Enum key, [NotNullWhen(true)] out T? data)

--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
 using Robust.Shared.GameStates;
-using Robust.Shared.Utility;
 using Robust.Shared.Serialization.Manager;
-using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Utility;
 
 namespace Robust.Client.GameObjects
 {

--- a/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
+++ b/Robust.Client/GameObjects/EntitySystems/AppearanceSystem.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
-using Robust.Shared.Serialization;
 using Robust.Shared.GameStates;
 using Robust.Shared.Utility;
 using Robust.Shared.Serialization.Manager;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Robust.Client.GameObjects
 {
@@ -69,10 +69,10 @@ namespace Robust.Client.GameObjects
         }
 
         /// <summary>
-        ///     Take in an appearance data dictionary and attempt to clone it.
+        /// Take in an appearance data dictionary and attempt to clone it.
         /// </summary>
         /// <remarks>
-        ///     As some appearance data values are not simple value-type objects, this is not just a shallow clone.
+        /// As some appearance data values are not simple value-type objects, this is not just a shallow clone.
         /// </remarks>
         private Dictionary<Enum, object> CloneAppearanceData(Dictionary<Enum, object> data)
         {
@@ -148,7 +148,7 @@ namespace Robust.Client.GameObjects
     }
 
     /// <summary>
-    ///     Raised whenever the appearance data for an entity changes.
+    /// Raised whenever the appearance data for an entity changes.
     /// </summary>
     [ByRefEvent]
     public struct AppearanceChangeEvent
@@ -156,5 +156,25 @@ namespace Robust.Client.GameObjects
         public AppearanceComponent Component;
         public IReadOnlyDictionary<Enum, object> AppearanceData;
         public SpriteComponent? Sprite;
+
+        /// <summary>
+        /// Looks up an enum in the dictionary if it can.
+        /// If it finds it, it outputs the value in <paramref name="data"/> and returns true.
+        /// Otherwise, it outputs default into data, returning false.
+        /// </summary>
+        public bool TryGetData<T>(Enum key, [NotNullWhen(true)] out T? data)
+        {
+            if (AppearanceData.TryGetValue(key, out var objValue)
+                && objValue is T value)
+            {
+                data = value;
+                return true;
+            }
+            else
+            {
+                data = default!;
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds a convenience function to get and check the appearance data inside ApperanceChangeEvent.

## Why?

On SS14's master at time of writing, there are 21 uses of "args.ApperanceData.TryGetValue" into a cast.  This function exists on the ApperanceSystem, but that involves a pointless Resolve from the context of an AppearanceChangeEvent handler.  Despite this, it's still used in a glut of AppearanceChangedEvent handlers in SS14's master.

We can simplify all of those a little bit with this new method!