### PR TITLE
Int to byte drawdepths

### DIFF
--- a/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
+++ b/Robust.Client/GameObjects/Components/Renderable/SpriteComponent.cs
@@ -77,14 +77,14 @@ namespace Robust.Client.GameObjects
         private SpriteSystem Sys => _sys ??= (entities.Started ? entities.System<SpriteSystem>() : null)!;
         private SpriteTreeSystem TreeSys => _treeSys ??= (entities.Started ? entities.System<SpriteTreeSystem>() : null)!;
 
-        [DataField("drawdepth", customTypeSerializer: typeof(ConstantSerializer<DrawDepthTag>))]
-        internal int drawDepth = DrawDepthTag.Default;
+        [DataField("drawdepth", customTypeSerializer: typeof(ByteConstantSerializer<DrawDepthTag>))]
+        internal byte drawDepth = DrawDepthTag.Default;
 
         /// <summary>
         ///     Z-index for drawing.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public int DrawDepth
+        public byte DrawDepth
         {
             get => drawDepth;
             [Obsolete("Use SpriteSystem.SetDrawDepth() instead.")]

--- a/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Setters.cs
+++ b/Robust.Client/GameObjects/EntitySystems/SpriteSystem.Setters.cs
@@ -75,7 +75,7 @@ public sealed partial class SpriteSystem
         _tree.QueueTreeUpdate(sprite!);
     }
 
-    public void SetDrawDepth(Entity<SpriteComponent?> sprite, int value)
+    public void SetDrawDepth(Entity<SpriteComponent?> sprite, byte value)
     {
         if (!_query.Resolve(sprite.Owner, ref sprite.Comp))
             return;

--- a/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.HLR.cs
@@ -304,7 +304,7 @@ namespace Robust.Client.Graphics.Clyde
             var worldOverlays = GetOverlaysForSpace(OverlaySpace.WorldSpaceEntities);
 
             var spriteSystem = _entityManager.System<SpriteSystem>();
-            int[] indexList;
+            SpriteSortItem[] indexList;
             using (_prof.Group("Gather Sprites"))
             {
                 GetSprites(mapId, viewport, eye, worldBounds, out indexList);
@@ -313,10 +313,10 @@ namespace Robust.Client.Graphics.Clyde
             var overlayIndex = 0;
 
             bool flushed = false;
-            using var _drawZone = _prof.Group("Draw");
+            using var drawZone = _prof.Group("Draw");
             for (var i = 0; i < _drawingSpriteList.Count; i++)
             {
-                ref var entry = ref _drawingSpriteList[indexList[i]];
+                ref var entry = ref _drawingSpriteList[indexList[i].Index];
                 var postShaders = spriteSystem.GetPostShaders(entry.Sprite);
 
                 for (; overlayIndex < worldOverlays.Count; overlayIndex++)
@@ -360,7 +360,7 @@ namespace Robust.Client.Graphics.Clyde
                 RenderSingleWorldOverlay(worldOverlays[overlayIndex], viewport, OverlaySpace.WorldSpaceEntities, worldAABB, worldBounds);
             }
 
-            ArrayPool<int>.Shared.Return(indexList);
+            ArrayPool<SpriteSortItem>.Shared.Return(indexList);
 
             _debugStats.Entities += _drawingSpriteList.Count;
             _drawingSpriteList.Clear();

--- a/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
-using System.Threading.Tasks;
 using Robust.Client.GameObjects;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Graphics;
@@ -21,44 +21,95 @@ internal partial class Clyde
 {
     [Shared.IoC.Dependency] private IParallelManager _parMan = default!;
     private readonly RefList<SpriteData> _drawingSpriteList = new();
-    private const int _spriteProcessingBatchSize = 25;
+    private readonly SpriteSortBucket[] _spriteSortBuckets = new SpriteSortBucket[byte.MaxValue + 1];
+    private const byte SpriteProcessingBatchSize = 32;
 
-    private void GetSprites(MapId map, Viewport view, IEye eye, Box2Rotated worldBounds, out int[] indexList)
+    private void GetSprites(MapId map, Viewport view, IEye eye, Box2Rotated worldBounds, out SpriteSortItem[] sortItems)
     {
         ProcessSpriteEntities(map, view, eye, worldBounds, _drawingSpriteList);
 
         var count = _drawingSpriteList.Count;
+        sortItems = ArrayPool<SpriteSortItem>.Shared.Rent(count);
 
-        indexList = ArrayPool<int>.Shared.Rent(count);
-        var sortItems = ArrayPool<SpriteSortItem>.Shared.Rent(count);
+        using (_prof.Group("Build sprite sort"))
+        {
+            for (var i = 0; i < count; i++)
+            {
+                ref var data = ref _drawingSpriteList[i];
+                sortItems[i] = new SpriteSortItem(
+                    i,
+                    data.Sprite.DrawDepth,
+                    data.Sprite.RenderOrder,
+                    data.SortY,
+                    data.Uid);
+            }
+        }
+
+        using (_prof.Group("Sort sprites"))
+        {
+            SortSprites(ref sortItems, count);
+        }
+    }
+
+    private void SortSprites(ref SpriteSortItem[] items, int count)
+    {
+        Array.Clear(_spriteSortBuckets);
+
+        if (count == 0)
+            return;
 
         for (var i = 0; i < count; i++)
         {
-            ref var data = ref _drawingSpriteList[i];
-            sortItems[i] = new SpriteSortItem(
-                i,
-                data.Sprite.DrawDepth,
-                data.Sprite.RenderOrder,
-                data.SpriteScreenBB.Top,
-                data.Uid);
+            ref readonly var item = ref items[i];
+            _spriteSortBuckets[item.DrawDepth].Count++;
         }
 
-        // TODO better sorting? parallel merge sort?
-        Array.Sort(sortItems, 0, count);
+        var offset = 0;
+        var highestBucket = 0;
 
-        for (var i = 0; i < count; i++)
+        for (var i = 0; i < _spriteSortBuckets.Length; i++)
         {
-            indexList[i] = sortItems[i].Index;
+            ref var bucket = ref _spriteSortBuckets[i];
+            if (bucket.Count == 0)
+                continue;
+
+            bucket.Offset = offset;
+            bucket.Next = offset;
+            offset += bucket.Count;
+            highestBucket = Math.Max(i, highestBucket);
         }
 
-        ArrayPool<SpriteSortItem>.Shared.Return(sortItems);
+        var bucketed = ArrayPool<SpriteSortItem>.Shared.Rent(count);
+        try
+        {
+            for (var i = 0; i < count; i++)
+            {
+                ref readonly var item = ref items[i];
+                ref var bucket = ref _spriteSortBuckets[item.DrawDepth];
+                bucketed[bucket.Next++] = item;
+            }
+
+            for (var i = 0; i < highestBucket; i++)
+            {
+                var bucket = _spriteSortBuckets[i];
+                if (bucket.Count > 1)
+                    Array.Sort(bucketed, bucket.Offset, bucket.Count, SpriteSortItemDepthComparer.Instance);
+            }
+        }
+        catch
+        {
+            ArrayPool<SpriteSortItem>.Shared.Return(bucketed);
+            throw;
+        }
+
+        ArrayPool<SpriteSortItem>.Shared.Return(items);
+        items = bucketed;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void ProcessSpriteEntities(MapId map, Viewport view, IEye eye, Box2Rotated worldBounds, RefList<SpriteData> list)
     {
         var query = _entityManager.GetEntityQuery<TransformComponent>();
-        var gridQuery = _entityManager.GetEntityQuery<MapGridComponent>();
         var viewScale = eye.Scale * view.RenderScale * new Vector2(EyeManager.PixelsPerMeter, -EyeManager.PixelsPerMeter);
         var treeData = new BatchData()
         {
@@ -74,8 +125,6 @@ internal partial class Clyde
         // parallelize the rotation & bounding box calculations.
         var index = 0;
         var added = 0;
-        var opts = new ParallelOptions { MaxDegreeOfParallelism = _parMan.ParallelProcessCount };
-
         foreach (var (treeOwner, comp) in _spriteTreeSystem.GetIntersectingTrees(map, worldBounds))
         {
             var treeXform = query.GetComponent(treeOwner);
@@ -83,15 +132,12 @@ internal partial class Clyde
             var bounds = _transformSystem.GetInvWorldMatrix(treeOwner).TransformBox(worldBounds);
             DebugTools.Assert(treeXform.MapUid == treeXform.ParentUid || !treeXform.ParentUid.IsValid());
 
-            if (gridQuery.HasComponent(treeOwner))
-            {
-                treePos += GetPixelSnapOffset(
-                    treePos,
-                    treeData.ViewPosition,
-                    treeData.ViewRotation,
-                    treeData.ViewScale,
-                    view.Size);
-            }
+            treePos += GetPixelSnapOffset(
+                treePos,
+                treeData.ViewPosition,
+                treeData.ViewRotation,
+                treeData.ViewScale,
+                view.Size);
 
             treeData = treeData with
             {
@@ -102,31 +148,40 @@ internal partial class Clyde
                 Cos = MathF.Cos((float)treeXform.LocalRotation),
             };
 
-            comp.Tree.QueryAabb(ref list,
-                static (ref RefList<SpriteData> state, in ComponentTreeEntry<SpriteComponent> value) =>
-                {
-                    ref var entry = ref state.AllocAdd();
-                    entry.Uid = value.Uid;
-                    entry.Sprite = value.Component;
-                    entry.Xform = value.Transform;
-                    return true;
-                }, bounds, true);
+            using (_prof.Group("Query sprite tree"))
+            {
+                comp.Tree.QueryAabb(ref list,
+                    static (ref RefList<SpriteData> state, in ComponentTreeEntry<SpriteComponent> value) =>
+                    {
+                        ref var entry = ref state.AllocAdd();
+                        entry.Uid = value.Uid;
+                        entry.Sprite = value.Component;
+                        entry.Xform = value.Transform;
+                        return true;
+                    }, bounds, true);
+            }
 
             // Get bounding boxes & world positions
             added = list.Count - index;
-            var batches = added/_spriteProcessingBatchSize;
+            using (_prof.Group("Process sprite bounds"))
+            {
+                if (added >= 2 * SpriteProcessingBatchSize)
+                {
+                    _parMan.ProcessNow(new SpriteProcessingJob
+                    {
+                        Renderer = this,
+                        List = list,
+                        StartIndex = index,
+                        Batch = treeData,
+                    }, added);
+                }
+                else if (added > 0)
+                {
+                    ProcessSprites(list, index, added, treeData);
+                }
+            }
 
-            // TODO also do sorting here & use a merge sort later on for y-sorting?
-            if (batches > 1)
-                Parallel.For(0, batches, opts, (i) => ProcessSprites(list, index + i * _spriteProcessingBatchSize, _spriteProcessingBatchSize, treeData));
-            else
-                batches = 0;
-
-            var remainder = added - _spriteProcessingBatchSize * batches;
-            if (remainder > 0)
-                ProcessSprites(list, index + batches * _spriteProcessingBatchSize, remainder, treeData);
-
-            index += batches * _spriteProcessingBatchSize + remainder;
+            index += added;
         }
     }
 
@@ -191,11 +246,11 @@ internal partial class Clyde
             pos = batch.ViewRotation.RotateVec(pos - batch.ViewPosition);
 
             // special casing angle = n*pi/2 to avoid box rotation & bounding calculations doesn't seem to give significant speedups.
-            data.SpriteScreenBB = TransformCenteredBox(
+            data.SortY = TransformCenteredBox(
                 _spriteSystem.GetLocalBounds((data.Uid, data.Sprite)),
                 finalRotation,
                 pos + batch.PreScaleViewOffset,
-                batch.ViewScale);
+                batch.ViewScale).Top;
         }
     }
 
@@ -206,8 +261,9 @@ internal partial class Clyde
     internal static unsafe Box2 TransformCenteredBox(in Box2 box, float angle, in Vector2 offset, in Vector2 scale)
     {
         var boxVec = Unsafe.As<Box2, Vector128<float>>(ref Unsafe.AsRef(in box));
-        var sin = Vector128.Create(MathF.Sin(angle));
-        var cos = Vector128.Create(MathF.Cos(angle));
+        var (sinValue, cosValue) = MathF.SinCos(angle);
+        var sin = Vector128.Create(sinValue);
+        var cos = Vector128.Create(cosValue);
         var boxX = Vector128.Shuffle(boxVec, Vector128.Create(0, 0, 2, 2));
         var boxY = Vector128.Shuffle(boxVec, Vector128.Create(1, 3, 3, 1));
 
@@ -237,7 +293,23 @@ internal partial class Clyde
         public TransformComponent Xform;
         public Vector2 WorldPos;
         public Angle WorldRot;
-        public Box2 SpriteScreenBB;
+        public float SortY;
+    }
+
+    private readonly struct SpriteProcessingJob : IParallelBulkRobustJob
+    {
+        public required Clyde Renderer { get; init; }
+        public required RefList<SpriteData> List { get; init; }
+        public required int StartIndex { get; init; }
+        public required BatchData Batch { get; init; }
+
+        public int BatchSize => SpriteProcessingBatchSize;
+        public int MinimumBatchParallel => 1;
+
+        public void ExecuteRange(int startIndex, int endIndex)
+        {
+            Renderer.ProcessSprites(List, StartIndex + startIndex, endIndex - startIndex, Batch);
+        }
     }
 
     private readonly struct BatchData
@@ -255,15 +327,37 @@ internal partial class Clyde
         public float Cos { get;  init; }
     }
 
+    private struct SpriteSortBucket
+    {
+        public int Count;
+        public int Offset;
+        public int Next;
+    }
+
+    private sealed class SpriteSortItemDepthComparer : IComparer<SpriteSortItem>
+    {
+        public static readonly SpriteSortItemDepthComparer Instance = new();
+
+        public int Compare(SpriteSortItem x, SpriteSortItem y)
+        {
+            var comparison = x.RenderOrder.CompareTo(y.RenderOrder);
+            if (comparison != 0)
+                return comparison;
+
+            comparison = x.YSort.CompareTo(y.YSort);
+            return comparison != 0 ? comparison : x.Uid.CompareTo(y.Uid);
+        }
+    }
+
     private readonly struct SpriteSortItem : IComparable<SpriteSortItem>
     {
         public readonly int Index;
-        private readonly int _drawDepth;
+        private readonly byte _drawDepth;
         private readonly uint _renderOrder;
         private readonly float _ySort;
         private readonly EntityUid _uid;
 
-        public SpriteSortItem(int index, int drawDepth, uint renderOrder, float ySort, EntityUid uid)
+        public SpriteSortItem(int index, byte drawDepth, uint renderOrder, float ySort, EntityUid uid)
         {
             Index = index;
             _drawDepth = drawDepth;
@@ -271,6 +365,11 @@ internal partial class Clyde
             _ySort = ySort;
             _uid = uid;
         }
+
+        public byte DrawDepth => _drawDepth;
+        public uint RenderOrder => _renderOrder;
+        public float YSort => _ySort;
+        public EntityUid Uid => _uid;
 
         public int CompareTo(SpriteSortItem other)
         {

--- a/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
+++ b/Robust.Client/Graphics/Clyde/Clyde.Sprite.cs
@@ -65,6 +65,7 @@ internal partial class Clyde
         }
 
         var offset = 0;
+        var lowestBucket = int.MaxValue;
         var highestBucket = 0;
 
         for (var i = 0; i < _spriteSortBuckets.Length; i++)
@@ -76,6 +77,7 @@ internal partial class Clyde
             bucket.Offset = offset;
             bucket.Next = offset;
             offset += bucket.Count;
+            lowestBucket = Math.Min(i, lowestBucket);
             highestBucket = Math.Max(i, highestBucket);
         }
 
@@ -89,7 +91,7 @@ internal partial class Clyde
                 bucketed[bucket.Next++] = item;
             }
 
-            for (var i = 0; i < highestBucket; i++)
+            for (var i = lowestBucket; i <= highestBucket; i++)
             {
                 var bucket = _spriteSortBuckets[i];
                 if (bucket.Count > 1)

--- a/Robust.Client/Graphics/Overlays/Overlay.cs
+++ b/Robust.Client/Graphics/Overlays/Overlay.cs
@@ -4,6 +4,7 @@ using Robust.Shared.Timing;
 using Robust.Shared.Enums;
 using System;
 using Robust.Shared.Graphics;
+using Robust.Shared.GameObjects;
 
 namespace Robust.Client.Graphics
 {
@@ -31,9 +32,9 @@ namespace Robust.Client.Graphics
 
         /// <summary>
         ///    Overlays on the same OverlaySpace will be drawn from lowest ZIndex to highest ZIndex. As an example, ZIndex -1 will be drawn before ZIndex 2.
-        ///    This value is 0 by default. Overlays with same ZIndex will be drawn in an random order.
+        ///    This value defaults to <see cref="DrawDepth.Default"/>. Overlays with same ZIndex will be drawn in an random order.
         /// </summary>
-        public int? ZIndex { get; set; }
+        public int? ZIndex { get; set; } = DrawDepth.Default;
 
         protected IOverlayManager OverlayManager { get; }
 

--- a/Robust.Client/Graphics/Overlays/OverlayManager.cs
+++ b/Robust.Client/Graphics/Overlays/OverlayManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.IoC;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
 using Robust.Shared.Timing;
 using Robust.Shared.ViewVariables;
@@ -137,8 +138,8 @@ internal sealed partial class OverlayManager : IOverlayManagerInternal, IPostInj
 
         public int Compare(Overlay? x, Overlay? y)
         {
-            var zX = x?.ZIndex ?? 0;
-            var zY = y?.ZIndex ?? 0;
+            var zX = x?.ZIndex ?? DrawDepth.Default;
+            var zY = y?.ZIndex ?? DrawDepth.Default;
             return zX.CompareTo(zY);
         }
     }

--- a/Robust.Shared/GameObjects/DrawDepth.cs
+++ b/Robust.Shared/GameObjects/DrawDepth.cs
@@ -13,6 +13,6 @@ namespace Robust.Shared.GameObjects
         /// The default draw depth. The content enum which represents draw depth
         /// should respect this value, since it is used in the engine.
         /// </summary>
-        public const byte Default = 0;
+        public const byte Default = 128;
     }
 }

--- a/Robust.Shared/GameObjects/DrawDepth.cs
+++ b/Robust.Shared/GameObjects/DrawDepth.cs
@@ -13,6 +13,6 @@ namespace Robust.Shared.GameObjects
         /// The default draw depth. The content enum which represents draw depth
         /// should respect this value, since it is used in the engine.
         /// </summary>
-        public const int Default = 0;
+        public const byte Default = 0;
     }
 }

--- a/Robust.Shared/Serialization/Manager/SerializationManager.FlagsAndConstants.cs
+++ b/Robust.Shared/Serialization/Manager/SerializationManager.FlagsAndConstants.cs
@@ -22,19 +22,18 @@ namespace Robust.Shared.Serialization.Manager
                     throw new InvalidOperationException($"Could not create ConstantMapping for non-enum {constType}.");
                 }
 
-                if (Enum.GetUnderlyingType(constType) != typeof(int))
+                var underlyingType = Enum.GetUnderlyingType(constType);
+                if (underlyingType != typeof(int) && underlyingType != typeof(byte))
                 {
-                    throw new InvalidOperationException($"Could not create ConstantMapping for non-int enum {constType}.");
+                    throw new InvalidOperationException($"Could not create ConstantMapping for unsupported enum {constType}.");
                 }
 
                 foreach (var constantsForAttribute in constType.GetCustomAttributes<ConstantsForAttribute>(true))
                 {
-                    if (_constantsMapping.ContainsKey(constantsForAttribute.Tag))
+                    if (!_constantsMapping.TryAdd(constantsForAttribute.Tag, constType))
                     {
                         throw new NotSupportedException($"Multiple constant enums declared for the tag {constantsForAttribute.Tag}.");
                     }
-
-                    _constantsMapping.Add(constantsForAttribute.Tag, constType);
                 }
             }
 

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/ConstantSerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/Custom/ConstantSerializer.cs
@@ -56,4 +56,40 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations.Custom
             return new ValueDataNode(constantName);
         }
     }
+
+    /// <summary>
+    ///     Serializes or deserializes a byte from a set of known constants specified by an enum.
+    /// </summary>
+    public sealed class ByteConstantSerializer<TTag> : ITypeSerializer<byte, ValueDataNode>
+    {
+        public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node,
+            IDependencyCollection dependencies, ISerializationContext? context = null)
+        {
+            var constType = serializationManager.GetConstantTypeFromTag(typeof(TTag));
+            return Enum.TryParse(constType, node.Value, out _) ? new ValidatedValueNode(node) : new ErrorNode(node, "Failed parsing constant.", false);
+        }
+
+        public byte Read(ISerializationManager serializationManager, ValueDataNode node,
+            IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null,
+            ISerializationManager.InstantiationDelegate<byte>? instanceProvider = null)
+        {
+            var constType = serializationManager.GetConstantTypeFromTag(typeof(TTag));
+            return Convert.ToByte(Enum.Parse(constType, node.Value));
+        }
+
+        public DataNode Write(ISerializationManager serializationManager, byte value, IDependencyCollection dependencies,
+            bool alwaysWrite = false,
+            ISerializationContext? context = null)
+        {
+            var constType = serializationManager.GetConstantTypeFromTag(typeof(TTag));
+            var constantName = Enum.GetName(constType, value);
+
+            if (constantName == null)
+            {
+                throw new InvalidOperationException($"No constant corresponding to value {value} in {constType}.");
+            }
+
+            return new ValueDataNode(constantName);
+        }
+    }
 }


### PR DESCRIPTION
- Saves memory
- Pre-allocate drawdepth buckets and make sorting significantly faster.

Before:
<img width="1082" height="177" alt="image" src="https://github.com/user-attachments/assets/6c622d53-1d3e-41ef-9abc-0348877d4a64" />

After:
<img width="975" height="204" alt="image" src="https://github.com/user-attachments/assets/e20ec383-abc7-4154-9099-0cc13422ba42" />
