### PR TITLE
Change PrototypeListContainer to VirtualListContainer

### DIFF
--- a/Robust.Client/UserInterface/Controllers/Implementations/EntitySpawningUIController.cs
+++ b/Robust.Client/UserInterface/Controllers/Implementations/EntitySpawningUIController.cs
@@ -277,7 +277,7 @@ public sealed partial class EntitySpawningUIController : UIController
             return;
 
         // Calculate index of first prototype to render based on current scroll.
-        var height = _window.MeasureButton.DesiredSize.Y + PrototypeListContainer.Separation;
+        var height = _window.MeasureButton.DesiredSize.Y + VirtualListContainer.DefaultSeparation;
         var offset = Math.Max(-_window.PrototypeList.Position.Y, 0);
         var startIndex = (int)Math.Floor(offset / height);
         _window.PrototypeList.ItemOffset = startIndex;

--- a/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml
+++ b/Robust.Client/UserInterface/CustomControls/EntitySpawnWindow.xaml
@@ -9,7 +9,7 @@
             <Button Name="ClearButton" Access="Public" Disabled="True" Text="{Loc window-clear-button}" />
         </BoxContainer>
         <ScrollContainer Name="PrototypeScrollContainer" Access="Public" MinSize="200 0" VerticalExpand="True">
-            <PrototypeListContainer Name="PrototypeList" Access="Public"/>
+            <VirtualListContainer Name="PrototypeList" Access="Public"/>
         </ScrollContainer>
         <BoxContainer Orientation="Horizontal">
             <Button Name="ReplaceButton" Access="Public" ToggleMode="True" Text="{Loc entity-spawn-window-replace-button-text}"/>

--- a/Robust.Client/UserInterface/CustomControls/VirtualListContainer.cs
+++ b/Robust.Client/UserInterface/CustomControls/VirtualListContainer.cs
@@ -4,13 +4,17 @@ using Robust.Shared.Maths;
 
 namespace Robust.Client.UserInterface.CustomControls;
 
-public sealed class PrototypeListContainer : Container
+/// <summary>
+/// A fixed-height virtual list. The owner is responsible for materializing children for the current <see cref="ItemOffset"/>.
+/// </summary>
+public sealed class VirtualListContainer : Container
 {
     // Quick and dirty container to do virtualization of the list.
     // Basically, get total item count and offset to put the current buttons at.
     // Get a constant minimum height and move the buttons in the list up to match the scrollbar.
     private int _totalItemCount;
     private int _itemOffset;
+    private float? _itemHeight;
 
     public int TotalItemCount
     {
@@ -32,7 +36,29 @@ public sealed class PrototypeListContainer : Container
         }
     }
 
-    public const float Separation = 2;
+    /// <summary>
+    ///     The fixed height of every virtual item, excluding <see cref="Separation"/>. If not set, the first
+    ///     materialized child determines the height.
+    /// </summary>
+    public float? ItemHeight
+    {
+        get => _itemHeight;
+        set
+        {
+            if (value is <= 0)
+                throw new System.ArgumentOutOfRangeException(nameof(value));
+
+            if (_itemHeight == value)
+                return;
+
+            _itemHeight = value;
+            InvalidateMeasure();
+        }
+    }
+
+    public const float DefaultSeparation = 2;
+
+    public float Separation { get; set; } = DefaultSeparation;
 
     protected override Vector2 MeasureOverride(Vector2 availableSize)
     {
@@ -44,7 +70,8 @@ public sealed class PrototypeListContainer : Container
         var first = GetChild(0);
 
         first.Measure(availableSize);
-        var (minX, minY) = first.DesiredSize;
+        var (minX, desiredHeight) = first.DesiredSize;
+        var minY = ItemHeight ?? desiredHeight;
 
         return new Vector2(minX, minY * TotalItemCount + (TotalItemCount - 1) * Separation);
     }
@@ -58,8 +85,8 @@ public sealed class PrototypeListContainer : Container
 
         var first = GetChild(0);
 
-        var height = first.DesiredSize.Y;
-        var offset = ItemOffset * height + (ItemOffset - 1) * Separation;
+        var height = ItemHeight ?? first.DesiredSize.Y;
+        var offset = ItemOffset * (height + Separation);
 
         foreach (var child in Children)
         {


### PR DESCRIPTION
1. Having a virtual control thing is good for large lists but calling it prototypelist is weird when it has nothing to do with prototypes.
2. Some fixes I need to make 1,000 entity context menus open in a performant way.