### PR TITLE
Fix partial diagnostics crashing on non-partial types

### DIFF
--- a/Robust.Roslyn.Shared/Helpers/EquatableArray{T}.cs
+++ b/Robust.Roslyn.Shared/Helpers/EquatableArray{T}.cs
@@ -115,7 +115,16 @@ public readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnume
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ImmutableArray<T> AsImmutableArray()
     {
-        return Unsafe.As<T[]?, ImmutableArray<T>>(ref Unsafe.AsRef(in this.array));
+        if (array == null)
+            return ImmutableArray<T>.Empty;
+
+        // If you check for null, you get a null warning here
+        // If you introduce a variable, you also get null if you use it in both places instead of just 1
+        // I don't know man
+        // Regardless, this fixes [] resulting in a default EquatableArray which means a null array
+        // Which leads to calling IsEmpty throwing an NRE, which is not very intuitive
+        // You could also just not use Unsafe.As here, but I guess we need to save 0.001 nanoseconds
+        return Unsafe.As<T[]?, ImmutableArray<T>>(ref Unsafe.AsRef(in array)!);
     }
 
     /// <summary>

--- a/Robust.Roslyn.Shared/PartialTypeHelper.cs
+++ b/Robust.Roslyn.Shared/PartialTypeHelper.cs
@@ -34,13 +34,12 @@ public sealed record PartialTypeInfo(
 
         do
         {
+            parts.Insert(0, NestedPart.FromNode(curSymbol, curSyntax));
             if (!IsPartial(curSyntax))
             {
                 isValid = false;
                 break;
             }
-
-            parts.Insert(0, NestedPart.FromNode(curSymbol, curSyntax));
 
             curSymbol = curSymbol.ContainingType;
             curSyntax = curSyntax.Parent as TypeDeclarationSyntax;


### PR DESCRIPTION
CheckPartialDiagnostic has been broken since early May because a non-partial type has 0 parts, which means that Parts[^1] will throw an index out of error exception, for every non-partial type, meaning instead of getting a diagnostic you get a silently failing source generator without https://github.com/space-wizards/RobustToolbox/pull/7006
dope

Also  using [] to create a new EquatableArray, which in a sane world would mean an empty equatable array, actually gives you a default struct with a null array, which you don't notice because of the Unsafe.As cast that is saving you an infinitesimally small amount of time
From ILSpy
<img width="581" height="67" alt="image" src="https://github.com/user-attachments/assets/35bd34a1-9d6f-4dcd-b004-08091f0f444b" />

This then crashes your source generator silently if you use for example IsEmpty, and makes it not run at all silently without the PR linked above

Spent the whole day chasing down these hellbugs