### PR TITLE
Allow implicit conversion between EntityPrototype ProtoIds and EntProtoIds

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -35,7 +35,7 @@ END TEMPLATE-->
 
 ### Breaking changes
 
-*None yet*
+* As `EntProtoId` can now be converted into both `ProtoId<EntityPrototype>` and `string`, things expecting one or the other will need an explicit cast first to avoid ambiguous invocation.
 
 ### New features
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -40,6 +40,7 @@ END TEMPLATE-->
 ### New features
 
 * `AppearanceChangeEvent` now has a `TryGetData` function that checks the type of the data at a given key.
+* `EntProtoId` and `ProtoId<EntityPrototype>` can now be implicitly converted between eachother.
 
 ### Bugfixes
 

--- a/Robust.Shared.IntegrationTests/Prototypes/PrototypeVariantizationTest.cs
+++ b/Robust.Shared.IntegrationTests/Prototypes/PrototypeVariantizationTest.cs
@@ -39,9 +39,9 @@ internal sealed partial class PrototypeVariantizationTest : OurRobustUnitTest
     {
         Assert.Multiple(() =>
         {
-            Assert.That(protoManager.HasIndex<EntityPrototype>(TestProtoId));
-            Assert.That(protoManager.HasIndex<EntityPrototype>(TestProtoVariantAId));
-            Assert.That(protoManager.HasIndex<EntityPrototype>(TestProtoVariantBId));
+            Assert.That(protoManager.Resolve<EntityPrototype>(TestProtoId, out var _));
+            Assert.That(protoManager.Resolve<EntityPrototype>(TestProtoVariantAId, out _));
+            Assert.That(protoManager.Resolve<EntityPrototype>(TestProtoVariantBId, out _));
         });
     }
 

--- a/Robust.Shared.IntegrationTests/Prototypes/PrototypeVariantizationTest.cs
+++ b/Robust.Shared.IntegrationTests/Prototypes/PrototypeVariantizationTest.cs
@@ -39,9 +39,9 @@ internal sealed partial class PrototypeVariantizationTest : OurRobustUnitTest
     {
         Assert.Multiple(() =>
         {
-            Assert.That(protoManager.Resolve<EntityPrototype>(TestProtoId, out var _));
-            Assert.That(protoManager.Resolve<EntityPrototype>(TestProtoVariantAId, out _));
-            Assert.That(protoManager.Resolve<EntityPrototype>(TestProtoVariantBId, out _));
+            Assert.That(protoManager.HasIndex<EntityPrototype>(TestProtoId));
+            Assert.That(protoManager.HasIndex<EntityPrototype>(TestProtoVariantAId));
+            Assert.That(protoManager.HasIndex<EntityPrototype>(TestProtoVariantBId));
         });
     }
 

--- a/Robust.Shared/Prototypes/EntProtoId.cs
+++ b/Robust.Shared/Prototypes/EntProtoId.cs
@@ -40,6 +40,26 @@ public readonly record struct EntProtoId(string Id) : IEquatable<string>, ICompa
         return id == null ? default(EntProtoId?) : new EntProtoId(id);
     }
 
+    public static implicit operator EntProtoId(ProtoId<EntityPrototype> id)
+    {
+        return new EntProtoId(id.Id);
+    }
+
+    public static implicit operator EntProtoId?(ProtoId<EntityPrototype>? id)
+    {
+        return id == null ? default(EntProtoId?) : new EntProtoId(id.Value.Id);
+    }
+
+    public static implicit operator ProtoId<EntityPrototype>(EntProtoId id)
+    {
+        return new ProtoId<EntityPrototype>(id.Id);
+    }
+
+    public static implicit operator ProtoId<EntityPrototype>?(EntProtoId? id)
+    {
+        return id == null ? default(ProtoId<EntityPrototype>?) : new ProtoId<EntityPrototype>(id.Value.Id);
+    }
+
     public bool Equals(string? other)
     {
         return Id == other;

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -106,6 +106,10 @@ public interface IPrototypeManager
     EntityPrototype Index([ForbidLiteral] EntProtoId id);
 
     /// <inheritdoc cref="Index{T}(string)"/>
+    [Obsolete("Do not specify T when using EntProtoId")]
+    EntityPrototype Index<T>(EntProtoId protoId) where T : IInheritingPrototype;
+
+    /// <inheritdoc cref="Index{T}(string)"/>
     T Index<T>([ForbidLiteral] ProtoId<T> id) where T : class, IPrototype;
 
     /// <summary>
@@ -125,10 +129,18 @@ public interface IPrototypeManager
     bool HasIndex([ForbidLiteral] EntProtoId id);
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
+    [Obsolete("Do not specify T when using EntProtoId")]
+    bool HasIndex<T>([ForbidLiteral] EntProtoId id) where T : class, IInheritingPrototype;
+
+    /// <inheritdoc cref="HasIndex{T}(string)"/>
     bool HasIndex<T>([ForbidLiteral] ProtoId<T> id) where T : class, IPrototype;
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
     bool HasIndex([ForbidLiteral] EntProtoId? id);
+
+    /// <inheritdoc cref="HasIndex{T}(string)"/>
+    [Obsolete("Do not specify T when using EntProtoId")]
+    bool HasIndex<T>([ForbidLiteral] EntProtoId? id) where T : class, IInheritingPrototype;
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
     bool HasIndex<T>([ForbidLiteral] ProtoId<T>? id) where T : class, IPrototype;
@@ -175,6 +187,10 @@ public interface IPrototypeManager
     /// <seealso cref="TryIndex(EntProtoId,out EntityPrototype?)"/>
     bool Resolve([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype);
 
+    /// <inheritdoc cref="Resolve(EntProtoId,out EntityPrototype?)"/>
+    [Obsolete("Do not specify T when using EntProtoId")]
+    bool Resolve<T>([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype;
+
     /// <summary>
     /// Resolve an <see cref="EntityPrototype"/> by ID.
     /// </summary>
@@ -199,6 +215,10 @@ public interface IPrototypeManager
     /// <returns>True if the prototype exists, false if it does not.</returns>
     /// <seealso cref="Resolve(EntProtoId,out EntityPrototype?)"/>
     bool TryIndex([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype);
+
+    /// <inheritdoc cref="TryIndex(EntProtoId,out EntityPrototype?)"/>
+    [Obsolete("Do not specify T when using EntProtoId")]
+    bool TryIndex<T>([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype;
 
     /// <summary>
     /// Resolve a prototype by ID, logging an error if it does not exist.
@@ -275,6 +295,10 @@ public interface IPrototypeManager
     /// <seealso cref="TryIndex(EntProtoId?,out EntityPrototype?)"/>
     bool Resolve([ForbidLiteral] EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype);
 
+    /// <inheritdoc cref="Resolve(EntProtoId?,out EntityPrototype?)"/>
+    [Obsolete("Do not specify T when using EntProtoId")]
+    bool Resolve<T>([ForbidLiteral] EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype;
+
     /// <summary>
     /// Resolve an <see cref="EntityPrototype"/> by ID, gracefully handling null.
     /// </summary>
@@ -299,6 +323,10 @@ public interface IPrototypeManager
     /// <returns>True if the prototype exists, false if it does not.</returns>
     /// <seealso cref="Resolve(EntProtoId?,out EntityPrototype?)"/>
     bool TryIndex([ForbidLiteral] EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype);
+
+    /// <inheritdoc cref="TryIndex(EntProtoId?,out EntityPrototype?)"/>
+    [Obsolete("Do not specify T when using EntProtoId")]
+    bool TryIndex<T>([ForbidLiteral] EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype;
 
     /// <summary>
     /// Resolve a prototype by ID, gracefully handling null, and logging an error if it does not exist.

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -107,7 +107,7 @@ public interface IPrototypeManager
 
     /// <inheritdoc cref="Index{T}(string)"/>
     [Obsolete("Do not specify T when using EntProtoId")]
-    EntityPrototype Index<T>(EntProtoId protoId) where T : IInheritingPrototype;
+    EntityPrototype Index<T>(EntProtoId protoId) where T : IPrototype;
 
     /// <inheritdoc cref="Index{T}(string)"/>
     T Index<T>([ForbidLiteral] ProtoId<T> id) where T : class, IPrototype;
@@ -130,17 +130,13 @@ public interface IPrototypeManager
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
     [Obsolete("Do not specify T when using EntProtoId")]
-    bool HasIndex<T>([ForbidLiteral] EntProtoId id) where T : class, IInheritingPrototype;
+    bool HasIndex<T>([ForbidLiteral] EntProtoId id) where T : class, IPrototype;
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
     bool HasIndex<T>([ForbidLiteral] ProtoId<T> id) where T : class, IPrototype;
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
     bool HasIndex([ForbidLiteral] EntProtoId? id);
-
-    /// <inheritdoc cref="HasIndex{T}(string)"/>
-    [Obsolete("Do not specify T when using EntProtoId")]
-    bool HasIndex<T>([ForbidLiteral] EntProtoId? id) where T : class, IInheritingPrototype;
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
     bool HasIndex<T>([ForbidLiteral] ProtoId<T>? id) where T : class, IPrototype;
@@ -187,10 +183,6 @@ public interface IPrototypeManager
     /// <seealso cref="TryIndex(EntProtoId,out EntityPrototype?)"/>
     bool Resolve([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype);
 
-    /// <inheritdoc cref="Resolve(EntProtoId,out EntityPrototype?)"/>
-    [Obsolete("Do not specify T when using EntProtoId")]
-    bool Resolve<T>([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype;
-
     /// <summary>
     /// Resolve an <see cref="EntityPrototype"/> by ID.
     /// </summary>
@@ -218,7 +210,7 @@ public interface IPrototypeManager
 
     /// <inheritdoc cref="TryIndex(EntProtoId,out EntityPrototype?)"/>
     [Obsolete("Do not specify T when using EntProtoId")]
-    bool TryIndex<T>([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype;
+    bool TryIndex<T>([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IPrototype;
 
     /// <summary>
     /// Resolve a prototype by ID, logging an error if it does not exist.
@@ -295,10 +287,6 @@ public interface IPrototypeManager
     /// <seealso cref="TryIndex(EntProtoId?,out EntityPrototype?)"/>
     bool Resolve([ForbidLiteral] EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype);
 
-    /// <inheritdoc cref="Resolve(EntProtoId?,out EntityPrototype?)"/>
-    [Obsolete("Do not specify T when using EntProtoId")]
-    bool Resolve<T>([ForbidLiteral] EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype;
-
     /// <summary>
     /// Resolve an <see cref="EntityPrototype"/> by ID, gracefully handling null.
     /// </summary>
@@ -326,7 +314,7 @@ public interface IPrototypeManager
 
     /// <inheritdoc cref="TryIndex(EntProtoId?,out EntityPrototype?)"/>
     [Obsolete("Do not specify T when using EntProtoId")]
-    bool TryIndex<T>([ForbidLiteral] EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype;
+    bool TryIndex<T>([ForbidLiteral] EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IPrototype;
 
     /// <summary>
     /// Resolve a prototype by ID, gracefully handling null, and logging an error if it does not exist.

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -107,7 +107,7 @@ public interface IPrototypeManager
 
     /// <inheritdoc cref="Index{T}(string)"/>
     [Obsolete("Do not specify T when using EntProtoId")]
-    EntityPrototype Index<T>(EntProtoId protoId) where T : IPrototype;
+    T Index<T>(EntProtoId protoId) where T : class, IPrototype;
 
     /// <inheritdoc cref="Index{T}(string)"/>
     T Index<T>([ForbidLiteral] ProtoId<T> id) where T : class, IPrototype;
@@ -137,6 +137,10 @@ public interface IPrototypeManager
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
     bool HasIndex([ForbidLiteral] EntProtoId? id);
+
+    /// <inheritdoc cref="HasIndex{T}(string)"/>
+    [Obsolete("Do not specify T when using EntProtoId")]
+    bool HasIndex<T>([ForbidLiteral] EntProtoId? id) where T : class, IPrototype;
 
     /// <inheritdoc cref="HasIndex{T}(string)"/>
     bool HasIndex<T>([ForbidLiteral] ProtoId<T>? id) where T : class, IPrototype;
@@ -210,7 +214,7 @@ public interface IPrototypeManager
 
     /// <inheritdoc cref="TryIndex(EntProtoId,out EntityPrototype?)"/>
     [Obsolete("Do not specify T when using EntProtoId")]
-    bool TryIndex<T>([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IPrototype;
+    bool TryIndex<T>([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype;
 
     /// <summary>
     /// Resolve a prototype by ID, logging an error if it does not exist.
@@ -314,7 +318,7 @@ public interface IPrototypeManager
 
     /// <inheritdoc cref="TryIndex(EntProtoId?,out EntityPrototype?)"/>
     [Obsolete("Do not specify T when using EntProtoId")]
-    bool TryIndex<T>([ForbidLiteral] EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IPrototype;
+    bool TryIndex<T>([ForbidLiteral] EntProtoId? id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype;
 
     /// <summary>
     /// Resolve a prototype by ID, gracefully handling null, and logging an error if it does not exist.

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -7,8 +7,6 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using Robust.Shared.Asynchronous;
-using Robust.Shared.Collections;
 using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.IoC;
@@ -262,6 +260,12 @@ namespace Robust.Shared.Prototypes
 
         /// <inheritdoc />
         public EntityPrototype Index(EntProtoId id)
+        {
+            return Index<EntityPrototype>(id.Id);
+        }
+
+        /// <inheritdoc />
+        public EntityPrototype Index<T>(EntProtoId id) where T : IInheritingPrototype
         {
             return Index<EntityPrototype>(id.Id);
         }
@@ -804,6 +808,11 @@ namespace Robust.Shared.Prototypes
             return HasIndex<EntityPrototype>(id.Id);
         }
 
+        public bool HasIndex<T>(EntProtoId id) where T : class, IInheritingPrototype
+        {
+            return HasIndex(id);
+        }
+
         /// <inheritdoc />
         public bool HasIndex<T>(ProtoId<T> id) where T : class, IPrototype
         {
@@ -817,6 +826,11 @@ namespace Robust.Shared.Prototypes
                 return false;
 
             return HasIndex(id.Value);
+        }
+
+        public bool HasIndex<T>(EntProtoId? id) where T : class, IInheritingPrototype
+        {
+            return HasIndex(id);
         }
 
         /// <inheritdoc />
@@ -860,9 +874,19 @@ namespace Robust.Shared.Prototypes
             return false;
         }
 
+        public bool Resolve<T>(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype
+        {
+            return Resolve(id, out prototype);
+        }
+
         public bool TryIndex([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype)
         {
             return TryIndex(id.Id, out prototype);
+        }
+
+        public bool TryIndex<T>(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype
+        {
+            return TryIndex(id, out prototype);
         }
 
         public bool Resolve<T>(ProtoId<T> id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype
@@ -891,6 +915,11 @@ namespace Robust.Shared.Prototypes
             return Resolve(id.Value, out prototype);
         }
 
+        public bool Resolve<T>(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype
+        {
+            return Resolve(id, out prototype);
+        }
+
         public bool TryIndex(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype)
         {
             if (id == null)
@@ -900,6 +929,11 @@ namespace Robust.Shared.Prototypes
             }
 
             return TryIndex(id.Value, out prototype);
+        }
+
+        public bool TryIndex<T>(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype
+        {
+            return TryIndex(id, out prototype);
         }
 
         public bool Resolve<T>(ProtoId<T>? id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -265,9 +265,9 @@ namespace Robust.Shared.Prototypes
         }
 
         /// <inheritdoc />
-        public EntityPrototype Index<T>(EntProtoId id) where T : IPrototype
+        public T Index<T>(EntProtoId id) where T : class, IPrototype
         {
-            return Index<EntityPrototype>(id.Id);
+            return Index<T>(id.Id);
         }
 
         /// <inheritdoc />
@@ -810,7 +810,7 @@ namespace Robust.Shared.Prototypes
 
         public bool HasIndex<T>(EntProtoId id) where T : class, IPrototype
         {
-            return HasIndex(id);
+            return HasIndex<T>(id.Id);
         }
 
         /// <inheritdoc />
@@ -826,6 +826,15 @@ namespace Robust.Shared.Prototypes
                 return false;
 
             return HasIndex(id.Value);
+        }
+
+        /// <inheritdoc />
+        public bool HasIndex<T>(EntProtoId? id) where T : class, IPrototype
+        {
+            if (id == null)
+                return false;
+
+            return HasIndex<T>(id.Value);
         }
 
         /// <inheritdoc />
@@ -874,9 +883,9 @@ namespace Robust.Shared.Prototypes
             return TryIndex(id.Id, out prototype);
         }
 
-        public bool TryIndex<T>(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IPrototype
+        public bool TryIndex<T>(EntProtoId id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype
         {
-            return TryIndex(id, out prototype);
+            return TryIndex(id.Id, out prototype);
         }
 
         public bool Resolve<T>(ProtoId<T> id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype
@@ -916,9 +925,15 @@ namespace Robust.Shared.Prototypes
             return TryIndex(id.Value, out prototype);
         }
 
-        public bool TryIndex<T>(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IPrototype
+        public bool TryIndex<T>(EntProtoId? id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype
         {
-            return TryIndex(id, out prototype);
+            if (id == null)
+            {
+                prototype = null;
+                return false;
+            }
+
+            return TryIndex(id.Value, out prototype);
         }
 
         public bool Resolve<T>(ProtoId<T>? id, [NotNullWhen(true)] out T? prototype) where T : class, IPrototype

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -265,7 +265,7 @@ namespace Robust.Shared.Prototypes
         }
 
         /// <inheritdoc />
-        public EntityPrototype Index<T>(EntProtoId id) where T : IInheritingPrototype
+        public EntityPrototype Index<T>(EntProtoId id) where T : IPrototype
         {
             return Index<EntityPrototype>(id.Id);
         }
@@ -808,7 +808,7 @@ namespace Robust.Shared.Prototypes
             return HasIndex<EntityPrototype>(id.Id);
         }
 
-        public bool HasIndex<T>(EntProtoId id) where T : class, IInheritingPrototype
+        public bool HasIndex<T>(EntProtoId id) where T : class, IPrototype
         {
             return HasIndex(id);
         }
@@ -826,11 +826,6 @@ namespace Robust.Shared.Prototypes
                 return false;
 
             return HasIndex(id.Value);
-        }
-
-        public bool HasIndex<T>(EntProtoId? id) where T : class, IInheritingPrototype
-        {
-            return HasIndex(id);
         }
 
         /// <inheritdoc />
@@ -874,17 +869,12 @@ namespace Robust.Shared.Prototypes
             return false;
         }
 
-        public bool Resolve<T>(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype
-        {
-            return Resolve(id, out prototype);
-        }
-
         public bool TryIndex([ForbidLiteral] EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype)
         {
             return TryIndex(id.Id, out prototype);
         }
 
-        public bool TryIndex<T>(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype
+        public bool TryIndex<T>(EntProtoId id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IPrototype
         {
             return TryIndex(id, out prototype);
         }
@@ -915,11 +905,6 @@ namespace Robust.Shared.Prototypes
             return Resolve(id.Value, out prototype);
         }
 
-        public bool Resolve<T>(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype
-        {
-            return Resolve(id, out prototype);
-        }
-
         public bool TryIndex(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype)
         {
             if (id == null)
@@ -931,7 +916,7 @@ namespace Robust.Shared.Prototypes
             return TryIndex(id.Value, out prototype);
         }
 
-        public bool TryIndex<T>(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IInheritingPrototype
+        public bool TryIndex<T>(EntProtoId? id, [NotNullWhen(true)] out EntityPrototype? prototype) where T : IPrototype
         {
             return TryIndex(id, out prototype);
         }


### PR DESCRIPTION
They mean the same thing but aren't always able to be used in the same places. Too and from in the `EntProtoId` struct since regular `ProtoId` is generic, didn't add conversions for `EntProtoId<T>` since regular `EntProtoId` can't be converted into it, only out.

Had to mess with ProtoMan a little to get rid of a breaking change, and I'm not too happy with it. If this is bad with that in mind I don't mind this being closed, as it's mostly a minor convenience.