### PR TITLE
Fix client predicteddel running on detaching entities

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -43,7 +43,7 @@ END TEMPLATE-->
 
 ### Bugfixes
 
-*None yet*
+* ClientGameStateManager will now drop predicted deletions if they occur while an entity is detached to nullspace due to PVS.
 
 ### Other
 

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -258,6 +258,12 @@ namespace Robust.Client.GameObjects
                 if (meta.EntityLifeStage >= EntityLifeStage.Terminating)
                     continue;
 
+                // A reliable PVS leave may have detached the entity after this predicted deletion was queued.
+                // The server state must not be turned into a predicted detachment, or prediction
+                // reset will immediately restore it to the map.
+                if ((meta.Flags & MetaDataFlags.Detached) != 0)
+                    continue;
+
                 var xform = TransformQuery.GetComponentInternal(uid);
                 if (meta.NetEntity.IsClientSide())
                 {

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -481,6 +481,15 @@ namespace Robust.Client.GameStates
                 }
             }
 
+            // PVS leaves are sent separately from game states. If the leave was the last network update, it used to
+            // remain queued until an unrelated future state arrived. Drain messages after the matching game-state
+            // tick has been applied, while preserving against dropped or delayed states.
+            if (_processor.HasPvsDetachMessages)
+            {
+                using var _ = _timing.StartStateApplicationArea();
+                ProcessPvsDeparture(_timing.LastRealTick);
+            }
+
             // Slightly speed up or slow down the client tickrate based on the contents of the buffer.
             // TryGetTickStates should have cleaned out any old states, so the buffer contains [t+0(cur), t+1(next), t+2, t+3, ..., t+n]
             // we can use this info to properly time our tickrate so it does not run fast or slow compared to the server.
@@ -930,9 +939,8 @@ namespace Robust.Client.GameStates
             }
 
             // Detach entities to null space
-            var containerSys = _entitySystemManager.GetEntitySystem<ContainerSystem>();
             var lookupSys = _entitySystemManager.GetEntitySystem<EntityLookupSystem>();
-            ProcessPvsDeparture(curState.ToSequence, metas, xforms, xformSys, containerSys, lookupSys);
+            ProcessPvsDeparture(curState.ToSequence, metas, xforms, xformSys);
 
             // Check next state (AFTER having created new entities introduced in curstate)
             if (nextState != null)
@@ -1352,10 +1360,11 @@ namespace Robust.Client.GameStates
             GameTick toTick,
             EntityQuery<MetaDataComponent> metas,
             EntityQuery<TransformComponent> xforms,
-            SharedTransformSystem xformSys,
-            ContainerSystem containerSys,
-            EntityLookupSystem lookupSys)
+            SharedTransformSystem xformSys)
         {
+            if (!_processor.HasPvsDetachMessages)
+                return;
+
             var toDetach = _processor.GetEntitiesToDetach(toTick, _pvsDetachBudget);
 
             if (toDetach.Count == 0)
@@ -1366,6 +1375,8 @@ namespace Robust.Client.GameStates
             // things like container insertion and ejection.
 
             using var _ = _prof.Group("Leave PVS");
+            var containerSys = _entitySystemManager.GetEntitySystem<ContainerSystem>();
+            var lookupSys = _entitySystemManager.GetEntitySystem<EntityLookupSystem>();
 
             _detached.Clear();
             foreach (var (tick, ents) in toDetach)
@@ -1374,6 +1385,14 @@ namespace Robust.Client.GameStates
             }
 
             _prof.WriteValue("Count", ProfData.Int32(_detached.Count));
+        }
+
+        private void ProcessPvsDeparture(GameTick toTick)
+        {
+            var metas = _entities.GetEntityQuery<MetaDataComponent>();
+            var xforms = _entities.GetEntityQuery<TransformComponent>();
+            var xformSys = _entitySystemManager.GetEntitySystem<SharedTransformSystem>();
+            ProcessPvsDeparture(toTick, metas, xforms, xformSys);
         }
 
         private void Detach(GameTick maxTick,
@@ -1403,6 +1422,10 @@ namespace Robust.Client.GameStates
             {
                 var uid = ent.Owner;
                 var metadata = ent.Comp;
+
+                // An authoritative PVS departure wins over a locally predicted deletion. Otherwise the queued
+                // predicted deletion immediately restores this entity from its last known state.
+                _entities.ClearPredictedDeletion(uid);
 
                 if (lastStateApplied.HasValue)
                     metadata.LastStateApplied = lastStateApplied.Value;
@@ -1475,7 +1498,11 @@ namespace Robust.Client.GameStates
                 return false;
             }
 
-            if ((meta.Flags & (MetaDataFlags.Detached | MetaDataFlags.Undetachable)) != 0)
+            if ((meta.Flags & MetaDataFlags.Undetachable) != 0)
+                return false;
+
+            // A locally predicted deletion also detaches a networked entity so let detach cancel the prediction instead of dropping the leave.
+            if ((meta.Flags & MetaDataFlags.Detached) != 0 && !_entities.IsPredictedDetached(uid.Value))
                 return false;
 
             ent = (uid.Value, meta);

--- a/Robust.Client/GameStates/GameStateProcessor.cs
+++ b/Robust.Client/GameStates/GameStateProcessor.cs
@@ -21,6 +21,9 @@ namespace Robust.Client.GameStates
         private readonly List<GameState> _stateBuffer = new();
 
         private readonly List<(GameTick Tick, List<NetEntity> Entities)> _pvsDetachMessages = new();
+
+        public bool HasPvsDetachMessages => _pvsDetachMessages.Count != 0;
+
         public GameState? LastFullState { get; private set; }
         public bool WaitingForFull => LastFullStateRequested.HasValue;
         public (GameTick Tick, DateTime Time)? LastFullStateRequested { get; private set; } = (GameTick.Zero, DateTime.MaxValue);

--- a/Robust.Server.IntegrationTests/GameStates/PvsReEntryTest.cs
+++ b/Robust.Server.IntegrationTests/GameStates/PvsReEntryTest.cs
@@ -106,6 +106,12 @@ public sealed class PvsReEntryTest : RobustIntegrationTest
         Assert.That(meta!.Flags & MetaDataFlags.Detached, Is.EqualTo(MetaDataFlags.Detached));
         Assert.That(stateMan.IsQueuedForDetach(entity), Is.False);
 
+        // Entities can queue a predicted deletion after they have already left PVS. PVS is still authoritative
+        // and should take priority.
+        await client.WaitPost(() => cEntMan.PredictedQueueDeleteEntity(cEntMan.GetEntity(entity)));
+        await RunTicksSync(server, client, 2);
+        Assert.That(meta.Flags & MetaDataFlags.Detached, Is.EqualTo(MetaDataFlags.Detached));
+
         // Move the player back into range
         await server.WaitPost( () => xforms.SetCoordinates(sEntMan.GetEntity(player), coords));
         await RunTicksSync(server, client, 10);

--- a/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
+++ b/Robust.Shared/GameObjects/Systems/EntityLookup.Queries.cs
@@ -556,7 +556,7 @@ public sealed partial class EntityLookupSystem
 
         var state = (uid, transform, intersecting, _fixturesQuery, this, _physics, flags);
 
-        // Unfortuantely I can't think of a way to de-dupe this with the other ones as it's slightly different.
+        // Unfortunately I can't think of a way to de-dupe this with the other ones as it's slightly different.
         _map.FindGridsIntersecting(mapId, worldAABB, ref state,
             static (EntityUid gridUid, MapGridComponent grid,
                 ref (EntityUid entity, Transform transform, HashSet<EntityUid> intersecting,


### PR DESCRIPTION
The issue is that the client will restore the entity in a weird state so we just need to block those situations entirely. Once it's detached we should just ignore it entirely.

This should defensively guard against https://github.com/space-wizards/space-station-14/pull/45410 from the engine side.