### PR TITLE
Fix pause when audio disposed

### DIFF
--- a/Robust.Client/Audio/Sources/BaseAudioSource.cs
+++ b/Robust.Client/Audio/Sources/BaseAudioSource.cs
@@ -47,7 +47,7 @@ public abstract class BaseAudioSource : IAudioSource
     /// <inheritdoc />
     public void Pause()
     {
-        if (_isDisposed())
+        if (!Playing)
             return;
 
         AL.SourcePause(SourceHandle);
@@ -56,7 +56,7 @@ public abstract class BaseAudioSource : IAudioSource
     /// <inheritdoc />
     public void StartPlaying()
     {
-        if (_isDisposed() || Playing)
+        if (Playing)
             return;
 
         Playing = true;
@@ -65,7 +65,7 @@ public abstract class BaseAudioSource : IAudioSource
     /// <inheritdoc />
     public void StopPlaying()
     {
-        if (_isDisposed() || !Playing)
+        if (!Playing)
             return;
 
         Playing = false;
@@ -74,7 +74,7 @@ public abstract class BaseAudioSource : IAudioSource
     /// <inheritdoc />
     public void Restart()
     {
-        if (_isDisposed() || Playing)
+        if (Playing)
             return;
 
         AL.SourceRewind(SourceHandle);

--- a/Robust.Client/Audio/Sources/BaseAudioSource.cs
+++ b/Robust.Client/Audio/Sources/BaseAudioSource.cs
@@ -47,13 +47,16 @@ public abstract class BaseAudioSource : IAudioSource
     /// <inheritdoc />
     public void Pause()
     {
+        if (_isDisposed())
+            return;
+
         AL.SourcePause(SourceHandle);
     }
 
     /// <inheritdoc />
     public void StartPlaying()
     {
-        if (Playing)
+        if (_isDisposed() || Playing)
             return;
 
         Playing = true;
@@ -62,7 +65,7 @@ public abstract class BaseAudioSource : IAudioSource
     /// <inheritdoc />
     public void StopPlaying()
     {
-        if (!Playing)
+        if (_isDisposed() || !Playing)
             return;
 
         Playing = false;
@@ -71,6 +74,9 @@ public abstract class BaseAudioSource : IAudioSource
     /// <inheritdoc />
     public void Restart()
     {
+        if (_isDisposed() || Playing)
+            return;
+
         AL.SourceRewind(SourceHandle);
         StartPlaying();
     }

--- a/Robust.Client/Audio/Sources/BaseAudioSource.cs
+++ b/Robust.Client/Audio/Sources/BaseAudioSource.cs
@@ -78,7 +78,7 @@ public abstract class BaseAudioSource : IAudioSource
             return;
 
         AL.SourceRewind(SourceHandle);
-        StartPlaying();
+        Playing = true;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Part of #7017, dividing it on small patches, this change just Fixes #2012, by adding Playing check on pause operation and replaces StartPlaying() call with `Playing = true;` so it won't check Playing for the second time.