### PR TITLE
Audio resilent against device init failure

### DIFF
--- a/Robust.Client/Audio/AudioManager.Public.cs
+++ b/Robust.Client/Audio/AudioManager.Public.cs
@@ -69,18 +69,21 @@ internal partial class AudioManager
     /// <inheritdoc/>
     public void SetVelocity(Vector2 velocity)
     {
+        if (!_audioInitialized) return;
         AL.Listener(ALListener3f.Velocity, velocity.X, velocity.Y, 0f);
     }
 
     /// <inheritdoc/>
     public void SetPosition(Vector2 position)
     {
+        if (!_audioInitialized) return;
         AL.Listener(ALListener3f.Position, position.X, position.Y, _zOffset);
     }
 
     /// <inheritdoc/>
     public void SetRotation(Angle angle)
     {
+        if (!_audioInitialized) return;
         var vec = angle.ToVec();
 
         // Default orientation: at: (0, 0, -1)  up: (0, 1, 0)
@@ -118,6 +121,9 @@ internal partial class AudioManager
     public AudioStream LoadAudioOggVorbis(Stream stream, string? name = null)
     {
         var vorbis = AudioLoaderOgg.LoadAudioData(stream);
+        var length = TimeSpan.FromSeconds(vorbis.TotalSamples / (double)vorbis.SampleRate);
+
+        if (!_audioInitialized) return new AudioStream(this, 0, null, length, (int) vorbis.Channels, name, vorbis.Title, vorbis.Artist);
 
         var buffer = AL.GenBuffer();
 
@@ -151,7 +157,6 @@ internal partial class AudioManager
 
         var handle = new ClydeHandle(_audioSampleBuffers.Count);
         _audioSampleBuffers.Add(buffer, new LoadedAudioSample(buffer));
-        var length = TimeSpan.FromSeconds(vorbis.TotalSamples / (double) vorbis.SampleRate);
         return new AudioStream(this, buffer, handle, length, (int) vorbis.Channels, name, vorbis.Title, vorbis.Artist);
     }
 
@@ -159,6 +164,9 @@ internal partial class AudioManager
     public AudioStream LoadAudioWav(Stream stream, string? name = null)
     {
         var wav = AudioLoaderWav.LoadAudioData(stream);
+        var length = TimeSpan.FromSeconds(wav.Data.Length / (double)wav.BlockAlign / wav.SampleRate);
+
+        if (!_audioInitialized) return new AudioStream(this, 0, null, length, (int)wav.NumChannels, name);
 
         var buffer = AL.GenBuffer();
 
@@ -210,13 +218,16 @@ internal partial class AudioManager
 
         var handle = new ClydeHandle(_audioSampleBuffers.Count);
         _audioSampleBuffers.Add(buffer, new LoadedAudioSample(buffer));
-        var length = TimeSpan.FromSeconds(wav.Data.Length / (double) wav.BlockAlign / wav.SampleRate);
         return new AudioStream(this, buffer, handle, length, wav.NumChannels, name);
     }
 
     /// <inheritdoc/>
     public AudioStream LoadAudioRaw(ReadOnlySpan<short> samples, int channels, int sampleRate, string? name = null)
     {
+        var length = TimeSpan.FromSeconds((double)samples.Length / channels / sampleRate);
+
+        if (!_audioInitialized) return new AudioStream(this, 0, null, length, channels, name);
+
         var fmt = channels switch
         {
             1 => ALFormat.Mono16,
@@ -239,7 +250,6 @@ internal partial class AudioManager
         _checkAlError();
 
         var handle = new ClydeHandle(_audioSampleBuffers.Count);
-        var length = TimeSpan.FromSeconds((double) samples.Length / channels / sampleRate);
         _audioSampleBuffers.Add(buffer, new LoadedAudioSample(buffer));
         return new AudioStream(this, buffer, handle, length, channels, name);
     }
@@ -262,6 +272,8 @@ internal partial class AudioManager
 
     private void ApplyMasterGain()
     {
+        if (!_audioInitialized) return;
+
         var effectiveGain = BaseGain * FadeGain;
 
 
@@ -281,6 +293,7 @@ internal partial class AudioManager
 
     public void SetAttenuation(Attenuation attenuation)
     {
+        if (!_audioInitialized) return;
         switch (attenuation)
         {
             case Attenuation.NoAttenuation:
@@ -314,6 +327,7 @@ internal partial class AudioManager
 
     public void SetDopplerFactor(float factor)
     {
+        if (!_audioInitialized) return;
         factor = Math.Max(factor, 0f);
         AL.DopplerFactor(factor);
         OpenALSawmill.Info($"Set doppler factor to {factor:F2}");
@@ -331,6 +345,7 @@ internal partial class AudioManager
 
     public IAudioSource? CreateAudioSource(AudioStream stream)
     {
+        if (!_audioInitialized) return null;
         var source = AL.GenSource();
 
         if (!AL.IsSource(source))
@@ -352,6 +367,7 @@ internal partial class AudioManager
     /// <inheritdoc/>
     IBufferedAudioSource? IAudioInternal.CreateBufferedAudioSource(int buffers, bool floatAudio)
     {
+        if (!_audioInitialized) return null;
         var source = AL.GenSource();
 
         if (!AL.IsSource(source))

--- a/Robust.Client/Audio/AudioManager.Public.cs
+++ b/Robust.Client/Audio/AudioManager.Public.cs
@@ -69,21 +69,18 @@ internal partial class AudioManager
     /// <inheritdoc/>
     public void SetVelocity(Vector2 velocity)
     {
-        if (!_audioInitialized) return;
         AL.Listener(ALListener3f.Velocity, velocity.X, velocity.Y, 0f);
     }
 
     /// <inheritdoc/>
     public void SetPosition(Vector2 position)
     {
-        if (!_audioInitialized) return;
         AL.Listener(ALListener3f.Position, position.X, position.Y, _zOffset);
     }
 
     /// <inheritdoc/>
     public void SetRotation(Angle angle)
     {
-        if (!_audioInitialized) return;
         var vec = angle.ToVec();
 
         // Default orientation: at: (0, 0, -1)  up: (0, 1, 0)
@@ -121,9 +118,6 @@ internal partial class AudioManager
     public AudioStream LoadAudioOggVorbis(Stream stream, string? name = null)
     {
         var vorbis = AudioLoaderOgg.LoadAudioData(stream);
-        var length = TimeSpan.FromSeconds(vorbis.TotalSamples / (double)vorbis.SampleRate);
-
-        if (!_audioInitialized) return new AudioStream(this, 0, null, length, (int) vorbis.Channels, name, vorbis.Title, vorbis.Artist);
 
         var buffer = AL.GenBuffer();
 
@@ -157,6 +151,7 @@ internal partial class AudioManager
 
         var handle = new ClydeHandle(_audioSampleBuffers.Count);
         _audioSampleBuffers.Add(buffer, new LoadedAudioSample(buffer));
+        var length = TimeSpan.FromSeconds(vorbis.TotalSamples / (double) vorbis.SampleRate);
         return new AudioStream(this, buffer, handle, length, (int) vorbis.Channels, name, vorbis.Title, vorbis.Artist);
     }
 
@@ -164,9 +159,6 @@ internal partial class AudioManager
     public AudioStream LoadAudioWav(Stream stream, string? name = null)
     {
         var wav = AudioLoaderWav.LoadAudioData(stream);
-        var length = TimeSpan.FromSeconds(wav.Data.Length / (double)wav.BlockAlign / wav.SampleRate);
-
-        if (!_audioInitialized) return new AudioStream(this, 0, null, length, (int)wav.NumChannels, name);
 
         var buffer = AL.GenBuffer();
 
@@ -218,16 +210,13 @@ internal partial class AudioManager
 
         var handle = new ClydeHandle(_audioSampleBuffers.Count);
         _audioSampleBuffers.Add(buffer, new LoadedAudioSample(buffer));
+        var length = TimeSpan.FromSeconds(wav.Data.Length / (double) wav.BlockAlign / wav.SampleRate);
         return new AudioStream(this, buffer, handle, length, wav.NumChannels, name);
     }
 
     /// <inheritdoc/>
     public AudioStream LoadAudioRaw(ReadOnlySpan<short> samples, int channels, int sampleRate, string? name = null)
     {
-        var length = TimeSpan.FromSeconds((double)samples.Length / channels / sampleRate);
-
-        if (!_audioInitialized) return new AudioStream(this, 0, null, length, channels, name);
-
         var fmt = channels switch
         {
             1 => ALFormat.Mono16,
@@ -250,6 +239,7 @@ internal partial class AudioManager
         _checkAlError();
 
         var handle = new ClydeHandle(_audioSampleBuffers.Count);
+        var length = TimeSpan.FromSeconds((double) samples.Length / channels / sampleRate);
         _audioSampleBuffers.Add(buffer, new LoadedAudioSample(buffer));
         return new AudioStream(this, buffer, handle, length, channels, name);
     }
@@ -272,8 +262,6 @@ internal partial class AudioManager
 
     private void ApplyMasterGain()
     {
-        if (!_audioInitialized) return;
-
         var effectiveGain = BaseGain * FadeGain;
 
 
@@ -293,7 +281,6 @@ internal partial class AudioManager
 
     public void SetAttenuation(Attenuation attenuation)
     {
-        if (!_audioInitialized) return;
         switch (attenuation)
         {
             case Attenuation.NoAttenuation:
@@ -327,7 +314,6 @@ internal partial class AudioManager
 
     public void SetDopplerFactor(float factor)
     {
-        if (!_audioInitialized) return;
         factor = Math.Max(factor, 0f);
         AL.DopplerFactor(factor);
         OpenALSawmill.Info($"Set doppler factor to {factor:F2}");
@@ -345,7 +331,6 @@ internal partial class AudioManager
 
     public IAudioSource? CreateAudioSource(AudioStream stream)
     {
-        if (!_audioInitialized) return null;
         var source = AL.GenSource();
 
         if (!AL.IsSource(source))
@@ -367,7 +352,6 @@ internal partial class AudioManager
     /// <inheritdoc/>
     IBufferedAudioSource? IAudioInternal.CreateBufferedAudioSource(int buffers, bool floatAudio)
     {
-        if (!_audioInitialized) return null;
         var source = AL.GenSource();
 
         if (!AL.IsSource(source))

--- a/Robust.Client/Audio/AudioManager.cs
+++ b/Robust.Client/Audio/AudioManager.cs
@@ -104,6 +104,27 @@ internal sealed partial class AudioManager : IAudioInternal
         OpenALSawmill.Debug("HRTF status: {0}", hrtfEnabled == 1 ? "Enabled" : "Disabled");
     }
 
+    internal static bool IsAudioAvailable()
+    {
+        var device = ALC.OpenDevice(null);
+        if (device == ALDevice.Null)
+            return false;
+
+        try
+        {
+            var context = ALC.CreateContext(device, new[] { 0 });
+            if (context == ALContext.Null)
+                return false;
+
+            ALC.DestroyContext(context);
+            return true;
+        }
+        finally
+        {
+            ALC.CloseDevice(device);
+        }
+    }
+
     public IReadOnlyList<string> GetAudioDevices()
     {
         if (ALC.EnumerateAll.IsExtensionPresent())

--- a/Robust.Client/Audio/AudioSystem.cs
+++ b/Robust.Client/Audio/AudioSystem.cs
@@ -251,15 +251,8 @@ public sealed partial class AudioSystem : SharedAudioSystem
         {
             var newSource = _audio.CreateAudioSource(audioResource);
 
-            if (newSource == null)
-            {
-                Log.Error($"Error creating audio source for {audioResource}");
-                DebugTools.Assert(false);
-            }
-            else
-            {
+            if (newSource != null)
                 component.Source = newSource;
-            }
         }
 
         // Need to set all initial data for first frame.

--- a/Robust.Client/Audio/HeadlessAudioManager.cs
+++ b/Robust.Client/Audio/HeadlessAudioManager.cs
@@ -5,6 +5,8 @@ using System.Numerics;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.AudioLoading;
 using Robust.Shared.Audio.Sources;
+using Robust.Shared.IoC;
+using Robust.Shared.Log;
 using Robust.Shared.Maths;
 
 namespace Robust.Client.Audio;
@@ -12,8 +14,9 @@ namespace Robust.Client.Audio;
 /// <summary>
 /// Headless client audio.
 /// </summary>
-internal sealed class HeadlessAudioManager : IAudioInternal
+internal sealed partial class HeadlessAudioManager : IAudioInternal
 {
+    [Dependency] private ILogManager _logMan = default!;
 
     private readonly IReadOnlyList<string> _emptyDevices = Array.Empty<string>();
     private int _audioBuffer;
@@ -21,6 +24,7 @@ internal sealed class HeadlessAudioManager : IAudioInternal
     /// <inheritdoc />
     public void InitializePostWindowing()
     {
+        _logMan.GetSawmill("clyde.oal").Info("Application running Headless mode or misses audio device.");
     }
 
     /// <inheritdoc />

--- a/Robust.Client/ClientIoC.cs
+++ b/Robust.Client/ClientIoC.cs
@@ -129,8 +129,16 @@ namespace Robust.Client
                     deps.Register<IClyde, Clyde>();
                     deps.Register<IClipboardManager, Clyde>();
                     deps.Register<IClydeInternal, Clyde>();
-                    deps.Register<IAudioManager, AudioManager>();
-                    deps.Register<IAudioInternal, AudioManager>();
+                    if (AudioManager.IsAudioAvailable())
+                    {
+                        deps.Register<IAudioManager, AudioManager>();
+                        deps.Register<IAudioInternal, AudioManager>();
+                    }
+                    else
+                    {
+                        deps.Register<IAudioManager, HeadlessAudioManager>();
+                        deps.Register<IAudioInternal, HeadlessAudioManager>();
+                    }
                     deps.Register<IInputManager, ClydeInputManager>();
                     deps.Register<IUriOpener, UriOpener>();
                     deps.Register<ISystemFontManager, SystemFontManager>();


### PR DESCRIPTION
Part of #7017, dividing it on small patches, this change just Fixes #2180 and Fixes #6414, by adding init checks in public methods.

However, there is no hot reload, so you'll still need to restart the game to enable audio.