### PR TITLE
Use packaged OpenAL

### DIFF
--- a/Robust.Client/Audio/AudioManager.cs
+++ b/Robust.Client/Audio/AudioManager.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using OpenTK.Audio.OpenAL;
 using Robust.Client.Audio.Sources;
@@ -12,7 +14,6 @@ using Robust.Shared;
 using Robust.Shared.Audio;
 using Robust.Shared.Configuration;
 using Robust.Shared.Log;
-using Robust.Shared.Maths;
 using Robust.Shared.Utility;
 
 namespace Robust.Client.Audio;
@@ -42,6 +43,7 @@ internal sealed partial class AudioManager : IAudioInternal
     private readonly HashSet<string> _alContextExtensions = new();
     private Attenuation _attenuation;
     private bool _audioInitialized;
+    private int _preloaded;
     private bool _focused = true;
     private bool _muteUnfocused;
     private const float MasterFadeDuration = 0.25f;
@@ -168,6 +170,8 @@ internal sealed partial class AudioManager : IAudioInternal
     {
         OpenALSawmill = _logMan.GetSawmill("clyde.oal");
 
+        PreloadOpenAl();
+
         if (!_audioOpenDevice())
             return;
 
@@ -186,6 +190,40 @@ internal sealed partial class AudioManager : IAudioInternal
 
         _reload.OnChanged += OnReload;
         _audioInitialized = true;
+    }
+
+    private void PreloadOpenAl()
+    {
+        if (Interlocked.Exchange(ref _preloaded, 1) != 0)
+            return;
+
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var rid = Environment.Is64BitProcess ? "win-x64" : "win-x86";
+        var baseDir = AppContext.BaseDirectory;
+
+        string[] candidates =
+        [
+            Path.Combine(baseDir, "runtimes", rid, "native", "OpenAL32.dll"),
+            Path.Combine(baseDir, "OpenAL32.dll"),
+        ];
+
+        foreach (var candidate in candidates)
+        {
+            if (!File.Exists(candidate))
+                continue;
+
+            if (NativeLibrary.TryLoad(candidate, out _))
+            {
+                OpenALSawmill.Debug($"Preloaded bundled OpenAL from {candidate}");
+                return;
+            }
+
+            OpenALSawmill.Warning("Found {candidate} but failed to load it (architecture mismatch or missing dependencies).", candidate);
+        }
+
+        OpenALSawmill.Warning("No bundled OpenAL found, falling back to the system implementation. Hot-plug may be unavailable.");
     }
 
     private void OnMuteUnfocusedChanged(bool muteUnfocused)

--- a/Robust.Client/Audio/AudioManager.cs
+++ b/Robust.Client/Audio/AudioManager.cs
@@ -192,21 +192,43 @@ internal sealed partial class AudioManager : IAudioInternal
         _audioInitialized = true;
     }
 
+    /// <summary>
+    /// Preloads bundled OpenAL before OpenTK initialization, preventing it from using system variant with potentially different behavior.
+    /// </summary>
     private void PreloadOpenAl()
     {
         if (Interlocked.Exchange(ref _preloaded, 1) != 0)
             return;
 
-        if (!OperatingSystem.IsWindows())
-            return;
+        (string rid, string fileName) platform;
+        var arm = RuntimeInformation.ProcessArchitecture == Architecture.Arm;
+        var arm64 = RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
 
-        var rid = Environment.Is64BitProcess ? "win-x64" : "win-x86";
+        if (OperatingSystem.IsWindows())
+            platform = arm64 ? ("win-arm64", "OpenAL32.dll")
+                : Environment.Is64BitProcess
+                ? ("win-x64", "OpenAL32.dll")
+                : ("win-x86", "OpenAL32.dll");
+        else if (OperatingSystem.IsLinux())
+            platform = arm64
+                ? ("linux-arm64", "libopenal.so.1")
+                : ("linux-x64", "libopenal.so.1");
+        else if (OperatingSystem.IsMacOS())
+            platform = arm64
+                ? ("osx-arm64", "libopenal.1.dylib")
+                : ("osx-x64", "libopenal.1.dylib");
+        else
+        {
+            OpenALSawmill.Info("No bundled OpenAL for this platform, using the system implementation.");
+            return;
+        }
+
         var baseDir = AppContext.BaseDirectory;
 
         string[] candidates =
         [
-            Path.Combine(baseDir, "runtimes", rid, "native", "OpenAL32.dll"),
-            Path.Combine(baseDir, "OpenAL32.dll"),
+            Path.Combine(baseDir, "runtimes", rid, "native", fileName),
+            Path.Combine(baseDir, fileName),
         ];
 
         foreach (var candidate in candidates)

--- a/Robust.Client/Audio/AudioManager.cs
+++ b/Robust.Client/Audio/AudioManager.cs
@@ -234,18 +234,24 @@ internal sealed partial class AudioManager : IAudioInternal
         foreach (var candidate in candidates)
         {
             if (!File.Exists(candidate))
-                continue;
-
-            if (NativeLibrary.TryLoad(candidate, out _))
             {
-                OpenALSawmill.Debug($"Preloaded bundled OpenAL from {candidate}");
-                return;
+                OpenALSawmill.Debug("No bundled OpenAL at {candidate}, trying next candidate.", candidate);
+                continue;
             }
 
-            OpenALSawmill.Warning("Found {candidate} but failed to load it (architecture mismatch or missing dependencies).", candidate);
+            try
+            {
+                NativeLibrary.Load(candidate);
+                OpenALSawmill.Info("Preloaded bundled OpenAL from {candidate}", candidate);
+                return;
+            }
+            catch (Exception ex)
+            {
+                OpenALSawmill.Error("Found bundled OpenAL at {candidate} but failed to load it. {ex}", candidate, ex);
+            }
         }
 
-        OpenALSawmill.Warning("No bundled OpenAL found, falling back to the system implementation. Hot-plug may be unavailable.");
+        OpenALSawmill.Warning("No usable bundled OpenAL found for {0}, falling back to the system implementation. ", rid);
     }
 
     private void OnMuteUnfocusedChanged(bool muteUnfocused)

--- a/Robust.Client/Audio/AudioManager.cs
+++ b/Robust.Client/Audio/AudioManager.cs
@@ -227,8 +227,8 @@ internal sealed partial class AudioManager : IAudioInternal
 
         string[] candidates =
         [
-            Path.Combine(baseDir, "runtimes", rid, "native", fileName),
-            Path.Combine(baseDir, fileName),
+            Path.Combine(baseDir, "runtimes", platform.rid, "native", platform.fileName),
+            Path.Combine(baseDir, platform.fileName),
         ];
 
         foreach (var candidate in candidates)
@@ -251,7 +251,7 @@ internal sealed partial class AudioManager : IAudioInternal
             }
         }
 
-        OpenALSawmill.Warning("No usable bundled OpenAL found for {0}, falling back to the system implementation. ", rid);
+        OpenALSawmill.Warning("No usable bundled OpenAL found for {0}, falling back to the system implementation. ", platform.rid);
     }
 
     private void OnMuteUnfocusedChanged(bool muteUnfocused)


### PR DESCRIPTION
Part of #7017, dividing it on small patches, this change forces game to use packaged OpenAL instead of system ones by preloading it, because OpenAL prefers to use system one.

Why?

General Stability and Predictability: I've seen players complain about sound issues more than once; I attribute this to a corrupted OpenAL library installed on their systems, but we can't force everyone to reinstall the library or the app.
Also the same version and the same implementation will always be used, for example when I tried to add hot-plug it used my OpenAL, which was not OpenAL Soft.