### PR TITLE
Fix audio source collision

### DIFF
--- a/Robust.Client/Audio/AudioManager.Public.cs
+++ b/Robust.Client/Audio/AudioManager.Public.cs
@@ -330,7 +330,7 @@ internal partial class AudioManager
     {
         if (!_audioSampleBuffers.TryGetValue(stream.BufferId, out var sample))
         {
-            OpenALSawmill.Warning($"Audio stream '{stream.Name}' has no backing buffer, skipping.");
+            OpenALSawmill.Error($"Audio stream '{stream.Name}' has no backing buffer, skipping.");
             return null;
         }
 

--- a/Robust.Client/Audio/AudioManager.Public.cs
+++ b/Robust.Client/Audio/AudioManager.Public.cs
@@ -149,9 +149,8 @@ internal partial class AudioManager
 
         _checkAlError();
 
-        var handle = new ClydeHandle(_audioSampleBuffers.Count);
-        _audioSampleBuffers.Add(buffer, new LoadedAudioSample(buffer));
         var length = TimeSpan.FromSeconds(vorbis.TotalSamples / (double) vorbis.SampleRate);
+        var handle = RegisterBuffer(buffer);
         return new AudioStream(this, buffer, handle, length, (int) vorbis.Channels, name, vorbis.Title, vorbis.Artist);
     }
 
@@ -208,9 +207,8 @@ internal partial class AudioManager
 
         _checkAlError();
 
-        var handle = new ClydeHandle(_audioSampleBuffers.Count);
-        _audioSampleBuffers.Add(buffer, new LoadedAudioSample(buffer));
         var length = TimeSpan.FromSeconds(wav.Data.Length / (double) wav.BlockAlign / wav.SampleRate);
+        var handle = RegisterBuffer(buffer);
         return new AudioStream(this, buffer, handle, length, wav.NumChannels, name);
     }
 
@@ -238,9 +236,8 @@ internal partial class AudioManager
 
         _checkAlError();
 
-        var handle = new ClydeHandle(_audioSampleBuffers.Count);
         var length = TimeSpan.FromSeconds((double) samples.Length / channels / sampleRate);
-        _audioSampleBuffers.Add(buffer, new LoadedAudioSample(buffer));
+        var handle = RegisterBuffer(buffer);
         return new AudioStream(this, buffer, handle, length, channels, name);
     }
 
@@ -339,9 +336,14 @@ internal partial class AudioManager
             return null;
         }
 
-        // ReSharper disable once PossibleInvalidOperationException
-        // TODO: This really shouldn't be indexing based on the ClydeHandle...
-        AL.Source(source, ALSourcei.Buffer, _audioSampleBuffers[stream.BufferId].BufferHandle);
+        if (!_audioSampleBuffers.TryGetValue(stream.BufferId, out var sample))
+        {
+            OpenALSawmill.Warning($"Audio stream '{stream.Name}' has no backing buffer, skipping.");
+            AL.DeleteSource(source);
+            return null;
+        }
+
+        AL.Source(source, ALSourcei.Buffer, sample.BufferHandle);
 
         var audioSource = new AudioSource(this, source, stream);
         _audioSources.Add(source, new WeakReference<BaseAudioSource>(audioSource));

--- a/Robust.Client/Audio/AudioManager.Public.cs
+++ b/Robust.Client/Audio/AudioManager.Public.cs
@@ -328,18 +328,17 @@ internal partial class AudioManager
 
     public IAudioSource? CreateAudioSource(AudioStream stream)
     {
+        if (!_audioSampleBuffers.TryGetValue(stream.BufferId, out var sample))
+        {
+            OpenALSawmill.Warning($"Audio stream '{stream.Name}' has no backing buffer, skipping.");
+            return null;
+        }
+
         var source = AL.GenSource();
 
         if (!AL.IsSource(source))
         {
             OpenALSawmill.Error("Failed to generate source. Too many simultaneous audio streams? {0}", Environment.StackTrace);
-            return null;
-        }
-
-        if (!_audioSampleBuffers.TryGetValue(stream.BufferId, out var sample))
-        {
-            OpenALSawmill.Warning($"Audio stream '{stream.Name}' has no backing buffer, skipping.");
-            AL.DeleteSource(source);
             return null;
         }
 

--- a/Robust.Client/Audio/AudioManager.cs
+++ b/Robust.Client/Audio/AudioManager.cs
@@ -48,6 +48,7 @@ internal sealed partial class AudioManager : IAudioInternal
     private float _masterFadeElapsed = MasterFadeDuration;
     private float _masterFadeStartGain = 1f;
     private float _masterFadeTargetGain = 1f;
+    private int _nextClydeHandle;
 
     public bool HasAlDeviceExtension(string extension) => _alcDeviceExtensions.Contains(extension);
     public bool HasAlContextExtension(string extension) => _alContextExtensions.Contains(extension);
@@ -301,6 +302,15 @@ internal sealed partial class AudioManager : IAudioInternal
     internal bool IsMainThread()
     {
         return Thread.CurrentThread == _gameThread;
+    }
+
+    private ClydeHandle RegisterBuffer(int buffer)
+    {
+        if (buffer == 0)
+            throw new InvalidOperationException("AL.GenBuffer returned 0 - no current OpenAL context.");
+
+        _audioSampleBuffers.Add(buffer, new LoadedAudioSample(buffer));
+        return new ClydeHandle(Interlocked.Increment(ref _nextClydeHandle));
     }
 
     private static void RemoveEfx((int sourceHandle, int filterHandle) handles)


### PR DESCRIPTION
Part of #7017, dividing it on small patches, this PR changes buffer registration, to fix collision, also adds check in `CreateAudioSource` to be sure that buffer exists.