### PR TITLE
Fix a few partial prototype bugs and add more tests for component inheritance

### DIFF
--- a/Robust.Shared.IntegrationTests/Prototypes/PrototypePartialTest.cs
+++ b/Robust.Shared.IntegrationTests/Prototypes/PrototypePartialTest.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Log;
@@ -19,6 +18,8 @@ internal sealed partial class PrototypePartialTest
     private static readonly EntProtoId SequenceId = $"{nameof(PrototypePartialTest)}Sequence";
     private static readonly EntProtoId MappingId = $"{nameof(PrototypePartialTest)}Mapping";
     private static readonly EntProtoId MappingSequenceId = $"{nameof(PrototypePartialTest)}MappingSequence";
+    private static readonly EntProtoId InheritanceIdBase = $"{nameof(PrototypePartialTest)}InheritanceBase";
+    private static readonly EntProtoId InheritanceIdInheritor = $"{nameof(PrototypePartialTest)}InheritanceInheritor";
 
     private static readonly string Sequence = $@"
 - type: entity
@@ -116,12 +117,21 @@ internal sealed partial class PrototypePartialTest
               "a": !Remove
         """;
 
-    private static readonly string RemoveAllMapping = $"""
+    private static readonly string ClearMapping = $"""
         - type: entity
           id: {MappingId}
           components:
           - type: PrototypePartial
-            dictionary: !Remove
+            dictionary: !Clear
+        """;
+
+    private static readonly string ClearAndAddMapping = $"""
+        - type: entity
+          id: {MappingId}
+          components:
+          - type: PrototypePartial
+            dictionary: !Clear
+              "z": 123
         """;
 
     private static readonly string AddAndRemoveMapping = $"""
@@ -166,15 +176,6 @@ internal sealed partial class PrototypePartialTest
             dictionaryList:
             - "b": !Remove
             - "e": !Remove
-        """;
-
-    private static readonly string RemoveAllAndAddMappingSequence = $"""
-        - type: entity
-          id: {MappingSequenceId}
-          components:
-          - type: PrototypePartial
-            dictionaryList: !Remove
-            - "z": 123
         """;
 
     private static readonly string AddAndRemoveMappingSequence = $"""
@@ -229,6 +230,41 @@ internal sealed partial class PrototypePartialTest
     - 10
 ";
 
+    private static readonly string Inheritance = $@"
+- type: entity
+  id: {InheritanceIdBase}
+  components:
+  - type: PrototypePartialBase
+
+- type: entity
+  parent: {InheritanceIdBase}
+  id: {InheritanceIdInheritor}
+  components:
+  - type: PrototypePartialInheritor
+";
+
+    private static readonly string InheritanceBaseRemoveBoth = $@"
+- type: entity
+  id: {InheritanceIdBase}
+  components:
+  - !Remove type: PrototypePartialBase
+  - !Remove type: PrototypePartialInheritor
+";
+
+    private static readonly string InheritanceInheritorRemoveBase = $@"
+- type: entity
+  id: {InheritanceIdInheritor}
+  components:
+  - !Remove type: PrototypePartialBase
+";
+
+    private static readonly string InheritanceInheritorRemoveInheritor = $@"
+- type: entity
+  id: {InheritanceIdInheritor}
+  components:
+  - !Remove type: PrototypePartialInheritor
+";
+
     private ISimulation StartSim(
         bool partial = true,
         bool addBase = true,
@@ -241,7 +277,12 @@ internal sealed partial class PrototypePartialTest
         return RobustServerSimulation.NewSimulation()
             .ChangeCVar(factory => changeCVar?.Invoke(factory))
             .RegisterDependencies(factory => dependencies?.Invoke(factory))
-            .RegisterComponents(factory => { factory.RegisterClass<PrototypePartialComponent>(); })
+            .RegisterComponents(factory =>
+            {
+                factory.RegisterClass<PrototypePartialComponent>();
+                factory.RegisterClass<PrototypePartialBaseComponent>();
+                factory.RegisterClass<PrototypePartialInheritorComponent>();
+            })
             .AddRoot(factory =>
             {
                 var root = new MemoryContentRoot();
@@ -250,6 +291,7 @@ internal sealed partial class PrototypePartialTest
                     root.AddOrUpdateFile(new ResPath($"/Base/{nameof(Sequence)}.yml"), Sequence);
                     root.AddOrUpdateFile(new ResPath($"/Base/{nameof(Mapping)}.yml"), Mapping);
                     root.AddOrUpdateFile(new ResPath($"/Base/{nameof(MappingSequence)}.yml"), MappingSequence);
+                    root.AddOrUpdateFile(new ResPath($"/Base/{nameof(Inheritance)}.yml"), Inheritance);
                 }
 
                 for (var i = 0; i < ymlToLoad.Length; i++)
@@ -433,9 +475,9 @@ internal sealed partial class PrototypePartialTest
     }
 
     [Test]
-    public void RemoveAllMappingTest()
+    public void ClearMappingTest()
     {
-        var sim = StartSim(ymlToLoad: RemoveAllMapping);
+        var sim = StartSim(ymlToLoad: ClearMapping);
 
         var comps = sim.Resolve<IComponentFactory>();
         var prototypes = sim.Resolve<IPrototypeManager>();
@@ -443,6 +485,21 @@ internal sealed partial class PrototypePartialTest
         Assert.That(ent.TryComp(out PrototypePartialComponent? partial, comps), Is.True);
         Assert.That(partial, Is.Not.Null);
         Assert.That(partial.Dictionary, Is.Empty);
+        Assert.That(partial.List, Is.Empty);
+    }
+
+    [Test]
+    public void ClearAndAddMappingTest()
+    {
+        var sim = StartSim(ymlToLoad: ClearAndAddMapping);
+
+        var comps = sim.Resolve<IComponentFactory>();
+        var prototypes = sim.Resolve<IPrototypeManager>();
+        var ent = prototypes.Index(MappingId);
+        Assert.That(ent.TryComp(out PrototypePartialComponent? partial, comps), Is.True);
+        Assert.That(partial, Is.Not.Null);
+        Assert.That(partial.Dictionary, Has.Count.EqualTo(1));
+        Assert.That(partial.Dictionary["z"], Is.EqualTo(123));
         Assert.That(partial.List, Is.Empty);
     }
 
@@ -520,23 +577,6 @@ internal sealed partial class PrototypePartialTest
 
         Assert.That(first, Does.Not.ContainKey("e"));
         Assert.That(first, Does.Not.ContainValue(5));
-    }
-
-    [Test]
-    public void RemoveAllAndAddMappingSequenceTest()
-    {
-        var sim = StartSim(ymlToLoad: RemoveAllAndAddMappingSequence);
-
-        var comps = sim.Resolve<IComponentFactory>();
-        var prototypes = sim.Resolve<IPrototypeManager>();
-        var ent = prototypes.Index(MappingSequenceId);
-        Assert.That(ent.TryComp(out PrototypePartialComponent? partial, comps), Is.True);
-        Assert.That(partial, Is.Not.Null);
-        Assert.That(partial.DictionaryList, Has.Count.EqualTo(1));
-
-        var first = partial.DictionaryList[0];
-        Assert.That(first, Has.Count.EqualTo(1));
-        Assert.That(first["z"], Is.EqualTo(123));
     }
 
     [Test]
@@ -672,6 +712,70 @@ internal sealed partial class PrototypePartialTest
         Assert.That(partial.Dictionary, Is.Empty);
     }
 
+    [Test]
+    public void TestInheritanceNoRemoving()
+    {
+        var sim = StartSim();
+
+        var comps = sim.Resolve<IComponentFactory>();
+        var prototypes = sim.Resolve<IPrototypeManager>();
+        var baseEnt = prototypes.Index(InheritanceIdBase);
+        Assert.That(baseEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
+        Assert.That(baseEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.False);
+
+        var inheritorEnt = prototypes.Index(InheritanceIdInheritor);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.True);
+    }
+
+    [Test]
+    public void TestInheritanceBaseRemoveBoth()
+    {
+        var sim = StartSim(ymlToLoad: InheritanceBaseRemoveBoth);
+
+        var comps = sim.Resolve<IComponentFactory>();
+        var prototypes = sim.Resolve<IPrototypeManager>();
+        var baseEnt = prototypes.Index(InheritanceIdBase);
+        Assert.That(baseEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.False);
+        Assert.That(baseEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.False);
+
+        var inheritorEnt = prototypes.Index(InheritanceIdInheritor);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.False);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.True);
+    }
+
+    [Test]
+    public void TestInheritanceInheritorRemoveBase()
+    {
+        var sim = StartSim(ymlToLoad: InheritanceInheritorRemoveBase);
+
+        var comps = sim.Resolve<IComponentFactory>();
+        var prototypes = sim.Resolve<IPrototypeManager>();
+        var baseEnt = prototypes.Index(InheritanceIdBase);
+        Assert.That(baseEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
+        Assert.That(baseEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.False);
+
+        var inheritorEnt = prototypes.Index(InheritanceIdInheritor);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.True);
+    }
+
+    [Test]
+    public void TestInheritanceInheritorRemoveInheritor()
+    {
+        var sim = StartSim(ymlToLoad: InheritanceInheritorRemoveInheritor);
+
+        var comps = sim.Resolve<IComponentFactory>();
+        var prototypes = sim.Resolve<IPrototypeManager>();
+        var baseEnt = prototypes.Index(InheritanceIdBase);
+        Assert.That(baseEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
+        Assert.That(baseEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.False);
+
+        var inheritorEnt = prototypes.Index(InheritanceIdInheritor);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.False);
+    }
+
     internal sealed partial class PrototypePartialComponent : Component
     {
         [DataField]
@@ -686,4 +790,8 @@ internal sealed partial class PrototypePartialTest
         [DataField]
         public Dictionary<string, List<int>> ListDictionary = new();
     }
+
+    internal sealed partial class PrototypePartialBaseComponent : Component;
+
+    internal sealed partial class PrototypePartialInheritorComponent : Component;
 }

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -652,12 +652,12 @@ public interface IPrototypeManager
     ///   id: MyEntityOne
     ///   components:
     ///   - type: MyComponent
-    ///     list: !Remove
+    ///     list: !Clear
     ///     - 1
     /// </code>
     /// </example>
     /// <example>
-    /// Remove a mapping with the key 'a':
+    /// Remove a mapping with the key 'a' regardless of value:
     /// <code>
     /// - type: entity
     ///   id: MyEntityOne
@@ -668,7 +668,18 @@ public interface IPrototypeManager
     /// </code>
     /// </example>
     /// <example>
-    /// Remove a mapping with the key 'a' and add one with a key of 'b' and a value of 1:
+    /// Remove a mapping with the key 'a' only if its value is 1:
+    /// <code>
+    /// - type: entity
+    ///   id: MyEntityOne
+    ///   components:
+    ///   - type: MyComponent
+    ///     dictionary:
+    ///       "a": !Remove 1
+    /// </code>
+    /// </example>
+    /// <example>
+    /// Remove a mapping with the key 'a' and add one with a key of 'b' and a value of 2:
     /// <code>
     /// - type: entity
     ///   id: MyEntityOne
@@ -676,7 +687,19 @@ public interface IPrototypeManager
     ///   - type: MyComponent
     ///     list:
     ///       "a": !Remove
-    ///       "b": 1
+    ///       "b": 2
+    /// </code>
+    /// </example>
+    /// <example>
+    /// Remove a mapping with the key 'a', only if its value is 1, and add one with a key of 'b' and a value of 2:
+    /// <code>
+    /// - type: entity
+    ///   id: MyEntityOne
+    ///   components:
+    ///   - type: MyComponent
+    ///     list:
+    ///       "a": !Remove 1
+    ///       "b": 2
     /// </code>
     /// </example>
     /// <example>
@@ -716,7 +739,7 @@ public interface IPrototypeManager
     ///   - VendorPlushieHuman
     ///   - VendorPlushieMoth
     ///   - VendorPlushieVulp
-    ///   conditions: !Remove
+    ///   conditions: !Clear
     /// </code>
     /// </example>
     /// <example>

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -53,9 +53,25 @@ public partial class PrototypeManager
     internal const string PartialModifiedTag = "!PartialModified";
 
     /// <summary>
+    /// Partial prototypes that have this tag in their type node will not
+    /// create a new prototype if a non-partial one is not found.
+    /// </summary>
+    internal const string PartialOnlyTag = "!PartialOnly";
+
+    /// <summary>
     /// Tag used to position a partial addition to a sequence at a specific index.
     /// </summary>
     private const string PartialIndexTag = "!Index:";
+
+    /// <summary>
+    /// Tag used to remove a node.
+    /// </summary>
+    internal const string PartialRemoveTag = "!Remove";
+
+    /// <summary>
+    /// Tag used to clear a node.
+    /// </summary>
+    private const string PartialClearTag = "!Clear";
 
     /// <inheritdoc />
     public void LoadDirectory(ResPath path, bool overwrite = false,
@@ -295,7 +311,7 @@ public partial class PrototypeManager
         var kindData = _kinds[kind];
         Dictionary<string, ExtractedMappingData>? variantData = null;
 
-        var partialOnly = NodeHasTag(typeNode, "!PartialOnly");
+        var partialOnly = IsTag(typeNode, "!PartialOnly");
         if (!dataNode.TryGet<ValueDataNode>(IdDataFieldAttribute.Name, out var idNode))
         {
             // Check if the ID node is a CreateVariants node instead of a value.
@@ -394,6 +410,8 @@ public partial class PrototypeManager
 
         if (existing != null && partial)
         {
+            kindData.Partials[id] = data;
+
             if (kindData.PartialOriginals.TryGetValue(id, out var original))
             {
                 if (changed == null ||
@@ -410,13 +428,9 @@ public partial class PrototypeManager
 
             CombineMapNode(existing, data, static parent => parent.Clear(), existing, out var fullDeleted);
             if (fullDeleted && existing.IsEmpty)
-            {
                 kindData.RawResults.Remove(id);
-            }
             else
-            {
                 kindData.RawResults[id] = existing;
-            }
         }
         else if (partialOnly)
         {
@@ -431,7 +445,7 @@ public partial class PrototypeManager
         {
             if (parents != null)
                 inheritance.Add(id, parents);
-            else
+            else if (!partial) // If this is partial we don't want to mess up the inheritance graph
                 inheritance.Add(id);
         }
 
@@ -627,49 +641,71 @@ public partial class PrototypeManager
         MappingDataNode data,
         [RequireStaticDelegate] Action<T> fullDelete,
         T parent,
-        out bool fullDeleted
+        out bool fullDeleted,
+        bool removalOnly = false
     ) where T : DataNode
     {
         fullDeleted = false;
         foreach (var (key, dataNode) in data)
         {
-            // !Remove "a": 1 -> Clear the whole dict
-            if (IsRemoveTag(data.GetKeyTag(key)))
+            if (IsTag(data.GetKeyTag(key), PartialClearTag) || IsTag(dataNode, PartialClearTag))
             {
-                fullDelete(parent);
-                fullDeleted = true;
-                continue;
+                if (existing.TryGet(key, out MappingDataNode? existingMapping))
+                {
+                    existingMapping.Clear();
+                    existingMapping.Tag = PartialModifiedTag;
+                }
+                else if (existing.TryGet(key, out SequenceDataNode? existingSequence))
+                {
+                    existingSequence.Clear();
+                    existingSequence.Tag = PartialModifiedTag;
+                }
+
+                // We might want to add after clearing
             }
 
-            // "a": !Remove 1 -> Remove the element matching 1
-            // "a": !Remove
-            // - "b": 2 -> Remove the element matching b
-            if (IsRemoveTag(dataNode))
+            if (IsTag(data.GetKeyTag(key), PartialRemoveTag) || IsTag(dataNode, PartialRemoveTag))
             {
-                existing.Remove(key);
-                existing.Tag = PartialModifiedTag;
-                if (dataNode is ValueDataNode)
-                    continue;
+                // "a": !Remove -> Remove regardless of value
+                // "a": !Remove 1 -> Remove only if value is 1
+                if (dataNode.IsEmpty ||
+                    (existing.TryGetValue(key, out var existingValue) &&
+                     existingValue.Equals(dataNode)))
+                {
+                    existing.Remove(key);
+                    existing.Tag = PartialModifiedTag;
+
+                    if (existing.IsEmpty)
+                        fullDeleted = true;
+                }
+
+                continue;
             }
 
             if (existing.TryGetValue(key, out var existingNode) &&
-                Combine(existingNode, dataNode, out _))
+                Combine(existingNode, dataNode, out _, removalOnly))
             {
                 continue;
             }
+
+            if (removalOnly)
+                continue;
 
             if (!dataNode.IsEmpty)
                 existing[key] = dataNode;
         }
     }
 
-    private static void CombineSeqNode(SequenceDataNode existing, SequenceDataNode data)
+    private static void CombineSeqNode(
+        SequenceDataNode existing,
+        SequenceDataNode data,
+        bool removalOnly = false)
     {
         for (var i = data.Count - 1; i >= 0; i--)
         {
             var dataNode = data[i];
             if (existing.TryGetValue(i, out var existingNode) &&
-                Combine(existingNode, dataNode, out var fullDeleted))
+                Combine(existingNode, dataNode, out var fullDeleted, removalOnly))
             {
                 if (fullDeleted && existingNode.IsEmpty)
                     existing.RemoveAt(i);
@@ -677,11 +713,14 @@ public partial class PrototypeManager
                 continue;
             }
 
-            if (IsRemoveTag(dataNode))
+            if (IsTag(dataNode, PartialRemoveTag))
             {
                 existing.Remove(dataNode);
                 continue;
             }
+
+            if (removalOnly)
+                continue;
 
             if (dataNode.Tag?.StartsWith(PartialIndexTag) ?? false)
             {
@@ -705,14 +744,22 @@ public partial class PrototypeManager
                 index = Math.Clamp(index, 0, existing.Count);
                 existing.Insert(index, dataNode);
             }
-            else
+            // If this is a mapping with a single !Remove key, we don't want to add it if it doesn't already exist
+            else if (dataNode is not MappingDataNode mapping ||
+                     mapping.Count == 0 ||
+                     mapping.Count > 1 ||
+                     mapping.GetKeyTag(mapping.Keys.First()) != PartialRemoveTag)
             {
                 existing.Add(dataNode);
             }
         }
     }
 
-    private static bool Combine(DataNode existing, DataNode data, out bool fullDeleted)
+    private static bool Combine(
+        DataNode existing,
+        DataNode data,
+        out bool fullDeleted,
+        bool removalOnly = false)
     {
         fullDeleted = false;
         switch (existing, data)
@@ -723,11 +770,12 @@ public partial class PrototypeManager
                     dataMapping,
                     static parent => parent.Clear(),
                     existingMapping,
-                    out fullDeleted
+                    out fullDeleted,
+                    removalOnly
                 );
                 return true;
             case (SequenceDataNode existingSequence, SequenceDataNode dataSequence):
-                CombineSeqNode(existingSequence, dataSequence);
+                CombineSeqNode(existingSequence, dataSequence, removalOnly);
                 return true;
             default:
                 return false;
@@ -740,20 +788,9 @@ public partial class PrototypeManager
                nodeTag.Equals(tag, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool IsRemoveTag(string? tag)
+    private static bool IsTag(DataNode node, string tag)
     {
-        return IsTag(tag, "!Remove");
-    }
-
-    private static bool IsRemoveTag(DataNode node)
-    {
-        return IsRemoveTag(node.Tag);
-    }
-
-    private static bool NodeHasTag(DataNode node, string tag)
-    {
-        return node.Tag != null &&
-               node.Tag.Equals(tag, StringComparison.OrdinalIgnoreCase);
+        return IsTag(node.Tag, tag);
     }
 
     // All these fields can be null in case the

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -410,8 +410,6 @@ public partial class PrototypeManager
 
         if (existing != null && partial)
         {
-            kindData.Partials[id] = data;
-
             if (kindData.PartialOriginals.TryGetValue(id, out var original))
             {
                 if (changed == null ||
@@ -426,7 +424,7 @@ public partial class PrototypeManager
                 kindData.PartialOriginals[id] = existing;
             }
 
-            CombineMapNode(existing, data, static parent => parent.Clear(), existing, out var fullDeleted);
+            CombineMapNode(existing, data, out var fullDeleted);
             if (fullDeleted && existing.IsEmpty)
                 kindData.RawResults.Remove(id);
             else
@@ -636,14 +634,7 @@ public partial class PrototypeManager
         mapping.Add("abstract", "true");
     }
 
-    private static void CombineMapNode<T>(
-        MappingDataNode existing,
-        MappingDataNode data,
-        [RequireStaticDelegate] Action<T> fullDelete,
-        T parent,
-        out bool fullDeleted,
-        bool removalOnly = false
-    ) where T : DataNode
+    private static void CombineMapNode(MappingDataNode existing, MappingDataNode data, out bool fullDeleted)
     {
         fullDeleted = false;
         foreach (var (key, dataNode) in data)
@@ -683,29 +674,23 @@ public partial class PrototypeManager
             }
 
             if (existing.TryGetValue(key, out var existingNode) &&
-                Combine(existingNode, dataNode, out _, removalOnly))
+                Combine(existingNode, dataNode, out _))
             {
                 continue;
             }
-
-            if (removalOnly)
-                continue;
 
             if (!dataNode.IsEmpty)
                 existing[key] = dataNode;
         }
     }
 
-    private static void CombineSeqNode(
-        SequenceDataNode existing,
-        SequenceDataNode data,
-        bool removalOnly = false)
+    private static void CombineSeqNode(SequenceDataNode existing, SequenceDataNode data)
     {
         for (var i = data.Count - 1; i >= 0; i--)
         {
             var dataNode = data[i];
             if (existing.TryGetValue(i, out var existingNode) &&
-                Combine(existingNode, dataNode, out var fullDeleted, removalOnly))
+                Combine(existingNode, dataNode, out var fullDeleted))
             {
                 if (fullDeleted && existingNode.IsEmpty)
                     existing.RemoveAt(i);
@@ -718,9 +703,6 @@ public partial class PrototypeManager
                 existing.Remove(dataNode);
                 continue;
             }
-
-            if (removalOnly)
-                continue;
 
             if (dataNode.Tag?.StartsWith(PartialIndexTag) ?? false)
             {
@@ -758,24 +740,16 @@ public partial class PrototypeManager
     private static bool Combine(
         DataNode existing,
         DataNode data,
-        out bool fullDeleted,
-        bool removalOnly = false)
+        out bool fullDeleted)
     {
         fullDeleted = false;
         switch (existing, data)
         {
             case (MappingDataNode existingMapping, MappingDataNode dataMapping):
-                CombineMapNode(
-                    existingMapping,
-                    dataMapping,
-                    static parent => parent.Clear(),
-                    existingMapping,
-                    out fullDeleted,
-                    removalOnly
-                );
+                CombineMapNode(existingMapping, dataMapping, out fullDeleted);
                 return true;
             case (SequenceDataNode existingSequence, SequenceDataNode dataSequence):
-                CombineSeqNode(existingSequence, dataSequence, removalOnly);
+                CombineSeqNode(existingSequence, dataSequence);
                 return true;
             default:
                 return false;

--- a/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
+++ b/Robust.Shared/Serialization/Markdown/Mapping/MappingDataNode.cs
@@ -270,6 +270,7 @@ namespace Robust.Shared.Serialization.Markdown.Mapping
             }
 
             newMapping._keyNodes = _keyNodes;
+            newMapping._keyTags = _keyTags;
             return newMapping;
         }
 


### PR DESCRIPTION
Fixes removing a key not checking its value
Now:
```
    /// Remove a mapping with the key 'a' only if its value is 1:
    /// - type: entity
    ///   id: MyEntityOne
    ///   components:
    ///   - type: MyComponent
    ///     dictionary:
    ///       "a": !Remove 1
```

```
    /// Remove a mapping with the key 'a' regardless of value:
    /// - type: entity
    ///   id: MyEntityOne
    ///   components:
    ///   - type: MyComponent
    ///     dictionary:
    ///       "a": !Remove
```
---
Fixes !Remove being buggy when being used to clear dictionaries and lists
Now:
```
    /// - type: !PartialOnly listing
    ///   id: !type:CreateVariants
    ///   values:
    ///   - VendorPlushieHuman
    ///   - VendorPlushieMoth
    ///   - VendorPlushieVulp
    ///   conditions: !Clear
```