### PR TITLE
Fix invalid SDL spec

### DIFF
--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl3.Window.cs
@@ -253,11 +253,15 @@ internal partial class Clyde
             if (window == 0)
                 return default;
 
-            nint glContext = SDL.SDL_GL_CreateContext(window);
-            if (glContext == 0)
+            nint glContext = 0;
+            if (spec is not null)
             {
-                SDL.SDL_DestroyWindow(window);
-                return default;
+                glContext = SDL.SDL_GL_CreateContext(window);
+                if (glContext == 0)
+                {
+                    SDL.SDL_DestroyWindow(window);
+                    return default;
+                }
             }
 
             if ((parameters.Styles & OSWindowStyles.NoTitleOptions) != 0)


### PR DESCRIPTION
I tried setting display.compat and display.angle to true at the same time and got this.