### PR TITLE
Adds Custom to RSI Licenses

### DIFF
--- a/Schemas/rsi.json
+++ b/Schemas/rsi.json
@@ -83,7 +83,8 @@
                 "CC-BY-NC-4.0",
                 "CC-BY-NC-SA-3.0",
                 "CC-BY-NC-SA-4.0",
-                "CC0-1.0"
+                "CC0-1.0",
+                "Custom"
             ],
             "examples": [
                 "CC-BY-SA-3.0"


### PR DESCRIPTION
Allows forks to use Custom licensing for RSI

without having to edit engine files

I understand wanting to block this for standard wizden servers, however, testfailing on all servers is bad and and if its still desired it should be moved to content or something