### PR TITLE
RGA accepts a list of sources

### DIFF
--- a/Schemas/rga.yml
+++ b/Schemas/rga.yml
@@ -6,7 +6,7 @@ attribution:
   files: list(str())
   license: license()
   copyright: str()
-  source: url()
+  source: list(url())
 
 # Example
 # - files: ["deprecated.png"]
@@ -18,3 +18,9 @@ attribution:
 #   license: "CC-BY-NC-SA-3.0"
 #   copyright: "by WALPVRGIS for Goonstation, taken at commit 236551b95a5b24917c72f3069223026b2dc4e690 from floors.dmi"
 #   source: "https://github.com/goonstation/goonstation"
+#
+# - files: ["place_wires_1.ogg", "place_wires_2.ogg"]
+#   license: "CC-BY-4.0"
+#   copyright: "Foley by Clearwavsound and SiriusBizdness on freesound.org. Mixed by iaada (GitHub)."
+#   source: ["https://freesound.org/people/Clearwavsound/sounds/541035/",
+#           "https://freesound.org/people/SiriusBizdness/sounds/565193/"]

--- a/Schemas/rga.yml
+++ b/Schemas/rga.yml
@@ -13,13 +13,13 @@ attribution:
 #   license: "MIT"
 #   copyright: "created by 20kdc"
 #   source: "https://github.com/ParadiseSS13/Paradise"
-# 
+#
 # - files: ["arcadeblue2.png", "boxing.png", "carpetclown.png", "carpetoffice.png", "gym.png", "metaldiamond.png"]
 #   license: "CC-BY-NC-SA-3.0"
 #   copyright: "by WALPVRGIS for Goonstation, taken at commit 236551b95a5b24917c72f3069223026b2dc4e690 from floors.dmi"
 #   source: "https://github.com/goonstation/goonstation"
 #
-# - files: ["place_wires_1.ogg", "place_wires_2.ogg"]
+# - files: ["place_wires_1.ogg"]
 #   license: "CC-BY-4.0"
 #   copyright: "Foley by Clearwavsound and SiriusBizdness on freesound.org. Mixed by iaada (GitHub)."
 #   source: ["https://freesound.org/people/Clearwavsound/sounds/541035/",

--- a/Schemas/rga.yml
+++ b/Schemas/rga.yml
@@ -6,7 +6,7 @@ attribution:
   files: list(str())
   license: license()
   copyright: str()
-  source: list(url())
+  source: any(list(url()), url())
 
 # Example
 # - files: ["deprecated.png"]


### PR DESCRIPTION
I was working on an audio file and in it I used two sounds from different sources. I want to attribute them both, but the current schema only accepts a single source. With my limited understanding of the schema validation (and help from Whatstone) I believe this will work to make my `source:` list validate without any breaking changes.