### PR TITLE
Fix YML linter with partials, game not loading with non-partial partials, and ambiguous sequence operations on partial prototypes

### DIFF
--- a/Robust.Shared.IntegrationTests/Prototypes/PrototypePartialTest.cs
+++ b/Robust.Shared.IntegrationTests/Prototypes/PrototypePartialTest.cs
@@ -164,8 +164,8 @@ internal sealed partial class PrototypePartialTest
           components:
           - type: PrototypePartial
             dictionaryList:
-            - "g": 7
-            - "h": 8
+            - !CombineIndex:0 "g": 7
+            - !CombineIndex:1 "h": 8
         """;
 
     private static readonly string RemoveMappingSequence = $"""
@@ -174,8 +174,8 @@ internal sealed partial class PrototypePartialTest
           components:
           - type: PrototypePartial
             dictionaryList:
-            - "b": !Remove
-            - "e": !Remove
+            - !CombineIndex:0 "b": !Remove
+            - !CombineIndex:1 "e": !Remove
         """;
 
     private static readonly string AddAndRemoveMappingSequence = $"""
@@ -184,9 +184,9 @@ internal sealed partial class PrototypePartialTest
           components:
           - type: PrototypePartial
             dictionaryList:
-            - "g": 7
+            - !CombineIndex:0 "g": 7
               "b": !Remove
-            - "h": 8
+            - !CombineIndex:1 "h": 8
               "e": !Remove
         """;
 
@@ -263,6 +263,20 @@ internal sealed partial class PrototypePartialTest
   id: {InheritanceIdInheritor}
   components:
   - !Remove type: PrototypePartialInheritor
+";
+
+    private static readonly string InheritanceBaseAddInheritor = $@"
+- type: entity
+  id: {InheritanceIdBase}
+  components:
+  - type: PrototypePartialInheritor
+";
+
+    private static readonly string InheritanceBaseAddPartial = $@"
+- type: entity
+  id: {InheritanceIdBase}
+  components:
+  - type: PrototypePartial
 ";
 
     private ISimulation StartSim(
@@ -774,6 +788,40 @@ internal sealed partial class PrototypePartialTest
         var inheritorEnt = prototypes.Index(InheritanceIdInheritor);
         Assert.That(inheritorEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
         Assert.That(inheritorEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.False);
+    }
+
+    [Test]
+    public void TestInheritanceBaseAddInheritor()
+    {
+        var sim = StartSim(ymlToLoad: InheritanceBaseAddInheritor);
+
+        var comps = sim.Resolve<IComponentFactory>();
+        var prototypes = sim.Resolve<IPrototypeManager>();
+        var baseEnt = prototypes.Index(InheritanceIdBase);
+        Assert.That(baseEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
+        Assert.That(baseEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.True);
+
+        var inheritorEnt = prototypes.Index(InheritanceIdInheritor);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.True);
+    }
+
+    [Test]
+    public void TestInheritanceBaseAddPartial()
+    {
+        var sim = StartSim(ymlToLoad: InheritanceBaseAddPartial);
+
+        var comps = sim.Resolve<IComponentFactory>();
+        var prototypes = sim.Resolve<IPrototypeManager>();
+        var baseEnt = prototypes.Index(InheritanceIdBase);
+        Assert.That(baseEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
+        Assert.That(baseEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.False);
+        Assert.That(baseEnt.HasComp<PrototypePartialComponent>(comps), Is.True);
+
+        var inheritorEnt = prototypes.Index(InheritanceIdInheritor);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.True);
+        Assert.That(inheritorEnt.HasComp<PrototypePartialComponent>(comps), Is.True);
     }
 
     internal sealed partial class PrototypePartialComponent : Component

--- a/Robust.Shared.IntegrationTests/Prototypes/PrototypePartialTest.cs
+++ b/Robust.Shared.IntegrationTests/Prototypes/PrototypePartialTest.cs
@@ -20,6 +20,7 @@ internal sealed partial class PrototypePartialTest
     private static readonly EntProtoId MappingSequenceId = $"{nameof(PrototypePartialTest)}MappingSequence";
     private static readonly EntProtoId InheritanceIdBase = $"{nameof(PrototypePartialTest)}InheritanceBase";
     private static readonly EntProtoId InheritanceIdInheritor = $"{nameof(PrototypePartialTest)}InheritanceInheritor";
+    private static readonly EntProtoId ReloadId = $"{nameof(PrototypePartialTest)}Reload";
 
     private static readonly string Sequence = $@"
 - type: entity
@@ -279,6 +280,22 @@ internal sealed partial class PrototypePartialTest
   - type: PrototypePartial
 ";
 
+    private static readonly string Reload = $@"
+- type: entity
+  id: {ReloadId}
+  components:
+  - type: PrototypePartial
+";
+
+    private static readonly string ReloadAddSequenceData = $@"
+- type: entity
+  id: {ReloadId}
+  components:
+  - type: PrototypePartial
+    list:
+    - 1
+";
+
     private ISimulation StartSim(
         bool partial = true,
         bool addBase = true,
@@ -302,10 +319,11 @@ internal sealed partial class PrototypePartialTest
                 var root = new MemoryContentRoot();
                 if (addBase)
                 {
-                    root.AddOrUpdateFile(new ResPath($"/Base/{nameof(Sequence)}.yml"), Sequence);
-                    root.AddOrUpdateFile(new ResPath($"/Base/{nameof(Mapping)}.yml"), Mapping);
-                    root.AddOrUpdateFile(new ResPath($"/Base/{nameof(MappingSequence)}.yml"), MappingSequence);
-                    root.AddOrUpdateFile(new ResPath($"/Base/{nameof(Inheritance)}.yml"), Inheritance);
+                    root.AddOrUpdateFile(new ResPath($"/Base/{nameof(SequenceId)}.yml"), Sequence);
+                    root.AddOrUpdateFile(new ResPath($"/Base/{nameof(MappingId)}.yml"), Mapping);
+                    root.AddOrUpdateFile(new ResPath($"/Base/{nameof(MappingSequenceId)}.yml"), MappingSequence);
+                    root.AddOrUpdateFile(new ResPath($"/Base/{nameof(InheritanceIdBase)}.yml"), Inheritance);
+                    root.AddOrUpdateFile(new ResPath($"/Base/{nameof(ReloadId)}.yml"), Reload);
                 }
 
                 for (var i = 0; i < ymlToLoad.Length; i++)
@@ -822,6 +840,59 @@ internal sealed partial class PrototypePartialTest
         Assert.That(inheritorEnt.HasComp<PrototypePartialBaseComponent>(comps), Is.True);
         Assert.That(inheritorEnt.HasComp<PrototypePartialInheritorComponent>(comps), Is.True);
         Assert.That(inheritorEnt.HasComp<PrototypePartialComponent>(comps), Is.True);
+    }
+
+    [Test]
+    public void TestReloadAdd()
+    {
+        MemoryContentRoot root = null!;
+        var add = new ResPath($"/Partials/{nameof(ReloadAddSequenceData)}.yml");
+        var sim = StartSim(loadOrder: factory =>
+            {
+                factory.PartialDirectory(add, 0);
+            },
+            addFiles: factory =>
+            {
+                root = factory;
+                factory.AddOrUpdateFile(add, string.Empty);
+            }
+        );
+
+        var comps = sim.Resolve<IComponentFactory>();
+        var prototypes = (PrototypeManager) sim.Resolve<IPrototypeManager>();
+        var ent = prototypes.Index(ReloadId);
+        Assert.That(ent.TryComp(out PrototypePartialComponent? comp, comps), Is.True);
+        Assert.That(ent.HasComp<PrototypePartialBaseComponent>(comps), Is.False);
+        Assert.That(ent.HasComp<PrototypePartialInheritorComponent>(comps), Is.False);
+        Assert.That(comp, Is.Not.Null);
+        Assert.That(comp.List, Is.Empty);
+
+        root.AddOrUpdateFile(add, ReloadAddSequenceData);
+
+        var changedPrototypes = new Dictionary<Type, HashSet<string>>();
+        prototypes.LoadFile(add, true, changedPrototypes);
+        prototypes.ReloadPrototypes(changedPrototypes);
+
+        ent = prototypes.Index(ReloadId);
+        Assert.That(ent.TryComp(out comp, comps), Is.True);
+        Assert.That(ent.HasComp<PrototypePartialBaseComponent>(comps), Is.False);
+        Assert.That(ent.HasComp<PrototypePartialInheritorComponent>(comps), Is.False);
+        Assert.That(comp.List, Is.Not.Empty);
+        Assert.That(comp.List, Has.Count.EqualTo(1));
+        Assert.That(comp.List, Is.EquivalentTo([1]));
+
+        // Reload again, should not add another 1 to the list
+        changedPrototypes.Clear();
+        prototypes.LoadFile(add, true, changedPrototypes);
+        prototypes.ReloadPrototypes(changedPrototypes);
+
+        ent = prototypes.Index(ReloadId);
+        Assert.That(ent.TryComp(out comp, comps), Is.True);
+        Assert.That(ent.HasComp<PrototypePartialBaseComponent>(comps), Is.False);
+        Assert.That(ent.HasComp<PrototypePartialInheritorComponent>(comps), Is.False);
+        Assert.That(comp.List, Is.Not.Empty);
+        Assert.That(comp.List, Has.Count.EqualTo(1));
+        Assert.That(comp.List, Is.EquivalentTo([1]));
     }
 
     internal sealed partial class PrototypePartialComponent : Component

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -429,7 +429,7 @@ public interface IPrototypeManager
     /// <param name="path">The directory containing the yaml files that need validating.</param>
     /// <param name="prototypes">The prototypes ids that were present in the directory.</param>
     /// <param name="partialNoOriginalError">
-    /// Whether a partial existing without an original to modify is an error ot not.
+    /// Whether a partial existing without an original to modify is an error or not.
     /// !PartialOnly prototypes will not error, even if this is set to true.
     /// </param>
     /// <returns>A dictionary containing sets of errors for each file that failed validation.</returns>

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -417,7 +417,7 @@ public interface IPrototypeManager
     /// </summary>
     /// <param name="path">The directory containing the yaml files that need validating.</param>
     /// <param name="partialNoOriginalError">
-    /// Whether a partial existing without an original to modify is an error ot not.
+    /// Whether a partial existing without an original to modify is an error or not.
     /// !PartialOnly prototypes will not error, even if this is set to true.
     /// </param>
     /// <returns>A dictionary containing sets of errors for each file that failed validation.</returns>

--- a/Robust.Shared/Prototypes/IPrototypeManager.cs
+++ b/Robust.Shared/Prototypes/IPrototypeManager.cs
@@ -416,17 +416,27 @@ public interface IPrototypeManager
     /// Validate all prototypes defined in yaml files contained in the given directory.
     /// </summary>
     /// <param name="path">The directory containing the yaml files that need validating.</param>
+    /// <param name="partialNoOriginalError">
+    /// Whether a partial existing without an original to modify is an error ot not.
+    /// !PartialOnly prototypes will not error, even if this is set to true.
+    /// </param>
     /// <returns>A dictionary containing sets of errors for each file that failed validation.</returns>
-    Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResPath path);
+    Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResPath path, bool partialNoOriginalError = false);
 
     /// <summary>
     /// Validate all prototypes defined in yaml files contained in the given directory.
     /// </summary>
     /// <param name="path">The directory containing the yaml files that need validating.</param>
     /// <param name="prototypes">The prototypes ids that were present in the directory.</param>
+    /// <param name="partialNoOriginalError">
+    /// Whether a partial existing without an original to modify is an error ot not.
+    /// !PartialOnly prototypes will not error, even if this is set to true.
+    /// </param>
     /// <returns>A dictionary containing sets of errors for each file that failed validation.</returns>
-    Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResPath path,
-        out Dictionary<Type, HashSet<string>> prototypes);
+    Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(
+        ResPath path,
+        out Dictionary<Type, HashSet<string>> prototypes,
+        bool partialNoOriginalError = false);
 
     /// <summary>
     /// This method uses reflection to validate that all static prototype id fields correspond to valid prototypes.

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -412,7 +412,7 @@ public partial class PrototypeManager
         Dictionary<Type, HashSet<string>>? changed,
         bool partial)
     {
-        var (kind, id, parents, data, partialOnly, _) = mapping;
+        var (kind, id, _, _, _, _) = mapping;
 
         var kindData = _kinds[kind];
 
@@ -423,6 +423,17 @@ public partial class PrototypeManager
             throw new PrototypeLoadException($"Duplicate ID: '{id}' for kind '{kind}'");
         }
 
+        MergeMappingExisting(mapping, changed, partial, kindData, existing);
+    }
+
+    private MappingDataNode MergeMappingExisting(
+        ExtractedMappingData mapping,
+        Dictionary<Type, HashSet<string>>? changed,
+        bool partial,
+        KindData kindData,
+        MappingDataNode? existing)
+    {
+        var (kind, id, parents, data, partialOnly, _) = mapping;
         if (existing != null && partial)
         {
             if (kindData.PartialOriginals.TryGetValue(id, out var original))
@@ -463,7 +474,7 @@ public partial class PrototypeManager
         }
         else if (partialOnly)
         {
-            return;
+            return existing ?? data;
         }
         else
         {
@@ -479,10 +490,11 @@ public partial class PrototypeManager
         }
 
         if (changed == null)
-            return;
+            return existing ?? data;
 
         var set = changed.GetOrNew(kind);
         set.Add(id);
+        return existing ?? data;
     }
 
     public void LoadFromStream(

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -189,7 +189,7 @@ public partial class PrototypeManager
             {
                 try
                 {
-                    MergeMapping(mapping, overwrite, changed, false);
+                    MergeMapping(mapping, overwrite, changed, false, file);
                 }
                 catch (Exception e)
                 {
@@ -203,13 +203,13 @@ public partial class PrototypeManager
             if (array == null)
                 continue;
 
-            foreach (var (file, result) in array)
+            foreach (var (file, result) in array.OrderBy(f => f.File.CanonPath))
             {
                 foreach (var mapping in result)
                 {
                     try
                     {
-                        MergeMapping(mapping, overwrite, changed, true);
+                        MergeMapping(mapping, overwrite, changed, true, file);
                     }
                     catch (Exception e)
                     {
@@ -279,7 +279,7 @@ public partial class PrototypeManager
                         if (ignored)
                             AbstractPrototype(extracted.Data);
 
-                        MergeMapping(extracted, overwrite, changed, partial);
+                        MergeMapping(extracted, overwrite, changed, partial, file);
 
                         // If the prototype has variants, we need to add each of these to the extracted list as well
                         if (extracted.VariantData is not null)
@@ -292,7 +292,7 @@ public partial class PrototypeManager
                                 if (ignored)
                                     AbstractPrototype(variantExtracted.Data);
 
-                                MergeMapping(variantExtracted, overwrite, changed, partial);
+                                MergeMapping(variantExtracted, overwrite, changed, partial, file);
                             }
                         }
                     }
@@ -410,7 +410,8 @@ public partial class PrototypeManager
         ExtractedMappingData mapping,
         bool overwrite,
         Dictionary<Type, HashSet<string>>? changed,
-        bool partial)
+        bool partial,
+        ResPath? file)
     {
         var (kind, id, _, _, _, _) = mapping;
 
@@ -423,7 +424,7 @@ public partial class PrototypeManager
             throw new PrototypeLoadException($"Duplicate ID: '{id}' for kind '{kind}'");
         }
 
-        MergeMappingExisting(mapping, changed, partial, kindData, existing);
+        MergeMappingExisting(mapping, changed, partial, kindData, existing, file);
     }
 
     private MappingDataNode MergeMappingExisting(
@@ -431,19 +432,32 @@ public partial class PrototypeManager
         Dictionary<Type, HashSet<string>>? changed,
         bool partial,
         KindData kindData,
-        MappingDataNode? existing)
+        MappingDataNode? existing,
+        ResPath? file)
     {
         var (kind, id, parents, data, partialOnly, _) = mapping;
+        int? existingPartialDataIndex = null;
         if (existing != null && partial)
         {
             if (kindData.PartialOriginals.TryGetValue(id, out var original))
             {
+                // AKA: Are we yaml hot-reloading
+                // If so, reprocess all partials in order
                 if (changed != null &&
                     kindData.Partials.TryGetValue(id, out var partialsToProcess))
                 {
-                    foreach (var partialData in partialsToProcess)
+                    existing = original;
+
+                    for (var i = 0; i < partialsToProcess.Count; i++)
                     {
-                        existing = MergeMappingExisting(partialData, null, true, kindData, original);
+                        var partialData = partialsToProcess[i];
+                        if (partialData.File == file)
+                        {
+                            existingPartialDataIndex = i;
+                            continue;
+                        }
+
+                        existing = MergeMappingExisting(partialData.Data, null, true, kindData, original, file);
                     }
                 }
             }
@@ -453,8 +467,10 @@ public partial class PrototypeManager
             }
 
             var partials = kindData.Partials.GetOrNew(id);
-            if (!partials.Contains(mapping))
-                partials.Add(mapping);
+            if (existingPartialDataIndex == null)
+                partials.Add((mapping, file));
+            else
+                partials[existingPartialDataIndex.Value] = (mapping, file);
 
             LogVerbose($"Combining {kind.Name} {id} with partial");
 
@@ -525,7 +541,7 @@ public partial class PrototypeManager
                     if (extracted == null)
                         continue;
 
-                    MergeMapping(extracted, overwrite, changed, partial);
+                    MergeMapping(extracted, overwrite, changed, partial, null);
 
                     // If the prototype has variants, we need to add each of these to the extracted list as well
                     if (extracted.VariantData is null)
@@ -536,7 +552,7 @@ public partial class PrototypeManager
                         if (variantExtracted is null)
                             continue;
 
-                        MergeMapping(variantExtracted, overwrite, changed, partial);
+                        MergeMapping(variantExtracted, overwrite, changed, partial, null);
                     }
                 }
 

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -447,7 +447,7 @@ public partial class PrototypeManager
             }
             else
             {
-                kindData.PartialOriginals[id] = existing;
+                kindData.PartialOriginals[id] = existing.Copy();
             }
 
             LogVerbose($"Combining {kind.Name} {id} with partial");

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -835,7 +835,7 @@ public partial class PrototypeManager
                 var found = false;
                 for (var j = 0; j < existing.Count; j++)
                 {
-                    if (!existing.TryGetValue(i, out var existingNode) ||
+                    if (!existing.TryGetValue(j, out var existingNode) ||
                         existingNode is not MappingDataNode existingMapping)
                     {
                         continue;

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using JetBrains.Annotations;
+using Robust.Shared.Log;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Serialization.Markdown;
@@ -80,6 +82,16 @@ public partial class PrototypeManager
     /// Tag used to clear a node.
     /// </summary>
     private const string PartialClearTag = "!Clear";
+
+    /// <summary>
+    /// Tag used to replace a node at an index on a sequence, instead of adding to it.
+    /// </summary>
+    private const string PartialReplaceIndexTag = "!ReplaceIndex:";
+
+    /// <summary>
+    /// Tag used to combine a node at an index on a sequence, instead of adding to it.
+    /// </summary>
+    private const string PartialCombineIndexTag = "!CombineIndex:";
 
     /// <inheritdoc />
     public void LoadDirectory(ResPath path, bool overwrite = false,
@@ -319,7 +331,7 @@ public partial class PrototypeManager
         var kindData = _kinds[kind];
         Dictionary<string, ExtractedMappingData>? variantData = null;
 
-        var partialOnly = IsTag(typeNode, "!PartialOnly");
+        var partialOnly = IsTag(typeNode, PartialOnlyTag);
         if (!dataNode.TryGet<ValueDataNode>(IdDataFieldAttribute.Name, out var idNode))
         {
             // Check if the ID node is a CreateVariants node instead of a value.
@@ -432,11 +444,27 @@ public partial class PrototypeManager
                 kindData.PartialOriginals[id] = existing;
             }
 
-            CombineMapNode(existing, data, out var fullDeleted);
+            LogVerbose($"Combining {kind.Name} {id} with partial");
+
+            // Also known as, components pretend to be a list, while being a dictionary
+            // Chaos ensues
+            // You could expose this someway if Content decided to also do this
+            // for whatever reason
+            Func<string, string?>? onProcessAsMappingKey = kind == typeof(EntityPrototype)
+                ? key => key == "components" ? "type" : null
+                : null;
+
+            CombineMapNode(existing, data, out var fullDeleted, onProcessAsMappingKey);
             if (fullDeleted && existing.IsEmpty)
+            {
+                LogVerbose($"Full deleted and empty, removing prototype data");
                 kindData.RawResults.Remove(id);
+            }
             else
+            {
+                LogVerbose($"Replacing node with combined partial");
                 kindData.RawResults[id] = existing;
+            }
         }
         else if (partialOnly)
         {
@@ -671,20 +699,30 @@ public partial class PrototypeManager
             $"Node of type {node.GetType()} cannot be used as a single parent or list of parents! Expected {typeof(SequenceDataNode)} or {typeof(ValueDataNode)}. Node string:\n{node}");
     }
 
-    private static void CombineMapNode(MappingDataNode existing, MappingDataNode data, out bool fullDeleted)
+    private void CombineMapNode(
+        MappingDataNode existing,
+        MappingDataNode data,
+        out bool fullDeleted,
+        Func<string, string?>? onProcessAsMappingKey = null)
     {
         fullDeleted = false;
         foreach (var (key, dataNode) in data)
         {
-            if (IsTag(data.GetKeyTag(key), PartialClearTag) || IsTag(dataNode, PartialClearTag))
+            LogVerbose($"Mapping processing key {key}");
+            if (IsTag(data.GetKeyTag(key), PartialClearTag) ||
+                IsTag(dataNode, PartialClearTag))
             {
+                LogVerbose($"Mapping found {PartialClearTag}");
+
                 if (existing.TryGet(key, out MappingDataNode? existingMapping))
                 {
+                    LogVerbose($"Mapping clearing mapping with key {key}");
                     existingMapping.Clear();
                     existingMapping.Tag = PartialModifiedTag;
                 }
                 else if (existing.TryGet(key, out SequenceDataNode? existingSequence))
                 {
+                    LogVerbose($"Mapping clearing sequence with key {key}");
                     existingSequence.Clear();
                     existingSequence.Tag = PartialModifiedTag;
                 }
@@ -692,92 +730,210 @@ public partial class PrototypeManager
                 // We might want to add after clearing
             }
 
-            if (IsTag(data.GetKeyTag(key), PartialRemoveTag) || IsTag(dataNode, PartialRemoveTag))
+            if (IsTag(data.GetKeyTag(key), PartialRemoveTag) ||
+                IsTag(dataNode, PartialRemoveTag))
             {
+                LogVerbose($"Found {PartialRemoveTag}");
+
                 // "a": !Remove -> Remove regardless of value
                 // "a": !Remove 1 -> Remove only if value is 1
                 if (dataNode.IsEmpty ||
                     (existing.TryGetValue(key, out var existingValue) &&
                      existingValue.Equals(dataNode)))
                 {
+                    LogVerbose($"Mapping removing key {key}");
                     existing.Remove(key);
                     existing.Tag = PartialModifiedTag;
 
                     if (existing.IsEmpty)
+                    {
+                        LogVerbose($"Mapping node is empty after removal, full deleting");
                         fullDeleted = true;
+                    }
                 }
 
                 continue;
             }
 
-            if (existing.TryGetValue(key, out var existingNode) &&
-                Combine(existingNode, dataNode, out _))
+            if (existing.TryGetValue(key, out var existingNode))
             {
-                continue;
+                var processAsMappingKey = onProcessAsMappingKey?.Invoke(key);
+                if (Combine(existingNode, dataNode, out _, processAsMappingKey))
+                    continue;
             }
 
             if (!dataNode.IsEmpty)
+            {
+                LogVerbose(
+                    $"Mapping Node{GetValueNodeValueToLog(dataNode)} with key {key} is not empty, adding it to the mapping");
                 existing[key] = dataNode;
+            }
         }
     }
 
-    private static void CombineSeqNode(SequenceDataNode existing, SequenceDataNode data)
+    private void CombineSeqNode(SequenceDataNode existing, SequenceDataNode data, string? processAsMappingKey)
     {
         for (var i = data.Count - 1; i >= 0; i--)
         {
+            LogVerbose($"Sequence processing index {i}");
             var dataNode = data[i];
-            if (existing.TryGetValue(i, out var existingNode) &&
-                Combine(existingNode, dataNode, out var fullDeleted))
-            {
-                if (fullDeleted && existingNode.IsEmpty)
-                    existing.RemoveAt(i);
 
+            // - !ReplaceIndex:0 "a"
+            // - !ReplaceIndex:0 "a": 1
+            if (StartsWithTagOrMappingKeyTag(dataNode, PartialReplaceIndexTag, out var actualTag))
+            {
+                SequenceReplaceIndex(existing, dataNode, actualTag, i);
+                continue;
+            }
+
+            // - !CombineIndex:0 "a": 1
+            if (StartsWithTagOrMappingKeyTag(dataNode, PartialCombineIndexTag, out actualTag))
+            {
+                SequenceCombineIndex(existing, dataNode, actualTag, i);
                 continue;
             }
 
             if (IsTag(dataNode, PartialRemoveTag))
             {
-                existing.Remove(dataNode);
+                LogVerbose($"Sequence index {i} found {PartialRemoveTag}, removing node{GetValueNodeValueToLog(dataNode)} from sequence");
+                if (!existing.Remove(dataNode))
+                    LogVerbose($"Could not find node{GetValueNodeValueToLog(dataNode)} by equality to remove from sequence {i}");
+
                 continue;
             }
 
             if (dataNode.Tag?.StartsWith(PartialIndexTag) ?? false)
             {
+                LogVerbose($"Sequence index {i} found {PartialIndexTag}");
                 var indexStr = dataNode.Tag.AsSpan(PartialIndexTag.Length);
-                var fromEnd = false;
-                if (indexStr.StartsWith('-'))
-                {
-                    indexStr = indexStr[1..];
-                    fromEnd = true;
-                }
-
-                if (!int.TryParse(indexStr, out var index))
-                {
-                    throw new PrototypeLoadException(
-                        $"Found partial prototype node with index tag, but could not parse its index as a number. Expected tag in format !Index:0, got tag {dataNode.Tag} for data node {dataNode}");
-                }
-
-                if (fromEnd)
-                    index = existing.Count - index;
-
-                index = Math.Clamp(index, 0, existing.Count);
+                var index = ProcessPartialSeqNodeIndex(existing, indexStr, dataNode);
+                LogVerbose($"Sequence index {i} inserting node{GetValueNodeValueToLog(dataNode)} at index {index}");
                 existing.Insert(index, dataNode);
+                continue;
             }
-            // If this is a mapping with a single !Remove key, we don't want to add it if it doesn't already exist
-            else if (dataNode is not MappingDataNode mapping ||
-                     mapping.Count == 0 ||
-                     mapping.Count > 1 ||
-                     mapping.GetKeyTag(mapping.Keys.First()) != PartialRemoveTag)
+
+            if (processAsMappingKey != null)
             {
+                LogVerbose($"Sequence index {i} being processed as a mapping using key {processAsMappingKey}");
+                if (dataNode is not MappingDataNode dataNodeMap)
+                {
+                    LogVerbose($"Sequence index {i} is not a {nameof(MappingDataNode)}, cannot process as a mapping, skipping");
+                    continue;
+                }
+
+                if (dataNodeMap.Count == 0)
+                {
+                    LogVerbose($"Sequence index {i} mapping has no nodes, cannot process as a mapping, skipping");
+                    continue;
+                }
+
+                if (!dataNodeMap.TryGet(processAsMappingKey, out ValueDataNode? key))
+                {
+                    LogVerbose($"Sequence index {i} mapping has no {nameof(ValueDataNode)} key {key}, cannot process as a mapping, skipping");
+                    continue;
+                }
+
+                var found = false;
+                for (var j = 0; j < existing.Count; j++)
+                {
+                    if (!existing.TryGetValue(i, out var existingNode) ||
+                        existingNode is not MappingDataNode existingMapping)
+                    {
+                        continue;
+                    }
+
+                    if (!existingMapping.TryGet(processAsMappingKey, out ValueDataNode? existingKey) ||
+                        existingKey.Value != key.Value)
+                    {
+                        continue;
+                    }
+
+                    LogVerbose($"Sequence index {i} found mapping with key {key}, combining mapping nodes");
+                    CombineMapNode(existingMapping, dataNodeMap, out var fullDeleted);
+                    if (fullDeleted && existingMapping.IsEmpty)
+                    {
+                        LogVerbose($"Sequence index {i} found mapping with key {key} that full deleted, removing from sequence");
+                        existing.RemoveAt(j);
+                    }
+
+                    found = true;
+                    break;
+                }
+
+                if (found)
+                    continue;
+
+                LogVerbose($"Sequence index {i} could not find mapping with key {key} in original node, adding the full partial node to the original sequence");
+            }
+
+            // If this is a mapping with a single !Remove key, we don't want to add it if it doesn't already exist
+            if (dataNode is not MappingDataNode mapping ||
+                mapping.Count == 0 ||
+                mapping.Count > 1 ||
+                mapping.GetKeyTag(mapping.Keys.First()) != PartialRemoveTag)
+            {
+                LogVerbose($"Sequence index {i} adding its data node{GetValueNodeValueToLog(dataNode)} to existing sequence");
                 existing.Add(dataNode);
             }
         }
     }
 
-    private static bool Combine(
-        DataNode existing,
-        DataNode data,
-        out bool fullDeleted)
+    private void SequenceReplaceIndex(SequenceDataNode existing, DataNode dataNode, ReadOnlySpan<char> tag, int i)
+    {
+        var indexStr = tag[PartialReplaceIndexTag.Length..];
+        var index = ProcessPartialSeqNodeIndex(existing, indexStr, dataNode);
+        LogVerbose($"Sequence index {i} found {PartialReplaceIndexTag}, replaced index {index}");
+    }
+
+    private void SequenceCombineIndex(SequenceDataNode existing, DataNode dataNode, ReadOnlySpan<char> tag, int i)
+    {
+        var indexStr = tag[PartialCombineIndexTag.Length..];
+        var index = ProcessPartialSeqNodeIndex(existing, indexStr, dataNode);
+        LogVerbose($"Sequence index {i} found {PartialCombineIndexTag}");
+
+        if (existing.TryGetValue(index, out var existingNode) &&
+            Combine(existingNode, dataNode, out var fullDeleted, null))
+        {
+            LogVerbose($"Sequence index {i} combined index {index}");
+            if (fullDeleted && existingNode.IsEmpty)
+            {
+                LogVerbose($"Sequence index {i} full deleted, removing it from the sequence");
+                existing.RemoveAt(i);
+            }
+        }
+        else
+        {
+            LogVerbose($"Sequence index {i} could not find index {index} to combine");
+        }
+    }
+
+    private int ProcessPartialSeqNodeIndex(SequenceDataNode existing, ReadOnlySpan<char> indexStr, DataNode dataNode)
+    {
+        var fromEnd = false;
+        if (indexStr.StartsWith('-'))
+        {
+            LogVerbose($"Index {indexStr} is negative, searching from the end");
+            indexStr = indexStr[1..];
+            fromEnd = true;
+        }
+
+        if (!int.TryParse(indexStr, out var index))
+        {
+            throw new PrototypeLoadException(
+                $"Found partial prototype node with index tag, but could not parse its index as a number. Expected tag in format !Index:0 or !ReplaceIndex:0, got tag {dataNode.Tag} for data node {dataNode}");
+        }
+
+        if (fromEnd)
+            index = existing.Count - index;
+
+        if (index < 0 || index > existing.Count)
+            LogVerbose($"Index {index} is outside of bounds, clamping to minimum 0 and maximum {existing.Count}");
+
+        index = Math.Clamp(index, 0, existing.Count);
+        return index;
+    }
+
+    private bool Combine(DataNode existing, DataNode data, out bool fullDeleted, string? processAsMappingKey)
     {
         fullDeleted = false;
         switch (existing, data)
@@ -786,22 +942,56 @@ public partial class PrototypeManager
                 CombineMapNode(existingMapping, dataMapping, out fullDeleted);
                 return true;
             case (SequenceDataNode existingSequence, SequenceDataNode dataSequence):
-                CombineSeqNode(existingSequence, dataSequence);
+                CombineSeqNode(existingSequence, dataSequence, processAsMappingKey);
                 return true;
             default:
                 return false;
         }
     }
 
-    private static bool IsTag(string? nodeTag, string tag)
+    private bool IsTag(string? nodeTag, string tag)
     {
         return nodeTag != null &&
                nodeTag.Equals(tag, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool IsTag(DataNode node, string tag)
+    private bool IsTag(DataNode node, string tag)
     {
         return IsTag(node.Tag, tag);
+    }
+
+    private bool StartsWithTagOrMappingKeyTag(DataNode dataNode, string tag, [NotNullWhen(true)] out string? actualTag)
+    {
+        if (IsTag(dataNode, tag))
+        {
+            DebugTools.AssertNotNull(dataNode.Tag);
+            actualTag = dataNode.Tag;
+            return true;
+        }
+
+        if (dataNode is MappingDataNode dataNodeMapping &&
+            dataNodeMapping.Count > 0 &&
+            dataNodeMapping.GetKeyTag(dataNodeMapping[0].Key) is { } keyTag &&
+            keyTag.StartsWith(tag))
+        {
+            actualTag = keyTag;
+            return true;
+        }
+
+        actualTag = null;
+        return false;
+    }
+
+    private void LogVerbose([InterpolatedStringHandlerArgument] ref DefaultInterpolatedStringHandler handler)
+    {
+        // Check if it's enabled first so we don't allocate for fun
+        // if (Sawmill.IsLogLevelEnabled(LogLevel.Verbose))
+            Sawmill.Info(handler.ToStringAndClear());
+    }
+
+    private string GetValueNodeValueToLog(DataNode node)
+    {
+        return node is not ValueDataNode value ? string.Empty : $" {value.Value}";
     }
 
     // All these fields can be null in case the

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -965,8 +965,8 @@ public partial class PrototypeManager
     private void LogVerbose([InterpolatedStringHandlerArgument] ref DefaultInterpolatedStringHandler handler)
     {
         // Check if it's enabled first so we don't allocate for fun
-        // if (Sawmill.IsLogLevelEnabled(LogLevel.Verbose))
-            Sawmill.Info(handler.ToStringAndClear());
+        if (Sawmill.IsLogLevelEnabled(LogLevel.Verbose))
+            Sawmill.Verbose(handler.ToStringAndClear());
     }
 
     private string GetValueNodeValueToLog(DataNode node)

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -474,7 +474,7 @@ public partial class PrototypeManager
         {
             if (parents != null)
                 inheritance.Add(id, parents);
-            else if (!partial) // If this is partial we don't want to mess up the inheritance graph
+            else if (!partial || existing == null) // If this is partial we don't want to mess up the inheritance graph
                 inheritance.Add(id);
         }
 

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -84,11 +84,6 @@ public partial class PrototypeManager
     private const string PartialClearTag = "!Clear";
 
     /// <summary>
-    /// Tag used to replace a node at an index on a sequence, instead of adding to it.
-    /// </summary>
-    private const string PartialReplaceIndexTag = "!ReplaceIndex:";
-
-    /// <summary>
     /// Tag used to combine a node at an index on a sequence, instead of adding to it.
     /// </summary>
     private const string PartialCombineIndexTag = "!CombineIndex:";
@@ -778,16 +773,8 @@ public partial class PrototypeManager
             LogVerbose($"Sequence processing index {i}");
             var dataNode = data[i];
 
-            // - !ReplaceIndex:0 "a"
-            // - !ReplaceIndex:0 "a": 1
-            if (StartsWithTagOrMappingKeyTag(dataNode, PartialReplaceIndexTag, out var actualTag))
-            {
-                SequenceReplaceIndex(existing, dataNode, actualTag, i);
-                continue;
-            }
-
             // - !CombineIndex:0 "a": 1
-            if (StartsWithTagOrMappingKeyTag(dataNode, PartialCombineIndexTag, out actualTag))
+            if (StartsWithTagOrMappingKeyTag(dataNode, PartialCombineIndexTag, out var actualTag))
             {
                 SequenceCombineIndex(existing, dataNode, actualTag, i);
                 continue;
@@ -876,13 +863,6 @@ public partial class PrototypeManager
                 existing.Add(dataNode);
             }
         }
-    }
-
-    private void SequenceReplaceIndex(SequenceDataNode existing, DataNode dataNode, ReadOnlySpan<char> tag, int i)
-    {
-        var indexStr = tag[PartialReplaceIndexTag.Length..];
-        var index = ProcessPartialSeqNodeIndex(existing, indexStr, dataNode);
-        LogVerbose($"Sequence index {i} found {PartialReplaceIndexTag}, replaced index {index}");
     }
 
     private void SequenceCombineIndex(SequenceDataNode existing, DataNode dataNode, ReadOnlySpan<char> tag, int i)

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlLoad.cs
@@ -438,17 +438,23 @@ public partial class PrototypeManager
         {
             if (kindData.PartialOriginals.TryGetValue(id, out var original))
             {
-                if (changed == null ||
-                    !changed.TryGetValue(kind, out var kindChanged) ||
-                    !kindChanged.Contains(id))
+                if (changed != null &&
+                    kindData.Partials.TryGetValue(id, out var partialsToProcess))
                 {
-                    existing = original;
+                    foreach (var partialData in partialsToProcess)
+                    {
+                        existing = MergeMappingExisting(partialData, null, true, kindData, original);
+                    }
                 }
             }
             else
             {
                 kindData.PartialOriginals[id] = existing.Copy();
             }
+
+            var partials = kindData.Partials.GetOrNew(id);
+            if (!partials.Contains(mapping))
+                partials.Add(mapping);
 
             LogVerbose($"Combining {kind.Name} {id} with partial");
 

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
@@ -86,7 +86,7 @@ public partial class PrototypeManager
             }
 
             var partial = IsFilePartial(resourcePath, out var index);
-            var partialResults = new List<ExtractedMappingData>(0);
+            var partialResults = new List<ExtractedMappingData>();
             foreach (var (type, mapping) in extractedNodes)
             {
                 if (partial && ExtractMapping(mapping) is { } extracted)

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
@@ -150,7 +150,7 @@ public partial class PrototypeManager
 
                     try
                     {
-                        original.Mapping = MergeMappingExisting(mapping, null, true, _kinds[mapping.Kind], original.Mapping);
+                        original.Mapping = MergeMappingExisting(mapping, null, true, _kinds[mapping.Kind], original.Mapping, file);
 
                         // Re-remove "type" from merged partials
                         original.Mapping.Remove("type");

--- a/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.YamlValidate.cs
@@ -18,10 +18,12 @@ public partial class PrototypeManager
     // disallow them for all prototypes.
     private static readonly char[] DisallowedIdChars = [' ', '.'];
 
-    public Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResPath path) => ValidateDirectory(path, out _);
+    public Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResPath path, bool partialNoOriginalError = false) => ValidateDirectory(path, out _, partialNoOriginalError);
 
-    public Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(ResPath path,
-        out Dictionary<Type, HashSet<string>> protos)
+    public Dictionary<string, HashSet<ErrorNode>> ValidateDirectory(
+        ResPath path,
+        out Dictionary<Type, HashSet<string>> protos,
+        bool partialNoOriginalError = false)
     {
         var streams = Resources.ContentFindFiles(path).ToList().AsParallel()
             .Where(filePath => filePath.Extension == "yml" && !filePath.Filename.StartsWith("."));
@@ -29,6 +31,7 @@ public partial class PrototypeManager
         var dict = new Dictionary<string, HashSet<ErrorNode>>();
         var prototypes = new Dictionary<Type, Dictionary<string, PrototypeValidationData>>();
 
+        var queue = Array.Empty<Queue<(ResPath File, IEnumerable<ExtractedMappingData> Result)>?>();
         foreach (var resourcePath in streams)
         {
             using var reader = ReadFile(resourcePath);
@@ -82,8 +85,16 @@ public partial class PrototypeManager
                 }
             }
 
+            var partial = IsFilePartial(resourcePath, out var index);
+            var partialResults = new List<ExtractedMappingData>(0);
             foreach (var (type, mapping) in extractedNodes)
             {
+                if (partial && ExtractMapping(mapping) is { } extracted)
+                {
+                    partialResults.Add(extracted);
+                    partial = true;
+                }
+
                 var id = mapping.Get<ValueDataNode>("id").Value;
                 var data = new PrototypeValidationData(id, mapping, resourcePath.ToString());
                 mapping.Remove("type");
@@ -95,11 +106,60 @@ public partial class PrototypeManager
                                                     + $"character '{letter}'."));
                 }
 
+                if (partial)
+                    continue;
+
                 if (prototypes.GetOrNew(type).TryAdd(id, data))
                     continue;
 
                 var error = new ErrorNode(mapping, $"Found dupe prototype ID of {id} for {type}");
                 dict.GetOrNew(data.File).Add(error);
+            }
+
+            if (partialResults.Count > 0)
+            {
+                if (index >= queue.Length)
+                    Array.Resize(ref queue, index + 1);
+
+                ref var indexQueue = ref queue[index];
+                indexQueue ??= new Queue<(ResPath File, IEnumerable<ExtractedMappingData> Result)>();
+                indexQueue.Enqueue((resourcePath, partialResults));
+            }
+        }
+
+        // Process partial prototypes
+        foreach (var array in queue)
+        {
+            if (array == null)
+                continue;
+
+            foreach (var (file, result) in array)
+            {
+                foreach (var mapping in result)
+                {
+                    if (!prototypes.TryGetValue(mapping.Kind, out var kindProtos) ||
+                        !kindProtos.TryGetValue(mapping.Id, out var original))
+                    {
+                        if (partialNoOriginalError && !mapping.PartialOnly)
+                        {
+                            dict.GetOrNew(file.ToString()).Add(new ErrorNode(mapping.Data, $"Partial prototype {mapping.Id} of type {mapping.Kind.Name} does not have an original definition to modify, and is not marked as !PartialOnly. Did the original {mapping.Id} prototype that you are trying to modify get deleted?"));
+                        }
+
+                        continue;
+                    }
+
+                    try
+                    {
+                        original.Mapping = MergeMappingExisting(mapping, null, true, _kinds[mapping.Kind], original.Mapping);
+
+                        // Re-remove "type" from merged partials
+                        original.Mapping.Remove("type");
+                    }
+                    catch (Exception e)
+                    {
+                        Sawmill.Error($"Exception whilst loading partial prototypes from {file}:\n{e}");
+                    }
+                }
             }
         }
 

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -1191,6 +1191,13 @@ namespace Robust.Shared.Prototypes
             public readonly Dictionary<string, MappingDataNode> PartialOriginals = new();
 
             /// <summary>
+            /// The original mapping before it was modified by a partial prototype.
+            /// This will not have an element for a given ID if there are no partial prototypes
+            /// affecting that ID.
+            /// </summary>
+            public readonly Dictionary<string, List<ExtractedMappingData>> Partials = new();
+
+            /// <summary>
             /// The unfrozen instance of <see cref="Variants"/>.
             /// This is only populated if the kind has prototype variants.
             /// </summary>

--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -1195,7 +1195,7 @@ namespace Robust.Shared.Prototypes
             /// This will not have an element for a given ID if there are no partial prototypes
             /// affecting that ID.
             /// </summary>
-            public readonly Dictionary<string, List<ExtractedMappingData>> Partials = new();
+            public readonly Dictionary<string, List<(ExtractedMappingData Data, ResPath? File)>> Partials = new();
 
             /// <summary>
             /// The unfrozen instance of <see cref="Variants"/>.

--- a/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
+++ b/Robust.Shared/Serialization/TypeSerializers/Implementations/ComponentRegistrySerializer.cs
@@ -75,7 +75,7 @@ namespace Robust.Shared.Serialization.TypeSerializers.Implementations
                 if (referenceTypes[..refIdx].Contains(compIdx))
                 {
                     throw new InvalidOperationException(
-                        $"Duplicate component reference in prototype: '{compIdx}'");
+                        $"Duplicate component reference in prototype: '{registration.Name}'");
                 }
 
                 referenceTypes[refIdx++] = compIdx;


### PR DESCRIPTION
Fixes so good I had to re-code it from scratch 3 times because I lost my changes 2 times
- Fixes partial component addition/removals getting very confused and sometimes overwriting components
- Fixes it being a pain in the arse to modify long sequences but its still sort of unwieldy
- Fixes the game not loading if you partially lload a non-partial prototype
- Fixes the YML linter to work with partials, and added a partialNoOriginalError parameter to ValidateDirectory that when set to true will error when a non PartialOnly partial definition is found without an original to reference. This is set to false by default. This can be useful if you are not mixing partials and non-partials in the same directory
- Fixes not copying the original YML that is kept in PartialOriginals, resulting in duplicated data after applying partials
- Fixes YML hot reload with prototype partials
- Fixes inconsistent partial ordering if the same prototype is modified more than once in the same directory. Now it is ordered by the file path's name
- Added per-step verbose logging for prototype partials that logs every step of applying a partial prototype, if PrototypeManager's sawmill is set to show verbose logs.

The world if no dicts acting as lists
Also adds 2 more tests for the war

---

This
```yml
list:
- "g": 7
  "b": !Remove
- "h": 8
  "e": !Remove
```

Becomes
```yml
list:
- !CombineIndex:0 "g": 7
  "b": !Remove
- !CombineIndex:1 "h": 8
  "e": !Remove
```

# Breaking changes
- Using partial prototypes, use the tag !CombineIndex to combine a node in a sequence. This fixes a bug where modifying sequences (lists) in partial prototypes was buggy and inconsistent. If you are adding to a sequence or removing from it you don't need to change anything. If you were trying to modify existing sequence elements, you will need to replace - "a": 1 with - !CombineIndex:0 "a": 1 for example.