### PR TITLE
Combine predicted deletion

### DIFF
--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -87,26 +87,44 @@ namespace Robust.Client.GameObjects
             if (uid == null || uid == EntityUid.Invalid)
                 return;
 
-            if (IsClientSide(uid.Value))
+            // Some UIs get disposed after entity manager has shut down and already deleted all entities.
+            if (!Started || ShuttingDown)
+                return;
+
+            if (IsQueuedForDeletion(uid.Value))
+                return;
+
+            if (!MetaQuery.TryGetComponentInternal(uid.Value, out var meta))
+                return;
+
+            if (meta.NetEntity.IsClientSide())
             {
                 base.QueueDeleteEntity(uid);
                 return;
             }
 
-            if (ShuttingDown)
-                return;
-
-            // Client-side entity deletion is not supported and will cause errors.
-            if (_client.RunLevel == ClientRunLevel.Connected || _client.RunLevel == ClientRunLevel.InGame)
-                LogManager.RootSawmill.Error($"Predicting the queued deletion of a networked entity: {ToPrettyString(uid.Value)}. Trace: {Environment.StackTrace}");
+            // Networked entities can't be deleted client-side, so queue up a predicted deletion instead.
+            _queuedPredictedDeletionsSet.Add(uid.Value);
+            _queuedPredictedDeletions.Enqueue(uid.Value);
         }
 
-        public override void DeleteEntity(EntityUid? uid)
+        /// <inheritdoc />
+        public override void DeleteEntity(EntityUid uid, MetaDataComponent meta, TransformComponent xform)
         {
-            if (uid != null)
-                ClearPredictedDeletion(uid.Value);
+            // There's 3 scenarios:
+            // 1. We're applying server state, so the deletion is authoritative and actually happens.
+            // 2. Client-side entity, which we can just delete.
+            // 3. Networked entity, which we predict by detaching to nullspace and letting state handling restore it.
+            if (!_gameTiming.ApplyingState && !meta.NetEntity.IsClientSide())
+            {
+                if (meta.EntityLifeStage < EntityLifeStage.Terminating)
+                    PredictedDetachNetworkedEntity(uid, xform, meta);
 
-            base.DeleteEntity(uid);
+                return;
+            }
+
+            ClearPredictedDeletion(uid);
+            base.DeleteEntity(uid, meta, xform);
         }
 
         /// <inheritdoc />
@@ -258,16 +276,7 @@ namespace Robust.Client.GameObjects
                 if (meta.EntityLifeStage >= EntityLifeStage.Terminating)
                     continue;
 
-                var xform = TransformQuery.GetComponentInternal(uid);
-                if (meta.NetEntity.IsClientSide())
-                {
-                    ClearPredictedDeletion(uid);
-                    DeleteEntity(uid, meta, xform);
-                }
-                else
-                {
-                    PredictedDetachNetworkedEntity(uid, xform, meta);
-                }
+                DeleteEntity(uid, meta, TransformQuery.GetComponentInternal(uid));
             }
         }
 
@@ -347,32 +356,6 @@ namespace Robust.Client.GameObjects
         }
         #endregion
 
-        /// <inheritdoc />
-        public override void PredictedDeleteEntity(Entity<MetaDataComponent?, TransformComponent?> ent)
-        {
-            if (!MetaQuery.Resolve(ent.Owner, ref ent.Comp1)
-                || ent.Comp1.EntityLifeStage >= EntityLifeStage.Terminating
-                || !TransformQuery.Resolve(ent.Owner, ref ent.Comp2))
-            {
-                return;
-            }
-
-            // So there's 3 scenarios:
-            // 1. Networked entity we just move to nullspace and rely on state handling.
-            // 2. Clientside predicted entity we delete and rely on state handling.
-            // 3. Clientside only entity that actually needs deleting here.
-
-            if (ent.Comp1.NetEntity.IsClientSide())
-            {
-                ClearPredictedDeletion(ent.Owner);
-                DeleteEntity(ent, ent.Comp1, ent.Comp2);
-            }
-            else
-            {
-                PredictedDetachNetworkedEntity(ent.Owner, ent.Comp2, ent.Comp1);
-            }
-        }
-
         internal bool IsPredictedDetached(EntityUid uid)
         {
             return _predictedDetachedEntities.Contains(uid);
@@ -400,34 +383,5 @@ namespace Robust.Client.GameObjects
             => QueuedDeletionsSet.Contains(uid)
                || _queuedPredictedDeletionsSet.Contains(uid)
                || _predictedDetachedEntities.Contains(uid);
-
-        /// <inheritdoc />
-        public override void PredictedQueueDeleteEntity(Entity<MetaDataComponent?> ent)
-        {
-            // Some UIs get disposed after entity-manager has shut down and already deleted all entities.
-            if (!Started)
-                return;
-
-            if (IsQueuedForDeletion(ent.Owner))
-                return;
-
-            if (!MetaQuery.Resolve(ent.Owner, ref ent.Comp, false))
-                return;
-
-            if (ent.Comp.NetEntity.IsClientSide())
-            {
-                // client-side QueueDeleteEntity re-fetches MetadataComp and checks IsClientSide().
-                // base call to skip that.
-                // TODO create override that takes in metadata comp
-                base.QueueDeleteEntity(ent);
-            }
-            else
-            {
-                if (!_queuedPredictedDeletionsSet.Add(ent.Owner))
-                    return;
-
-                _queuedPredictedDeletions.Enqueue(ent.Owner);
-            }
-        }
     }
 }

--- a/Robust.Client/GameObjects/ClientEntityManager.cs
+++ b/Robust.Client/GameObjects/ClientEntityManager.cs
@@ -29,8 +29,6 @@ namespace Robust.Client.GameObjects
         internal event Action? AfterStartup;
         internal event Action? AfterShutdown;
 
-        private readonly Queue<EntityUid> _queuedPredictedDeletions = new();
-        private readonly HashSet<EntityUid> _queuedPredictedDeletionsSet = new();
         private readonly HashSet<EntityUid> _predictedDetachedEntities = new();
         private Histogram? _tickUpdateHistogram;
         private Histogram.Child? _entityNetHistogram;
@@ -62,8 +60,6 @@ namespace Robust.Client.GameObjects
             // Server doesn't network deletions on client shutdown so we need to
             // manually clear these out or risk stale data getting used.
             PendingNetEntityStates.Clear();
-            _queuedPredictedDeletions.Clear();
-            _queuedPredictedDeletionsSet.Clear();
             _predictedDetachedEntities.Clear();
             using var _ = _gameTiming.StartStateApplicationArea();
             base.FlushEntities();
@@ -91,21 +87,13 @@ namespace Robust.Client.GameObjects
             if (!Started || ShuttingDown)
                 return;
 
-            if (IsQueuedForDeletion(uid.Value))
+            // Already detached to nullspace by a predicted deletion, nothing left to queue.
+            if (_predictedDetachedEntities.Contains(uid.Value))
                 return;
 
-            if (!MetaQuery.TryGetComponentInternal(uid.Value, out var meta))
-                return;
-
-            if (meta.NetEntity.IsClientSide())
-            {
-                base.QueueDeleteEntity(uid);
-                return;
-            }
-
-            // Networked entities can't be deleted client-side, so queue up a predicted deletion instead.
-            _queuedPredictedDeletionsSet.Add(uid.Value);
-            _queuedPredictedDeletions.Enqueue(uid.Value);
+            // Networked entities are handled by DeleteEntity when the queue gets processed, which predicts the
+            // deletion by detaching them.
+            base.QueueDeleteEntity(uid);
         }
 
         /// <inheritdoc />
@@ -262,24 +250,6 @@ namespace Robust.Client.GameObjects
             _entityNetHistogram = histogram?.WithLabels("EntityNet");
         }
 
-        internal override void ProcessQueueudDeletions()
-        {
-            base.ProcessQueueudDeletions();
-            while (_queuedPredictedDeletions.TryDequeue(out var uid))
-            {
-                if (!_queuedPredictedDeletionsSet.Remove(uid))
-                    continue;
-
-                if (!MetaQuery.TryGetComponentInternal(uid, out var meta))
-                    continue;
-
-                if (meta.EntityLifeStage >= EntityLifeStage.Terminating)
-                    continue;
-
-                DeleteEntity(uid, meta, TransformQuery.GetComponentInternal(uid));
-            }
-        }
-
         /// <inheritdoc />
         public void SendSystemNetworkMessage(EntityEventArgs message, bool recordReplay = true)
         {
@@ -364,7 +334,7 @@ namespace Robust.Client.GameObjects
         internal void ClearPredictedDeletion(EntityUid uid)
         {
             _predictedDetachedEntities.Remove(uid);
-            _queuedPredictedDeletionsSet.Remove(uid);
+            QueuedDeletionsSet.Remove(uid);
         }
 
         private void PredictedDetachNetworkedEntity(EntityUid uid, TransformComponent xform, MetaDataComponent meta)
@@ -380,8 +350,6 @@ namespace Robust.Client.GameObjects
         }
 
         public override bool IsQueuedForDeletion(EntityUid uid)
-            => QueuedDeletionsSet.Contains(uid)
-               || _queuedPredictedDeletionsSet.Contains(uid)
-               || _predictedDetachedEntities.Contains(uid);
+            => QueuedDeletionsSet.Contains(uid) || _predictedDetachedEntities.Contains(uid);
     }
 }

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -1752,7 +1752,7 @@ namespace Robust.Client.GameStates
             if (!_entities.IsClientSide(uid) && _entities.TryGetComponent(uid, out TransformComponent? xform))
                 _recursiveRemoveState(meta.NetEntity, xform, _entities.GetEntityQuery<MetaDataComponent>(), _entities.GetEntityQuery<TransformComponent>());
 
-            // Set ApplyingState to true to avoid logging errors about predicting the deletion of networked entities.
+            // DeleteEntity predicts the deletion of networked entities.
             using (_timing.StartStateApplicationArea())
             {
                 _entities.DeleteEntity(uid);

--- a/Robust.Client/GameStates/ClientGameStateManager.cs
+++ b/Robust.Client/GameStates/ClientGameStateManager.cs
@@ -910,6 +910,7 @@ namespace Robust.Client.GameStates
                     DebugTools.Assert(!_toApply.ContainsKey(uid));
 
                     meta.Flags &= ~MetaDataFlags.Detached;
+                    _entities.ClearPredictedDeletion(uid);
                     if (isEnteringPvs)
                         enteringPvs++;
                 }

--- a/Robust.Shared.IntegrationTests/GameState/PredictedDeletionTests.cs
+++ b/Robust.Shared.IntegrationTests/GameState/PredictedDeletionTests.cs
@@ -81,16 +81,14 @@ internal sealed partial class PredictedDeletionTests : RobustIntegrationTest
 
         await client.WaitPost(() =>
         {
-            var ent = new Entity<MetaDataComponent?, TransformComponent?>(clientTarget, null, null);
-
-            client.EntMan.PredictedDeleteEntity(ent);
+            client.EntMan.DeleteEntity(clientTarget);
             var xform = client.EntMan.GetComponent<TransformComponent>(clientTarget);
             var firstDetachTick = xform.LastModifiedTick;
 
             Assert.That(((ClientEntityManager) client.EntMan).IsPredictedDetached(clientTarget), Is.True);
             Assert.That(client.EntMan.IsQueuedForDeletion(clientTarget), Is.True);
 
-            client.EntMan.PredictedDeleteEntity(ent);
+            client.EntMan.DeleteEntity(clientTarget);
 
             Assert.That(((ClientEntityManager) client.EntMan).IsPredictedDetached(clientTarget), Is.True);
             Assert.That(client.EntMan.IsQueuedForDeletion(clientTarget), Is.True);
@@ -139,8 +137,7 @@ internal sealed partial class PredictedDeletionTests : RobustIntegrationTest
 
         await client.WaitPost(() =>
         {
-            var ent = new Entity<MetaDataComponent?, TransformComponent?>(clientTarget, null, null);
-            client.EntMan.PredictedDeleteEntity(ent);
+            client.EntMan.DeleteEntity(clientTarget);
 
             var meta = client.EntMan.GetComponent<MetaDataComponent>(clientTarget);
             var xform = client.EntMan.GetComponent<TransformComponent>(clientTarget);
@@ -276,9 +273,9 @@ internal sealed partial class PredictedDeletionTests : RobustIntegrationTest
                 return;
 
             if (_mode == PredictedDeleteMode.Direct)
-                PredictedDel(uid.Value);
+                Del(uid.Value);
             else
-                PredictedQueueDel(uid.Value);
+                QueueDel(uid.Value);
         }
     }
 

--- a/Robust.Shared.IntegrationTests/GameState/PredictedDeletionTests.cs
+++ b/Robust.Shared.IntegrationTests/GameState/PredictedDeletionTests.cs
@@ -97,6 +97,57 @@ internal sealed partial class PredictedDeletionTests : RobustIntegrationTest
     }
 
     [Test]
+    public async Task PredictedQueueDeletionRaisesQueueDeletedEvent()
+    {
+        await using var pair = await StartConnectedPair();
+
+        var (_, client, _, clientTarget, _) = await SetupTarget(pair.Server, pair.Client);
+
+        await client.WaitPost(() =>
+        {
+            var entMan = (ClientEntityManager) client.EntMan;
+            EntityUid? raised = null;
+            void OnQueueDeleted(EntityUid uid) => raised = uid;
+
+            entMan.EntityQueueDeleted += OnQueueDeleted;
+            try
+            {
+                entMan.QueueDeleteEntity(clientTarget);
+            }
+            finally
+            {
+                entMan.EntityQueueDeleted -= OnQueueDeleted;
+            }
+
+            // Physics relies on this to purge contacts before the entity gets detached.
+            Assert.That(raised, Is.EqualTo(clientTarget));
+        });
+    }
+
+    [Test]
+    public async Task ClearingAQueuedPredictedDeletionCancelsIt()
+    {
+        await using var pair = await StartConnectedPair();
+
+        var (_, client, _, clientTarget, clientParent) = await SetupTarget(pair.Server, pair.Client);
+
+        await client.WaitPost(() =>
+        {
+            var entMan = (ClientEntityManager) client.EntMan;
+            entMan.QueueDeleteEntity(clientTarget);
+            Assert.That(entMan.IsQueuedForDeletion(clientTarget), Is.True);
+
+            // Rolling back the prediction cancels the deletion before the queue gets processed.
+            entMan.ClearPredictedDeletion(clientTarget);
+            Assert.That(entMan.IsQueuedForDeletion(clientTarget), Is.False);
+        });
+
+        await client.WaitRunTicks(1);
+
+        await AssertRolledBack(client, clientTarget, clientParent);
+    }
+
+    [Test]
     public async Task PredictedDeletionFollowedByAuthoritativeDeletionDeletesEntity()
     {
         await using var pair = await StartConnectedPair();

--- a/Robust.Shared/Containers/SharedContainerSystem.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.cs
@@ -623,7 +623,7 @@ public abstract partial class SharedContainerSystem
                 continue;
 
             Remove(ent, container, force: true);
-            PredictedDel(ent);
+            Del(ent);
         }
     }
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -302,10 +302,14 @@ namespace Robust.Shared.GameObjects
             _componentCullHistogram = histogram?.WithLabels("ComponentCull");
         }
 
-        internal virtual void ProcessQueueudDeletions()
+        internal void ProcessQueueudDeletions()
         {
             while (QueuedDeletions.TryDequeue(out var uid))
             {
+                // The deletion may have been canceled since it was queued.
+                if (!QueuedDeletionsSet.Remove(uid))
+                    continue;
+
                 DeleteEntity(uid);
             }
 

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -573,8 +573,10 @@ namespace Robust.Shared.GameObjects
 
         /// <summary>
         /// Shuts-down and removes given Entity. This is also broadcast to all clients.
+        /// On the client this predicts the deletion: a networked entity is detached to nullspace and then either
+        /// restored or actually deleted by state handling.
         /// </summary>
-        public void DeleteEntity(EntityUid e, MetaDataComponent meta, TransformComponent xform)
+        public virtual void DeleteEntity(EntityUid e, MetaDataComponent meta, TransformComponent xform)
         {
             // Some UIs get disposed after entity-manager has shut down and already deleted all entities.
             if (!Started)
@@ -753,60 +755,44 @@ namespace Robust.Shared.GameObjects
         public virtual bool IsQueuedForDeletion(EntityUid uid) => QueuedDeletionsSet.Contains(uid);
 
         /// <inheritdoc />
-        public virtual void PredictedDeleteEntity(Entity<MetaDataComponent?, TransformComponent?> ent)
-        {
-            DeleteEntity(ent.Owner);
-        }
+        [Obsolete("Use DeleteEntity")]
+        public void PredictedDeleteEntity(Entity<MetaDataComponent?, TransformComponent?> ent)
+            => DeleteEntity(ent.Owner);
 
         /// <inheritdoc />
+        [Obsolete("Use DeleteEntity")]
         public void PredictedDeleteEntity(Entity<MetaDataComponent?, TransformComponent?>? ent)
-        {
-            if (ent == null)
-                return;
-
-            PredictedDeleteEntity(ent.Value);
-        }
+            => DeleteEntity(ent?.Owner);
 
         /// <inheritdoc />
-        public virtual void PredictedQueueDeleteEntity(Entity<MetaDataComponent?> ent)
-        {
-            QueueDeleteEntity(ent);
-        }
+        [Obsolete("Use QueueDeleteEntity")]
+        public void PredictedQueueDeleteEntity(Entity<MetaDataComponent?> ent)
+            => QueueDeleteEntity(ent.Owner);
 
         /// <inheritdoc />
+        [Obsolete("Use QueueDeleteEntity")]
         public void PredictedQueueDeleteEntity(Entity<MetaDataComponent?>? ent)
-        {
-            if (ent != null)
-                PredictedQueueDeleteEntity(ent.Value);
-        }
+            => QueueDeleteEntity(ent?.Owner);
 
         /// <inheritdoc />
-        [Obsolete("use variant without TransformComponent")]
+        [Obsolete("Use QueueDeleteEntity")]
         public void PredictedQueueDeleteEntity(Entity<MetaDataComponent?, TransformComponent?> ent)
-        {
-            PredictedQueueDeleteEntity(new Entity<MetaDataComponent?>(ent.Owner, ent.Comp1));
-        }
+            => QueueDeleteEntity(ent.Owner);
 
         /// <inheritdoc />
-        [Obsolete("use variant without TransformComponent")]
+        [Obsolete("Use QueueDeleteEntity")]
         public void PredictedQueueDeleteEntity(Entity<MetaDataComponent?, TransformComponent?>? ent)
-        {
-            if (ent != null)
-                PredictedQueueDeleteEntity(new Entity<MetaDataComponent?>(ent.Value.Owner, ent.Value.Comp1));
-        }
+            => QueueDeleteEntity(ent?.Owner);
 
         /// <inheritdoc />
+        [Obsolete("Use QueueDeleteEntity")]
         public void PredictedQueueDeleteEntity(EntityUid uid)
-        {
-            PredictedQueueDeleteEntity(new Entity<MetaDataComponent?>(uid, null));
-        }
+            => QueueDeleteEntity(uid);
 
         /// <inheritdoc />
+        [Obsolete("Use QueueDeleteEntity")]
         public void PredictedQueueDeleteEntity(EntityUid? uid)
-        {
-            if (uid != null)
-                PredictedQueueDeleteEntity(new Entity<MetaDataComponent?>(uid.Value, null));
-        }
+            => QueueDeleteEntity(uid);
 
         public bool EntityExists(EntityUid uid)
         {

--- a/Robust.Shared/GameObjects/EntityManager.cs
+++ b/Robust.Shared/GameObjects/EntityManager.cs
@@ -537,7 +537,7 @@ namespace Robust.Shared.GameObjects
             if (Deleted(uid.Value))
                 return false;
 
-            if (QueuedDeletionsSet.Contains(uid.Value))
+            if (IsQueuedForDeletion(uid.Value))
                 return false;
 
             QueueDeleteEntity(uid);

--- a/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
+++ b/Robust.Shared/GameObjects/EntitySystem.Proxy.cs
@@ -936,66 +936,66 @@ public partial class EntitySystem
 
     /// <inheritdoc cref="IEntityManager.DeleteEntity(EntityUid?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [ProxyFor(typeof(EntityManager), nameof(EntityManager.PredictedDeleteEntity))]
+    [Obsolete("Use Del")]
     protected void PredictedDel(Entity<MetaDataComponent?, TransformComponent?> ent)
     {
-        EntityManager.PredictedDeleteEntity(ent);
+        EntityManager.DeleteEntity(ent.Owner);
     }
 
     /// <inheritdoc cref="IEntityManager.DeleteEntity(EntityUid?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [ProxyFor(typeof(EntityManager), nameof(EntityManager.PredictedDeleteEntity))]
+    [Obsolete("Use Del")]
     protected void PredictedDel(Entity<MetaDataComponent?, TransformComponent?>? ent)
     {
-        EntityManager.PredictedDeleteEntity(ent);
+        EntityManager.DeleteEntity(ent?.Owner);
     }
 
     /// <inheritdoc cref="IEntityManager.QueueDeleteEntity(EntityUid?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [ProxyFor(typeof(EntityManager), nameof(EntityManager.PredictedQueueDeleteEntity))]
+    [Obsolete("Use QueueDel")]
     protected void PredictedQueueDel(Entity<MetaDataComponent?> ent)
     {
-        EntityManager.PredictedQueueDeleteEntity(ent);
+        EntityManager.QueueDeleteEntity(ent.Owner);
     }
 
     /// <inheritdoc cref="IEntityManager.QueueDeleteEntity(EntityUid?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [ProxyFor(typeof(EntityManager), nameof(EntityManager.PredictedQueueDeleteEntity))]
+    [Obsolete("Use QueueDel")]
     protected void PredictedQueueDel(Entity<MetaDataComponent?>? ent)
     {
-        EntityManager.PredictedQueueDeleteEntity(ent);
+        EntityManager.QueueDeleteEntity(ent?.Owner);
     }
 
-    /// <inheritdoc cref="IEntityManager.DeleteEntity(EntityUid?)" />
+    /// <inheritdoc cref="IEntityManager.QueueDeleteEntity(EntityUid?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [ProxyFor(typeof(EntityManager), nameof(EntityManager.PredictedQueueDeleteEntity))]
+    [Obsolete("Use QueueDel")]
     protected void PredictedQueueDel(EntityUid uid)
     {
-        EntityManager.PredictedQueueDeleteEntity(uid);
+        EntityManager.QueueDeleteEntity(uid);
     }
 
     /// <inheritdoc cref="IEntityManager.QueueDeleteEntity(EntityUid?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [ProxyFor(typeof(EntityManager), nameof(EntityManager.PredictedQueueDeleteEntity))]
+    [Obsolete("Use QueueDel")]
     protected void PredictedQueueDel(EntityUid? uid)
     {
-        EntityManager.PredictedQueueDeleteEntity(uid);
+        EntityManager.QueueDeleteEntity(uid);
     }
 
     /// <inheritdoc cref="IEntityManager.QueueDeleteEntity(EntityUid?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("use variant without TransformComponent")]
+    [Obsolete("Use QueueDel")]
     protected void PredictedQueueDel(Entity<MetaDataComponent?, TransformComponent?> ent)
     {
-        EntityManager.PredictedQueueDeleteEntity(ent);
+        EntityManager.QueueDeleteEntity(ent.Owner);
     }
 
     /// <inheritdoc cref="IEntityManager.QueueDeleteEntity(EntityUid?)" />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("use variant without TransformComponent")]
+    [Obsolete("Use QueueDel")]
     protected void PredictedQueueDel(Entity<MetaDataComponent?, TransformComponent?>? ent)
     {
-        EntityManager.PredictedQueueDeleteEntity(ent);
+        EntityManager.QueueDeleteEntity(ent?.Owner);
     }
 
     /// <inheritdoc cref="IEntityManager.TryQueueDeleteEntity(EntityUid?)" />

--- a/Robust.Shared/GameObjects/IEntityManager.cs
+++ b/Robust.Shared/GameObjects/IEntityManager.cs
@@ -155,43 +155,51 @@ namespace Robust.Shared.GameObjects
         /// </summary>
         public bool TryQueueDeleteEntity(EntityUid? uid);
 
+        /// <summary>
+        /// Deletes the entity at the end of the tick.
+        /// On the client this predicts the deletion: a networked entity is detached to nullspace and then either
+        /// restored or actually deleted by state handling.
+        /// </summary>
         public void QueueDeleteEntity(EntityUid? uid);
 
         public bool IsQueuedForDeletion(EntityUid uid);
 
-        /// <summary>
-        /// Tries to predict entity deletion. On the server it runs the normal code path and on the client the entity is detached.
-        /// </summary>
+        /// <inheritdoc cref="DeleteEntity(EntityUid?)"/>
+        [Obsolete("Use DeleteEntity")]
         void PredictedDeleteEntity(Entity<MetaDataComponent?, TransformComponent?> ent);
 
-        /// <inheritdoc cref="PredictedDeleteEntity(Entity{MetaDataComponent?,TransformComponent?})"/>
+        /// <inheritdoc cref="DeleteEntity(EntityUid?)"/>
+        [Obsolete("Use DeleteEntity")]
         void PredictedDeleteEntity(Entity<MetaDataComponent?, TransformComponent?>? ent);
 
-        /// <summary>
-        /// Variant of <see cref="PredictedDeleteEntity(Entity{MetaDataComponent?,TransformComponent?})"/> that defers deletion until the end of the tick.
-        /// </summary>
+        /// <inheritdoc cref="QueueDeleteEntity(EntityUid?)"/>
+        [Obsolete("Use QueueDeleteEntity")]
         void PredictedQueueDeleteEntity(Entity<MetaDataComponent?> ent);
 
-        /// <inheritdoc cref="PredictedQueueDeleteEntity(Entity{MetaDataComponent?})"/>
+        /// <inheritdoc cref="QueueDeleteEntity(EntityUid?)"/>
+        [Obsolete("Use QueueDeleteEntity")]
         void PredictedQueueDeleteEntity(Entity<MetaDataComponent?>? ent);
 
-        /// <inheritdoc cref="PredictedQueueDeleteEntity(Entity{MetaDataComponent?})"/>
-        [Obsolete("use variant without TransformComponent")]
+        /// <inheritdoc cref="QueueDeleteEntity(EntityUid?)"/>
+        [Obsolete("Use QueueDeleteEntity")]
         void PredictedQueueDeleteEntity(Entity<MetaDataComponent?, TransformComponent?> ent);
 
-        /// <inheritdoc cref="PredictedQueueDeleteEntity(Entity{MetaDataComponent?})"/>
-        [Obsolete("use variant without TransformComponent")]
+        /// <inheritdoc cref="QueueDeleteEntity(EntityUid?)"/>
+        [Obsolete("Use QueueDeleteEntity")]
         void PredictedQueueDeleteEntity(Entity<MetaDataComponent?, TransformComponent?>? ent);
 
         // The following 2 methods exist to handle ambiguous implicit casts.
-        // They should probably be removed whenever the transform variants are removed
-        /// <inheritdoc cref="PredictedQueueDeleteEntity(Entity{MetaDataComponent?})"/>
+        /// <inheritdoc cref="QueueDeleteEntity(EntityUid?)"/>
+        [Obsolete("Use QueueDeleteEntity")]
         void PredictedQueueDeleteEntity(EntityUid ent);
-        /// <inheritdoc cref="PredictedQueueDeleteEntity(Entity{MetaDataComponent?})"/>
+        /// <inheritdoc cref="QueueDeleteEntity(EntityUid?)"/>
+        [Obsolete("Use QueueDeleteEntity")]
         void PredictedQueueDeleteEntity(EntityUid? ent);
 
         /// <summary>
         /// Shuts-down and removes the entity with the given <see cref="Robust.Shared.GameObjects.EntityUid"/>. This is also broadcast to all clients.
+        /// On the client this predicts the deletion: a networked entity is detached to nullspace and then either
+        /// restored or actually deleted by state handling.
         /// </summary>
         /// <param name="uid">Uid of entity to remove.</param>
         void DeleteEntity(EntityUid? uid);


### PR DESCRIPTION
- Client `DeleteEntity` and `QueueDeleteEntity` now predict deletions of networked entities by detaching them to nullspace which is what `PredictedDeleteEntity` and `PredictedQueueDeleteEntity` did. They're obsolete aliases now along with the `PredictedDel` and `PredictedQueueDel`
- Removed the client's separate predicted deletion queue
- Fixed `TryQueueDeleteEntity` ignoring the predicted deletion queues and returning true for entities that were already going away
- Fixed predicted deletion state not being cleared on PVS reentry which left entities stuck detached
- Fixed a queued deletion still running after it had been cancelled. The queue only checked the set on insert but didn't on dequeue

Client-side `Del` and `QueueDel` on a networked entity used to log an error and do nothing - now it detaches. The obsoletion warnings cover the `PredictedDel` -> `Del` rename but not this so anything that was quietly relying on the noop will start visibly deleting for a tick


I hope that is what [metalgearsloth](https://github.com/metalgearsloth) meant. 
___
Solves: #7043
