### PR TITLE
Allow prototype upload validation to pass fields unknown to Server

### DIFF
--- a/Robust.Shared/Prototypes/PrototypeManager.cs
+++ b/Robust.Shared/Prototypes/PrototypeManager.cs
@@ -516,6 +516,7 @@ namespace Robust.Shared.Prototypes
 
             var errors = _serializationManager.ValidateNode(kind, validationMapping, context)
                 .GetErrors()
+                .Where(x => x.AlwaysRelevant)
                 .ToArray();
 
             if (errors.Length == 0)


### PR DESCRIPTION
Resolves #7061 

With the recently added ValidatePrototype function added to PrototypeManager, it now pre-validates the prototypes and fails the upload if it detects errors. Since this runs on the Server, the validation has no knowledge of components with Client-only fields (i.e. when the component is split up in Client/Server component versions). This causes the validation to get errors and reject valid prototypes. 

While ideally there shouldn't be a component split (or some better support for it), since that is a longterm issue this PR fixes it by checking that the ErrorNode has AlwaysRelevant set to true, which should filter out unrecognized fields. 

This does mean that incorrect/non-existent fields can pass, but afaik they get discarded anyways so it shouldn't mess up the game, just at worst make the prototype not behave as the uploader expects. 