### PR TITLE
Make Control.Restyle public

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,7 +41,7 @@ END TEMPLATE-->
 
 ### New features
 
-*None yet*
+* `Control.Restyle` has been made public for manually restyling controls on edge cases.
 
 ### Bugfixes
 

--- a/Robust.Client/UserInterface/Control.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Styling.cs
@@ -124,9 +124,11 @@ namespace Robust.Client.UserInterface
         }
 
         /// <summary>
-        /// Ensures the control will be restyled, handled automatically in most cases.
-        /// You likely don't need to call this yourself.
+        /// Ensures the control will be restyled, handled automatically through most API calls.
         /// </summary>
+        /// <remarks>
+        /// You likely don't need to call this yourself.
+        /// </remarks>
         public void Restyle()
         {
             if (_stylingDirty)

--- a/Robust.Client/UserInterface/Control.Styling.cs
+++ b/Robust.Client/UserInterface/Control.Styling.cs
@@ -123,7 +123,11 @@ namespace Robust.Client.UserInterface
             _styleClasses.Add(className);
         }
 
-        internal void Restyle()
+        /// <summary>
+        /// Ensures the control will be restyled, handled automatically in most cases.
+        /// You likely don't need to call this yourself.
+        /// </summary>
+        public void Restyle()
         {
             if (_stylingDirty)
             {


### PR DESCRIPTION
What the title says.

## Why?

This is a nasty workaround in SS14 that is currently getting to Restyle through adding and removing style classes:

https://github.com/space-wizards/space-station-14/pull/45549

If the change to the parent's pseudoclass should propagate into restyling its children, that's great - and I could do that here, but currently that doesn't happen, so you're doing it manually.  And doing it via the Restyle call directly is probably better than what the SwitchButton is doing in the above PR.