### PR TITLE
Added optional parameters to public item-dropping methods to permit `force` removal of items from their current containers

### DIFF
--- a/Robust.Shared.IntegrationTests/GameObjects/ContainerTests.ForceRemoval.cs
+++ b/Robust.Shared.IntegrationTests/GameObjects/ContainerTests.ForceRemoval.cs
@@ -1,0 +1,208 @@
+using NUnit.Framework;
+using Robust.UnitTesting;
+using System.Numerics;
+using Robust.Client.GameObjects;
+using Robust.Client.Timing;
+using Robust.Server.Player;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.Shared.Network;
+using Robust.Shared.Reflection;
+using Robust.Shared.Timing;
+
+namespace Robust.UnitTesting.Shared.GameObjects
+{
+    
+    [TestFixture]
+    internal sealed partial class ContainerTestsForceRemoval: RobustIntegrationTest
+    {
+        /// <summary>
+        /// Creates a situation where an unremovable item is created and tries to remove it from the container
+        /// heavily based on <see cref="Robust.UnitTesting.Shared.GameObjects.ContainerTests.TestContainerExpectedEntityDeleted">TestContainerExpectedEntityDeleted</see>.
+        /// <br/>
+        /// could probably cut down on a lot of the boilerplate here
+        /// </summary>
+        [Test]
+        public async Task TestForceRemovalOfUnremovableItem()
+        {
+            var options = new ServerIntegrationOptions();
+            options.Pool = false;
+            options.BeforeRegisterComponents += () =>
+            {
+                var fact = IoCManager.Resolve<IComponentFactory>();
+                fact.RegisterClass<UnremovableFromContainerComponent>();
+            };
+            options.BeforeStart += () =>
+            {
+                var sysMan = IoCManager.Resolve<IEntitySystemManager>();
+                sysMan.LoadExtraSystemType<UnremovableFromContainerSystem>();
+            };
+            
+            var server = StartServer(options);
+            var client = StartClient();
+            
+    
+            await Task.WhenAll(client.WaitIdleAsync(), server.WaitIdleAsync());
+    
+            var cEntManager = client.ResolveDependency<IEntityManager>();
+            var clientTime = client.ResolveDependency<IClientGameTiming>();
+            var clientNetManager = client.ResolveDependency<IClientNetManager>();
+    
+            var sEntManager = server.ResolveDependency<IEntityManager>();
+            var sPlayerManager = server.ResolveDependency<IPlayerManager>();
+            var serverTime = server.ResolveDependency<IGameTiming>();
+
+            Assert.DoesNotThrow(() => client.SetConnectTarget(server));
+            await client.WaitPost(() =>
+            {
+                clientNetManager.ClientConnect(null!, 0, null!);
+            });
+    
+            for (int i = 0; i < 10; i++)
+            {
+                await server.WaitRunTicks(1);
+                await client.WaitRunTicks(1);
+            }
+    
+            // Setup
+            MapId mapId;
+            var mapPos = MapCoordinates.Nullspace;
+    
+            EntityUid sEntityUid = default!;
+            EntityUid sItemUid = default!;
+            NetEntity netEnt = default;
+    
+            var cContainerSys = cEntManager.System<ContainerSystem>();
+            var sContainerSys = sEntManager.System<SharedContainerSystem>();
+            var sMetadataSys = sEntManager.System<MetaDataSystem>();
+    
+            await server.WaitAssertion(() =>
+            {
+                sEntManager.System<SharedMapSystem>().CreateMap(out mapId);
+                mapPos = new MapCoordinates(new Vector2(0, 0), mapId);
+    
+                sEntityUid = sEntManager.SpawnEntity(null, mapPos);
+                sMetadataSys.SetEntityName(sEntityUid, "Container");
+                sContainerSys.EnsureContainer<Container>(sEntityUid, "dummy");
+    
+                // Setup PVS
+                sEntManager.AddComponent<EyeComponent>(sEntityUid);
+                var player = sPlayerManager.Sessions.First();
+                server.PlayerMan.SetAttachedEntity(player, sEntityUid);
+                sPlayerManager.JoinGame(player);
+            });
+    
+            for (int i = 0; i < 10; i++)
+            {
+                await server.WaitRunTicks(1);
+                await client.WaitRunTicks(1);
+            }
+    
+            await server.WaitAssertion(() =>
+            {
+                sItemUid = sEntManager.SpawnEntity(null, mapPos);
+                netEnt = sEntManager.GetNetEntity(sItemUid);
+                sMetadataSys.SetEntityName(sItemUid, "Item");
+                // make the item unremovable
+                sEntManager.AddComponent<UnremovableFromContainerComponent>(sItemUid);
+                var container = sContainerSys.GetContainer(sEntityUid, "dummy");
+                sContainerSys.Insert(sItemUid, container);
+    
+                // Modify visibility layer so that the item does not get sent ot the player
+                sEntManager.System<SharedVisibilitySystem>().AddLayer(sItemUid, 10 );
+            });
+    
+            await server.WaitRunTicks(1);
+    
+            while (clientTime.LastRealTick < serverTime.CurTick - 1)
+            {
+                await client.WaitRunTicks(1);
+            }
+    
+            var cUid = cEntManager.GetEntity(sEntManager.GetNetEntity(sEntityUid));
+    
+            await client.WaitAssertion(() =>
+            {
+                if (!cEntManager.TryGetComponent<ContainerManagerComponent>(cUid, out var containerManagerComp))
+                {
+                    Assert.Fail();
+                    return;
+                }
+    
+                var container = cContainerSys.GetContainer(cUid, "dummy", containerManagerComp);
+                Assert.That(container.ContainedEntities.Count, Is.EqualTo(0));
+                Assert.That(container.ExpectedEntities.Count, Is.EqualTo(1));
+    
+                Assert.That(cContainerSys.ExpectedEntities.ContainsKey(netEnt));
+                Assert.That(cContainerSys.ExpectedEntities.Count, Is.EqualTo(1));
+            });
+    
+            await server.WaitAssertion(() =>
+            {
+                Assume.That(sEntManager.EntityExists(sItemUid), Is.True, "Item does not exist :(");
+                
+                Assume.That(sContainerSys.TryGetContainingContainer(sItemUid, out _), Is.True, "Item was not in a container :(");
+                
+                Assert.That(sContainerSys.TryRemoveFromContainer(sItemUid, force: false), Is.False, "Unremovable item was removed from container without being forced!");
+                Assert.That(sContainerSys.IsEntityInContainer(sItemUid), Is.True, "Unremovable item still in container after unforced removal");
+                
+                Assert.That(sContainerSys.TryRemoveFromContainer(sItemUid, force: true), Is.True, "Unremovable item wasn't removed from container despite being forced!");
+                Assert.That(sContainerSys.IsEntityInContainer(sItemUid), Is.False, "Unremovable item still in container after forced removal :(");
+    
+                //sEntManager.DeleteEntity(sItemUid);
+            });
+    
+            await server.WaitRunTicks(1);
+            await client.WaitRunTicks(4);
+    
+            await client.WaitAssertion(() =>
+            {
+                if (!cEntManager.TryGetComponent<ContainerManagerComponent>(cUid, out var containerManagerComp))
+                {
+                    Assert.Fail();
+                    return;
+                }
+    
+                var container = cContainerSys.GetContainer(cUid, "dummy", containerManagerComp);
+                Assert.That(container.ContainedEntities.Count, Is.EqualTo(0));
+                Assert.That(container.ExpectedEntities.Count, Is.EqualTo(0));
+    
+                Assert.That(!cContainerSys.ExpectedEntities.ContainsKey(netEnt));
+                Assert.That(cContainerSys.ExpectedEntities.Count, Is.EqualTo(0));
+            });
+    
+            await client.WaitPost(() => clientNetManager.ClientDisconnect(""));
+            await server.WaitRunTicks(5);
+            await client.WaitRunTicks(5);
+        }
+
+        
+        /// <summary>
+        /// component which prevents the entity from being removed from the container unless forced
+        /// </summary>
+        [Reflect(discoverable:false)]
+#pragma warning disable RA0003
+        private partial class UnremovableFromContainerComponent : Component { }
+#pragma warning restore RA0003
+
+        /// <summary>
+        /// prevents entities with UnremovableFromContainerComponent from getting removed from containers
+        /// </summary>
+        [Reflect(discoverable:false)]
+        private sealed class UnremovableFromContainerSystem : EntitySystem
+        {
+            public override void Initialize()
+            {
+                SubscribeLocalEvent<ContainerGettingRemovedAttemptEvent>(OnContainerGettingRemovedAttemptEvent);
+            }
+
+            private void OnContainerGettingRemovedAttemptEvent(ContainerGettingRemovedAttemptEvent ev)
+            {
+                ev.Cancel();
+            }
+        }
+    }
+}
+

--- a/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
+++ b/Robust.Shared/Containers/SharedContainerSystem.Insert.cs
@@ -12,7 +12,7 @@ public abstract partial class SharedContainerSystem
 {
 
     /// <summary>
-    /// Attempts to insert the entity into this container.
+    /// Attempts to insert the entity into this container (removing it from its current container, if needed)
     /// </summary>
     /// <remarks>
     /// If the insertion is successful, the inserted entity will end up parented to the
@@ -22,7 +22,8 @@ public abstract partial class SharedContainerSystem
     /// <param name="container">The container to insert into.</param>
     /// <param name="containerXform">The container's transform component.</param>
     /// <param name="force">Whether to bypass normal insertion checks.</param>
-    /// <returns>False if the entity could not be inserted.</returns>
+    /// <param name="forceRemoval">Whether to bypass normal removal checks (forcing the entity out of current container, if it's inside one)</param>
+    /// <returns>False if the entity could not be removed from current container and inserted into target container.</returns>
     /// <exception cref="InvalidOperationException">
     /// Thrown if this container is a child of the entity,
     /// which would cause infinite loops.
@@ -30,7 +31,8 @@ public abstract partial class SharedContainerSystem
     public bool Insert(Entity<TransformComponent?, MetaDataComponent?, PhysicsComponent?> toInsert,
         BaseContainer container,
         TransformComponent? containerXform = null,
-        bool force = false)
+        bool force = false,
+        bool forceRemoval = false)
     {
         var (uid, transform, meta, physics) = toInsert;
 
@@ -75,7 +77,7 @@ public abstract partial class SharedContainerSystem
         if ((meta.Flags & MetaDataFlags.InContainer) != 0 &&
             TryComp(transform.ParentUid, out ContainerManagerComponent? oldManager) &&
             TryGetContainingContainer(transform.ParentUid, toInsert, out var oldContainer, oldManager) &&
-            !Remove((uid, transform, meta), oldContainer, reparent: false, force: false))
+            !Remove((uid, transform, meta), oldContainer, reparent: false, force: forceRemoval))
         {
             // failed to remove from container --> cannot insert.
             return false;
@@ -140,18 +142,25 @@ public abstract partial class SharedContainerSystem
     /// Attempts to insert an entity into a container. If it fails, it will instead drop the entity next to the
     /// container entity.
     /// </summary>
+    /// <param name="toInsert">The entity to insert.</param>
+    /// <param name="container">The container to insert into.</param>
+    /// <param name="containerXform">The container's transform component.</param>
+    /// <param name="forceInsertion">Whether to bypass normal insertion checks.</param>
+    /// <param name="forceRemoval">Whether to bypass normal removal checks (forcing the entity out of current container, if it's inside one)</param>
     /// <returns>Whether or not the entity was successfully inserted</returns>
     public bool InsertOrDrop(Entity<TransformComponent?, MetaDataComponent?, PhysicsComponent?> toInsert,
         BaseContainer container,
-        TransformComponent? containerXform = null)
+        TransformComponent? containerXform = null,
+        bool forceInsertion = false,
+        bool forceRemoval = false)
     {
         if (!Resolve(toInsert.Owner, ref toInsert.Comp1) || !Resolve(container.Owner, ref containerXform))
             return false;
 
-        if (Insert(toInsert, container, containerXform))
+        if (Insert(toInsert, container, containerXform, force: forceInsertion, forceRemoval: forceRemoval))
             return true;
 
-        _transform.DropNextTo(toInsert, (container.Owner, containerXform));
+        _transform.DropNextTo(toInsert, (container.Owner, containerXform), forceInsertion: forceInsertion, forceRemoval: forceRemoval);
         return false;
     }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -1841,7 +1841,7 @@ public abstract partial class SharedTransformSystem
                 continue;
 
             if (!_container.Insert((entity, xform, null, null), container, force: forceInsertion, forceRemoval:forceRemoval))
-                PlaceNextTo((entity, xform), targetXform.ParentUid);
+                PlaceNextTo((entity, xform), targetXform.ParentUid, forceInsertion: forceInsertion, forceRemoval: forceRemoval);
         }
     }
 

--- a/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
+++ b/Robust.Shared/GameObjects/Systems/SharedTransformSystem.Component.cs
@@ -1773,7 +1773,9 @@ public abstract partial class SharedTransformSystem
     /// this will attempt to insert that entity into the same container. Otherwise it will attach the entity to the
     /// grid or map at the same world-position as the target entity.
     /// </summary>
-    public void DropNextTo(Entity<TransformComponent?> entity, Entity<TransformComponent?> target)
+    /// <param name="forceInsertion">Whether to bypass normal insertion checks.</param>
+    /// <param name="forceRemoval">Whether to bypass normal removal checks (forcing the entity out of current container, if it's inside one)</param>
+    public void DropNextTo(Entity<TransformComponent?> entity, Entity<TransformComponent?> target, bool forceInsertion = false, bool forceRemoval = false)
     {
         var xform = entity.Comp;
         if (!XformQuery.Resolve(entity, ref xform))
@@ -1794,7 +1796,7 @@ public abstract partial class SharedTransformSystem
         {
             if (_container.IsEntityInContainer(targetUid)
                 && _container.TryGetContainingContainer(targetXform.ParentUid, targetUid, out var container)
-                && _container.Insert((entity, xform, null, null), container))
+                && _container.Insert((entity, xform, null, null), container, force: forceInsertion, forceRemoval: forceRemoval))
             {
                 return;
             }
@@ -1811,7 +1813,9 @@ public abstract partial class SharedTransformSystem
     /// Attempts to place one entity next to another entity. If the target entity is in a container, this will attempt
     /// to insert that entity into the same container. Otherwise it will attach the entity to the same parent.
     /// </summary>
-    public void PlaceNextTo(Entity<TransformComponent?> entity, Entity<TransformComponent?> target)
+    /// <param name="forceInsertion">Whether to bypass normal insertion checks.</param>
+    /// <param name="forceRemoval">Whether to bypass normal removal checks (forcing the entity out of current container, if it's inside one)</param>
+    public void PlaceNextTo(Entity<TransformComponent?> entity, Entity<TransformComponent?> target, bool forceInsertion = false, bool forceRemoval = false)
     {
         var xform = entity.Comp;
         if (!XformQuery.Resolve(entity, ref xform))
@@ -1836,7 +1840,7 @@ public abstract partial class SharedTransformSystem
             if (!container.Contains(target))
                 continue;
 
-            if (!_container.Insert((entity, xform, null, null), container))
+            if (!_container.Insert((entity, xform, null, null), container, force: forceInsertion, forceRemoval:forceRemoval))
                 PlaceNextTo((entity, xform), targetXform.ParentUid);
         }
     }


### PR DESCRIPTION
Unblocking https://github.com/space-wizards/space-station-14/pull/45844

# summary of code changes

* SharedContainerSystem.Insert.cs
  * Added `bool forceRemoval = false` parameter to `Insert()` and `InsertOrDrop()`
    * Passed to the internal `Remove()` call in `Insert()` (and to `Insert()` itself)
  * Added `bool forceInsertion = false` parameter to `InsertOrDrop()`
    * Passed as to internal `Insert()` call as `force`
* SharedTransformSystem.Component.cs
  * Added `bool forceInsertion = false` and `bool forceRemoval = false` parameter to `DropNextTo()` and `PlaceNextTo()`
    * Passed along to internal calls to those other methods

# why

* linked PR in ss14 repo is blocked by the inability to bypass removal checks in `DropNextTo()` method in RobustToolbox - this PR provides the option for a programmer to bypass removal checks in these methods if they have a very good reason for doing so.
  * named it `forceRemoval` instead of `force` to make it clear which side of the operation is being forced.
* also, I noticed that the public `Insert` method already has an optional `force` parameter to bypass insertion checks - figured that I may as well make that parameter accessible by these other methods which internally call `Insert`, in case it's of any use to anyone.
  * named it `forceInsertion` in those other methods to make it clear that it's being used to force _insertion_ alone
  * did not rename `force` in `Insert()` to `forceInsertion` to avoid breaking the public interface - even though that parameter (still) only forces insertion.

# breaking changes

no breaking changes are anticipated as a result of this PR (existing method parameters are unchanged, new parameters are all optional, default values preserve prior behaviour).

# testing

* new `forceInsertion` params assume that the `force` parameter of the `Insert()` method in `SharedContainerSystem.Insert.cs` works as described
  * not sure where to start with writing a unit test for that, could just remove those parameters from the PR instead
* new `forceRemoval` params assume that the `force` parameter of the `Remove()` method in `SharedContainerSystem.Remove.cs` works as described.
  * Bodged together an (admittedly rather shoddy) test for that in `Robust.Shared.IntegrationTests/GameObjects/ContainerTests.ForceRemoval.cs`